### PR TITLE
Custom invalid parameter exception

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -255,25 +255,25 @@ jobs:
           set -euo pipefail
 
           NUGET="$("${VCPKG_EXE}" fetch nuget | awk 'NF{last=$0} END{print last}')"
-          
+
           declare -a NUGET_CMD=()   # <-- make it exist to appease `set -u`
-          
+
           if [[ "$NUGET" == *.exe ]]; then
             NUGET_CMD=(mono "$NUGET")
           else
             NUGET_CMD=("$NUGET")
           fi
-          
+
           # Print robustly
           printf 'Using NuGet CLI: %q\n' "${NUGET_CMD[@]}"
-          
+
           "${NUGET_CMD[@]}" sources add \
             -Source "${FEED_URL}" \
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${USERNAME}" \
             -Password "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}"
-          
+
           "${NUGET_CMD[@]}" setapikey "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}" -Source "${FEED_URL}"
 
       - name: Create virtual environment

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -142,7 +142,6 @@ jobs:
             **/pyproject.toml
             **/requirements*.txt
 
-      # NEW: Pin the exact interpreter path for this matrix leg
       - name: Pin matrix Python interpreter
         run: |
           PY="$(python -c 'import sys; print(sys.executable)')"
@@ -150,7 +149,6 @@ jobs:
           echo "Pinned Python: $PY"
           "$PY" -V
 
-      # ---- System toolchains + GCC 13 (Linux only) ----
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -182,29 +180,18 @@ jobs:
           gcc-13 -dumpfullversion
           g++-13 -dumpfullversion
 
-      # Ensure a consistent Ninja on Linux and force generator + make program
       - name: Normalize Ninja on Linux
         if: runner.os == 'Linux'
         run: |
           set -euo pipefail
           sudo apt-get install -y ninja-build
-          echo "Before:"
-          which -a ninja || true
-          ls -l /usr/bin/ninja || true
-          ls -l /usr/local/bin/ninja || true
-          if [[ -x /usr/local/bin/ninja && "$(readlink -f /usr/local/bin/ninja || echo '')" != "/usr/bin/ninja" ]]; then
-            echo "Removing shadowing /usr/local/bin/ninja"
-            sudo rm -f /usr/local/bin/ninja
-          fi
           echo "/usr/bin" >> "$GITHUB_PATH"
           echo "CMAKE_GENERATOR=Ninja"              >> "$GITHUB_ENV"
           echo "CMAKE_MAKE_PROGRAM=/usr/bin/ninja"  >> "$GITHUB_ENV"
           echo "NINJA_STATUS=[%f/%t %o/sec] "       >> "$GITHUB_ENV"
-          echo "After:"
           command -v ninja
           ninja --version
 
-      # ---- System toolchains (macOS uses AppleClang) ----
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
         env:
@@ -220,7 +207,6 @@ jobs:
           clang++ --version
           ccache --version
 
-      # Optional: print what CMake will see before vcpkg/cmake configure
       - name: Toolchain sanity check
         run: |
           echo "RUNNER_OS=${RUNNER_OS}"
@@ -235,53 +221,11 @@ jobs:
           which g++-13  && g++-13 -dumpfullversion || true
           which ninja   && ninja --version   || true
 
-      # -------- ccache: configure + restore cache --------
-      - name: Configure ccache
-        run: |
-          echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
-          echo "CCACHE_COMPRESS=1"        >> "$GITHUB_ENV"
-          echo "CCACHE_MAXSIZE=1G"        >> "$GITHUB_ENV"
-          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
-          mkdir -p "$HOME/.ccache"
-          ccache --set-config=verbose=true || true
-          ccache --zero-stats || true
-
-      - name: Compute ccache key suffix
-        id: ccache_keys
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${RUNNER_OS}" == "Linux" ]]; then
-            ver="$(gcc-13 -dumpfullversion || gcc -dumpfullversion || echo unknown)"
-            echo "suffix=linux-gcc-${ver}" >> "$GITHUB_OUTPUT"
-          else
-            ver="$(clang --version | head -n1 | sed 's/ /-/g')"
-            echo "suffix=macos-${ver}" >> "$GITHUB_OUTPUT"
-          fi
-          echo "suffix=${suffix:-unset}"
-
-      - name: Restore ccache cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.ccache
-          key: ccache-${{ runner.os }}-${{ steps.ccache_keys.outputs.suffix }}-${{ hashFiles('basilisk/src/vcpkg.json', 'basilisk/src/vcpkg-configuration.json') }}
-          restore-keys: |
-            ccache-${{ runner.os }}-${{ steps.ccache_keys.outputs.suffix }}-
-            ccache-${{ runner.os }}-
-
-      # -----------------------------------------------
-
-      - name: Enable ccache for CMake
-        run: |
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache"   >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
       - name: Setup CMake 3.25.2
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.25.2'
 
-      # vcpkg uses the same generator/make program and policy workaround
       - name: Install vcpkg
         uses: lukka/run-vcpkg@v11
         with:
@@ -309,24 +253,31 @@ jobs:
           VCPKG_EXE: ${{ github.workspace }}/b/vcpkg/vcpkg
         run: |
           set -euo pipefail
-          NUGET="$(${VCPKG_EXE} fetch nuget | tail -n 1)"
+
+          NUGET="$("${VCPKG_EXE}" fetch nuget | awk 'NF{last=$0} END{print last}')"
+          
+          declare -a NUGET_CMD=()   # <-- make it exist to appease `set -u`
+          
           if [[ "$NUGET" == *.exe ]]; then
             NUGET_CMD=(mono "$NUGET")
           else
             NUGET_CMD=("$NUGET")
           fi
-          echo "Using NuGet CLI: ${NUGET_CMD[*]}"
+          
+          # Print robustly
+          printf 'Using NuGet CLI: %q\n' "${NUGET_CMD[@]}"
+          
           "${NUGET_CMD[@]}" sources add \
             -Source "${FEED_URL}" \
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${USERNAME}" \
-            -Password "${{ secrets.GITHUB_TOKEN }}"
-          "${NUGET_CMD[@]}" setapikey "${{ secrets.GITHUB_TOKEN }}" -Source "${FEED_URL}"
+            -Password "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}"
+          
+          "${NUGET_CMD[@]}" setapikey "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}" -Source "${FEED_URL}"
 
       - name: Create virtual environment
         run: |
-          # Use the pinned matrix interpreter for this venv
           "$PYTHON_EXE" -m venv .venv
           source .venv/bin/activate
           python -m pip install --upgrade pip
@@ -392,7 +343,7 @@ jobs:
           GCOV_BIN="$(command -v gcov-13 || command -v gcov)"
           echo "Using gcov executable: ${GCOV_BIN}"
           common_args=(
-            --root "${GITHUB_WORKSPACE}/algorithms"
+            --root "${GITHUB_WORKSPACE}"
             --filter "${GITHUB_WORKSPACE}/algorithms"
             --object-directory "${GITHUB_WORKSPACE}/basilisk/dist3"
             --exclude ".*_tests/.*"
@@ -419,146 +370,6 @@ jobs:
             cat coverage/external-modules-coverage.txt;
             echo '```';
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Detect changed source files (Linux / py3.11 only)
-        id: changed_ext_modules
-        if: ${{ runner.os == 'Linux' && matrix.python-version == '3.11' }}
-        uses: tj-actions/changed-files@v46
-        with:
-          files: |
-            algorithms/**/*.c
-            algorithms/**/*.cc
-            algorithms/**/*.cxx
-            algorithms/**/*.cpp
-
-      - name: Enforce coverage threshold on touched files (Linux / py3.11 only)
-        if: ${{ runner.os == 'Linux' && matrix.python-version == '3.11' }}
-        env:
-          COVERAGE_THRESHOLD: '0.8'
-          CHANGED_FILES: ${{ steps.changed_ext_modules.outputs.all_changed_files }}
-        run: |
-          source .venv/bin/activate
-          python <<'PY'
-          import json
-          import os
-          import sys
-          from pathlib import Path
-
-          workspace = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
-          threshold = float(os.environ.get("COVERAGE_THRESHOLD", "0.8")) * 100.0
-
-          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-
-          def append_summary(lines):
-              if not summary_path:
-                  return
-              with open(summary_path, "a", encoding="utf-8") as fh:
-                  fh.write("\n".join(lines) + "\n")
-
-          append_summary(["### Coverage Threshold Check", ""])
-
-          touched_raw = os.environ.get("CHANGED_FILES", "").strip()
-          touched = [
-              line.strip().replace("\\", "/")
-              for line in touched_raw.splitlines()
-              if line.strip()
-          ]
-
-          tracked_suffixes = (".c", ".cc", ".cxx", ".cpp")
-          touched_sources = [
-              path for path in touched
-              if path.startswith("algorithms/") and path.endswith(tracked_suffixes)
-          ]
-
-          if not touched_sources:
-              msg = "No touched source files under algorithms/; skipping coverage gate."
-              print(msg)
-              append_summary([msg, ""])
-              sys.exit(0)
-
-          coverage_path = workspace / "coverage" / "external-modules-coverage.json"
-          if not coverage_path.exists():
-              msg = f"Coverage report '{coverage_path}' not found; cannot enforce threshold."
-              print(msg)
-              append_summary([msg, ""])
-              sys.exit(0)
-
-          with coverage_path.open("r", encoding="utf-8") as fh:
-              data = json.load(fh)
-
-          file_entries = {}
-          for entry in data.get("files", []):
-              raw = entry.get("file", "")
-              if not raw:
-                  continue
-              path = Path(raw)
-              candidates = set()
-              candidates.add(path.as_posix())
-              try:
-                  candidates.add(path.resolve().relative_to(workspace).as_posix())
-              except Exception:
-                  try:
-                      candidates.add(path.resolve().as_posix())
-                  except Exception:
-                      pass
-              if not path.is_absolute():
-                  candidates.add((workspace / path).resolve().relative_to(workspace).as_posix())
-              for candidate in candidates:
-                  file_entries[candidate] = entry
-
-          def percent(entry):
-              lines = entry.get("lines", {}) if isinstance(entry, dict) else {}
-              total = lines.get("count") or lines.get("total") or 0
-              covered = lines.get("covered") or 0
-              pct = lines.get("percent")
-              if pct is None:
-                  rate = lines.get("rate") or lines.get("line_rate")
-                  if rate is not None:
-                      pct = float(rate) * 100.0
-              if pct is not None:
-                  return float(pct)
-              if total == 0:
-                  return 100.0
-              return (covered / total) * 100.0
-
-          report_lines = ["| File | Line % |", "| --- | ---: |"]
-          failures = []
-          for rel in touched_sources:
-              key = rel
-              entry = file_entries.get(key)
-              if entry is None:
-                  abs_candidates = [
-                      Path(rel).resolve().as_posix(),
-                      (workspace / rel).resolve().as_posix(),
-                  ]
-                  for candidate in abs_candidates:
-                      entry = file_entries.get(candidate)
-                      if entry:
-                          break
-
-              pct = percent(entry) if entry else 0.0
-              report_lines.append(f"| {rel} | {pct:.2f}% |")
-              if pct + 1e-9 < threshold:
-                  failures.append((rel, pct))
-
-          print("\n".join(report_lines))
-          append_summary(report_lines + [""])
-
-          if failures:
-              fail_lines = [
-                  "Touched files below threshold ({}%):".format(threshold),
-              ] + [
-                  f"- {rel}: {pct:.2f}%"
-                  for rel, pct in failures
-              ]
-              print("\n".join(fail_lines))
-              append_summary(fail_lines + [""])
-              sys.exit(1)
-
-          success_msg = "All touched files meet the {:.0f}% coverage threshold.".format(threshold)
-          print(success_msg)
-          append_summary([success_msg, ""])
-          PY
 
       - name: Upload coverage artifacts (Linux / py3.11 only)
         if: ${{ runner.os == 'Linux' && matrix.python-version == '3.11' }}

--- a/algorithms/attTrackingError/attTrackingError.cpp
+++ b/algorithms/attTrackingError/attTrackingError.cpp
@@ -40,7 +40,7 @@ void AttTrackingError::updateState(uint64_t callTime) {
     convert(this->attNavInMsg(), navF32);
 
     AttGuidMsgPayload attGuidOut{};
-    AttGuidMsgF32Payload attGuidOutF32 = this->algorithm.update(callTime, refF32, navF32);
+    const AttGuidMsgF32Payload attGuidOutF32 = this->algorithm.update(callTime, refF32, navF32);
     convert(attGuidOutF32, attGuidOut);
 
     this->attGuidOutMsg.write(&attGuidOut, this->moduleID, callTime);

--- a/algorithms/attTrackingError/attTrackingError.cpp
+++ b/algorithms/attTrackingError/attTrackingError.cpp
@@ -50,11 +50,11 @@ void AttTrackingError::updateState(uint64_t callTime) {
  @return void
  @param sigma_R0R
 */
-void AttTrackingError::setSigma_R0R(const Eigen::Vector3d &sigma_R0R) {
+void AttTrackingError::setSigma_R0R(const Eigen::Vector3d& sigma_R0R) {
     this->algorithm.setSigma_R0R(sigma_R0R.cast<float>());
 }
 
 /*! Getter method for sigma_R0R.
  @return const Eigen::Vector3d
 */
-const Eigen::Vector3d AttTrackingError::getSigma_R0R() const { return this->algorithm.getSigma_R0R().cast<double>();}
+const Eigen::Vector3d AttTrackingError::getSigma_R0R() const { return this->algorithm.getSigma_R0R().cast<double>(); }

--- a/algorithms/attTrackingError/attTrackingError.cpp
+++ b/algorithms/attTrackingError/attTrackingError.cpp
@@ -7,7 +7,6 @@
 #include "attTrackingError.h"
 
 #include "architecture/utilities/eigenSupport.h"
-#include "architecture/utilities/rigidBodyKinematics.hpp"
 
 #include "../../architecture/utilities/messageConversionHelpers.hpp"
 

--- a/algorithms/attTrackingError/attTrackingError.cpp
+++ b/algorithms/attTrackingError/attTrackingError.cpp
@@ -6,7 +6,7 @@
 
 #include "attTrackingError.h"
 
-#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/eigenSupport.h"
 #include "architecture/utilities/rigidBodyKinematics.hpp"
 
 #include "../../architecture/utilities/messageConversionHelpers.hpp"

--- a/algorithms/attTrackingError/attTrackingErrorAlgorithm.cpp
+++ b/algorithms/attTrackingError/attTrackingErrorAlgorithm.cpp
@@ -24,31 +24,31 @@ void AttTrackingErrorAlgorithm::reset(uint64_t callTime) {
  */
 AttGuidMsgF32Payload AttTrackingErrorAlgorithm::update(uint64_t callTime,
                                                        AttRefMsgF32Payload& attRefInMsg,
-                                                       NavAttMsgF32Payload& attNavInMsg) {
+                                                       NavAttMsgF32Payload& attNavInMsg) const {
 
     // Compute MRP from the original reference frame R0 to the corrected reference frame R
-    Eigen::Vector3f sigma_RR0 = -1.0 * this->sigma_R0R;
+    const Eigen::Vector3f sigma_RR0 = -1.0 * this->sigma_R0R;
 
     // Compute MRP from inertial to updated reference frame sigma_RN
     Eigen::Vector3f sigma_RN = cArrayAsEigenVector(attRefInMsg.sigma_RN);
     sigma_RN = addMrp(sigma_RN, sigma_RR0);
 
     // Compute attitude error sigma_BR
-    Eigen::Vector3f sigma_BN = cArrayAsEigenVector(attNavInMsg.sigma_BN);
-    Eigen::Vector3f sigma_BR = subMrp(sigma_BN, sigma_RN);
+    const Eigen::Vector3f sigma_BN = cArrayAsEigenVector(attNavInMsg.sigma_BN);
+    const Eigen::Vector3f sigma_BR = subMrp(sigma_BN, sigma_RN);
 
     // Compute angular velocity reference body frame components omega_RN_B
-    Eigen::Matrix3f dcm_BN = mrpToDcm(sigma_BN);
-    Eigen::Vector3f omega_RN_N = cArrayAsEigenVector(attRefInMsg.omega_RN_N);
-    Eigen::Vector3f omega_RN_B = dcm_BN * omega_RN_N;
+    const Eigen::Matrix3f dcm_BN = mrpToDcm(sigma_BN);
+    const Eigen::Vector3f omega_RN_N = cArrayAsEigenVector(attRefInMsg.omega_RN_N);
+    const Eigen::Vector3f omega_RN_B = dcm_BN * omega_RN_N;
 
     // Compute angular velocity error omega_BR
-    Eigen::Vector3f omega_BN_B = cArrayAsEigenVector(attNavInMsg.omega_BN_B);
-    Eigen::Vector3f omega_BR_B = omega_BN_B - omega_RN_B;
+    const Eigen::Vector3f omega_BN_B = cArrayAsEigenVector(attNavInMsg.omega_BN_B);
+    const Eigen::Vector3f omega_BR_B = omega_BN_B - omega_RN_B;
 
     // Compute reference angular velocity rate in body frame components domega_RN_B
-    Eigen::Vector3f domega_RN_N = cArrayAsEigenVector(attRefInMsg.domega_RN_N);
-    Eigen::Vector3f domega_RN_B = dcm_BN * domega_RN_N;
+    const Eigen::Vector3f domega_RN_N = cArrayAsEigenVector(attRefInMsg.domega_RN_N);
+    const Eigen::Vector3f domega_RN_B = dcm_BN * domega_RN_N;
 
     // Write attitude guidance output message
     AttGuidMsgF32Payload attGuidOut{};

--- a/algorithms/attTrackingError/attTrackingErrorAlgorithm.cpp
+++ b/algorithms/attTrackingError/attTrackingErrorAlgorithm.cpp
@@ -25,7 +25,6 @@ void AttTrackingErrorAlgorithm::reset(uint64_t callTime) {
 AttGuidMsgF32Payload AttTrackingErrorAlgorithm::update(uint64_t callTime,
                                                        AttRefMsgF32Payload& attRefInMsg,
                                                        NavAttMsgF32Payload& attNavInMsg) const {
-
     // Compute MRP from the original reference frame R0 to the corrected reference frame R
     const Eigen::Vector3f sigma_RR0 = -1.0 * this->sigma_R0R;
 

--- a/algorithms/attTrackingError/attTrackingErrorAlgorithm.cpp
+++ b/algorithms/attTrackingError/attTrackingErrorAlgorithm.cpp
@@ -6,7 +6,7 @@
 
 #include "attTrackingErrorAlgorithm.h"
 
-#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/eigenSupport.h"
 #include "architecture/utilities/rigidBodyKinematics.hpp"
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
@@ -30,32 +30,32 @@ AttGuidMsgF32Payload AttTrackingErrorAlgorithm::update(uint64_t callTime,
     Eigen::Vector3f sigma_RR0 = -1.0 * this->sigma_R0R;
 
     // Compute MRP from inertial to updated reference frame sigma_RN
-    Eigen::Vector3f sigma_RN = cArray2EigenVector3f(attRefInMsg.sigma_RN);
+    Eigen::Vector3f sigma_RN = cArrayAsEigenVector(attRefInMsg.sigma_RN);
     sigma_RN = addMrp(sigma_RN, sigma_RR0);
 
     // Compute attitude error sigma_BR
-    Eigen::Vector3f sigma_BN = cArray2EigenVector3f(attNavInMsg.sigma_BN);
+    Eigen::Vector3f sigma_BN = cArrayAsEigenVector(attNavInMsg.sigma_BN);
     Eigen::Vector3f sigma_BR = subMrp(sigma_BN, sigma_RN);
 
     // Compute angular velocity reference body frame components omega_RN_B
     Eigen::Matrix3f dcm_BN = mrpToDcm(sigma_BN);
-    Eigen::Vector3f omega_RN_N = cArray2EigenVector3f(attRefInMsg.omega_RN_N);
+    Eigen::Vector3f omega_RN_N = cArrayAsEigenVector(attRefInMsg.omega_RN_N);
     Eigen::Vector3f omega_RN_B = dcm_BN * omega_RN_N;
 
     // Compute angular velocity error omega_BR
-    Eigen::Vector3f omega_BN_B = cArray2EigenVector3f(attNavInMsg.omega_BN_B);
+    Eigen::Vector3f omega_BN_B = cArrayAsEigenVector(attNavInMsg.omega_BN_B);
     Eigen::Vector3f omega_BR_B = omega_BN_B - omega_RN_B;
 
     // Compute reference angular velocity rate in body frame components domega_RN_B
-    Eigen::Vector3f domega_RN_N = cArray2EigenVector3f(attRefInMsg.domega_RN_N);
+    Eigen::Vector3f domega_RN_N = cArrayAsEigenVector(attRefInMsg.domega_RN_N);
     Eigen::Vector3f domega_RN_B = dcm_BN * domega_RN_N;
 
     // Write attitude guidance output message
     AttGuidMsgF32Payload attGuidOut{};
-    eigenVector3f2CArray(omega_RN_B, attGuidOut.omega_RN_B);
-    eigenVector3f2CArray(omega_BR_B, attGuidOut.omega_BR_B);
-    eigenVector3f2CArray(sigma_BR, attGuidOut.sigma_BR);
-    eigenVector3f2CArray(domega_RN_B, attGuidOut.domega_RN_B);
+    eigenVectorToCArray(omega_RN_B, attGuidOut.omega_RN_B);
+    eigenVectorToCArray(omega_BR_B, attGuidOut.omega_BR_B);
+    eigenVectorToCArray(sigma_BR, attGuidOut.sigma_BR);
+    eigenVectorToCArray(domega_RN_B, attGuidOut.domega_RN_B);
 
     return attGuidOut;
 }

--- a/algorithms/attTrackingError/attTrackingErrorAlgorithm.h
+++ b/algorithms/attTrackingError/attTrackingErrorAlgorithm.h
@@ -19,8 +19,8 @@ class AttTrackingErrorAlgorithm {
     AttGuidMsgF32Payload update(uint64_t callTime,
                                 AttRefMsgF32Payload& attRefInMsg,
                                 NavAttMsgF32Payload& attNavInMsg) const;  //!< Algorithm update method
-    void setSigma_R0R(const Eigen::Vector3f& sigma_R0R);      //!< Setter for sigma_R0R variable
-    const Eigen::Vector3f& getSigma_R0R() const;              //!< Getter for sigma_R0R variable
+    void setSigma_R0R(const Eigen::Vector3f& sigma_R0R);                  //!< Setter for sigma_R0R variable
+    const Eigen::Vector3f& getSigma_R0R() const;                          //!< Getter for sigma_R0R variable
 
    private:
     Eigen::Vector3f sigma_R0R{};  //!< MRP from corrected reference frame to original reference frame R0.

--- a/algorithms/attTrackingError/attTrackingErrorAlgorithm.h
+++ b/algorithms/attTrackingError/attTrackingErrorAlgorithm.h
@@ -18,7 +18,7 @@ class AttTrackingErrorAlgorithm {
     void reset(uint64_t callTime);  //!< Method for algorithm reset
     AttGuidMsgF32Payload update(uint64_t callTime,
                                 AttRefMsgF32Payload& attRefInMsg,
-                                NavAttMsgF32Payload& attNavInMsg);  //!< Algorithm update method
+                                NavAttMsgF32Payload& attNavInMsg) const;  //!< Algorithm update method
     void setSigma_R0R(const Eigen::Vector3f& sigma_R0R);      //!< Setter for sigma_R0R variable
     const Eigen::Vector3f& getSigma_R0R() const;              //!< Getter for sigma_R0R variable
 

--- a/algorithms/attTrackingError/attTrackingErrorAlgorithm_c.cpp
+++ b/algorithms/attTrackingError/attTrackingErrorAlgorithm_c.cpp
@@ -4,7 +4,8 @@
  */
 
 #include "attTrackingErrorAlgorithm_c.h"
-#include "attTrackingErrorAlgorithm.h"  // the original C++ class
+#include "attTrackingErrorAlgorithm.h"
+
 #include <Eigen/Core>
 
 AttTrackingErrorAlgorithm* AttTrackingErrorAlgorithm_create(void) {

--- a/algorithms/ephemNavConverter/ephemNavConverter.cpp
+++ b/algorithms/ephemNavConverter/ephemNavConverter.cpp
@@ -6,6 +6,8 @@
 
 #include "ephemNavConverter.h"
 
+#include <stdexcept>
+
 /*! Reset method for the module adapter interface.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)

--- a/algorithms/ephemNavConverter/ephemNavConverter.h
+++ b/algorithms/ephemNavConverter/ephemNavConverter.h
@@ -7,11 +7,10 @@
 #ifndef F32XIMERA_EPHEM_NAV_CONVERTER_H
 #define F32XIMERA_EPHEM_NAV_CONVERTER_H
 
-#include <stdexcept>
+#include "ephemNavConverterAlgorithm.h"
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
-#include "ephemNavConverterAlgorithm.h"
 #include "msgPayloadDef/EphemerisMsgF32Payload.h"
 #include "msgPayloadDef/NavTransMsgF32Payload.h"
 

--- a/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.cpp
+++ b/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.cpp
@@ -18,7 +18,8 @@ static void v3Copy(float const v[3], float result[3]) {
  @param callTime [ns] Time the method is called
  @param ephemerisInMsg Ephemeris message
  */
-NavTransMsgF32Payload EphemNavConverterAlgorithm::update(uint64_t callTime, EphemerisMsgF32Payload ephemerisInMsg) {
+NavTransMsgF32Payload
+EphemNavConverterAlgorithm::update(uint64_t callTime, const EphemerisMsgF32Payload &ephemerisInMsg) const {
     // Create the output message
     auto navTransMsgBuffer = NavTransMsgF32Payload{};
 

--- a/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.cpp
+++ b/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.cpp
@@ -18,8 +18,8 @@ static void v3Copy(float const v[3], float result[3]) {
  @param callTime [ns] Time the method is called
  @param ephemerisInMsg Ephemeris message
  */
-NavTransMsgF32Payload
-EphemNavConverterAlgorithm::update(uint64_t callTime, const EphemerisMsgF32Payload &ephemerisInMsg) const {
+NavTransMsgF32Payload EphemNavConverterAlgorithm::update(uint64_t callTime,
+                                                         const EphemerisMsgF32Payload& ephemerisInMsg) const {
     // Create the output message
     auto navTransMsgBuffer = NavTransMsgF32Payload{};
 

--- a/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.h
+++ b/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.h
@@ -17,7 +17,7 @@ class EphemNavConverterAlgorithm {
     EphemNavConverterAlgorithm() = default;   //!< Constructor
     ~EphemNavConverterAlgorithm() = default;  //!< Destructor
 
-    NavTransMsgF32Payload update(uint64_t callTime, const EphemerisMsgF32Payload &ephemerisInMsg) const;
+    NavTransMsgF32Payload update(uint64_t callTime, const EphemerisMsgF32Payload& ephemerisInMsg) const;
 };
 
 #endif

--- a/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.h
+++ b/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.h
@@ -17,7 +17,7 @@ class EphemNavConverterAlgorithm {
     EphemNavConverterAlgorithm() = default;   //!< Constructor
     ~EphemNavConverterAlgorithm() = default;  //!< Destructor
 
-    NavTransMsgF32Payload update(uint64_t callTime, EphemerisMsgF32Payload ephemerisInMsg);
+    NavTransMsgF32Payload update(uint64_t callTime, const EphemerisMsgF32Payload &ephemerisInMsg) const;
 };
 
 #endif

--- a/algorithms/freestandingInvalidArgument.h
+++ b/algorithms/freestandingInvalidArgument.h
@@ -1,0 +1,88 @@
+/*
+ MIT License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ */
+
+#ifndef FP32_XIMERA_FSW_ALGORITHMS_CUSTOMEXCEPTIONS_H
+#define FP32_XIMERA_FSW_ALGORITHMS_CUSTOMEXCEPTIONS_H
+
+// Give a clear compile-time error if <exception> isn't present (when supported).
+#if defined(__has_include)
+#if !__has_include(<exception>)
+#error "This target requires <exception>; none found."
+#endif
+#endif
+
+#include <cstddef>
+#include <exception>
+
+#ifndef FS_EXC_MAX_MSG
+#define FS_EXC_MAX_MSG 256  // override if you need longer messages
+#endif
+
+namespace fs {
+
+class invalid_argument : public std::exception {
+   public:
+    explicit invalid_argument(const char* msg) noexcept { safe_copy(this->message, FS_EXC_MAX_MSG, msg); }
+
+    const char* what() const noexcept override { return this->message[0] ? this->message : "invalid argument"; }
+
+   private:
+    char message[FS_EXC_MAX_MSG];
+
+    static void safe_copy(char* dst, std::size_t cap, const char* src) noexcept {
+        if (!dst || cap == 0) return;
+        if (!src) {
+            dst[0] = '\0';
+            return;
+        }
+        std::size_t i = 0;
+        while (i + 1 < cap && src[i] != '\0') {
+            dst[i] = src[i];
+            ++i;
+        }
+        dst[i] = '\0';
+    }
+};
+
+}  // namespace fs
+
+// Require exceptions if you want (set to 1), otherwise we'll still compile.
+#ifndef FS_REQUIRE_EXCEPTIONS
+#define FS_REQUIRE_EXCEPTIONS 0
+#endif
+
+#if FS_REQUIRE_EXCEPTIONS && !defined(__cpp_exceptions)
+#error "Exceptions are required for this target (define __cpp_exceptions)."
+#endif
+
+#if defined(__cpp_exceptions)
+#define FS_THROW_INVALID_ARGUMENT(msg_cstr) throw fs::invalid_argument((msg_cstr))
+#else
+   // No <cstdio>/<cstdlib>. Use a trap so this stays freestanding.
+#if defined(__GNUC__) || defined(__clang__)
+#define FS_THROW_INVALID_ARGUMENT(msg_cstr) \
+    do {                                    \
+        (void)(msg_cstr);                   \
+        __builtin_trap();                   \
+    } while (0)
+#elif defined(_MSC_VER)
+#include <intrin.h>
+#define FS_THROW_INVALID_ARGUMENT(msg_cstr) \
+    do {                                    \
+        (void)(msg_cstr);                   \
+        __debugbreak();                     \
+    } while (0)
+#else
+#define FS_THROW_INVALID_ARGUMENT(msg_cstr) \
+    do {                                    \
+        (void)(msg_cstr);                   \
+        for (;;) {                          \
+        }                                   \
+    } while (0)
+#endif
+#endif
+
+#endif  // FP32_XIMERA_FSW_ALGORITHMS_CUSTOMEXCEPTIONS_H

--- a/algorithms/navAggregate/navAggregate.cpp
+++ b/algorithms/navAggregate/navAggregate.cpp
@@ -6,6 +6,7 @@
 
 #include "navAggregate.h"
 
+#include <array>
 #include <stdexcept>
 
 /*! This resets the module to original states.

--- a/algorithms/navAggregate/navAggregate.cpp
+++ b/algorithms/navAggregate/navAggregate.cpp
@@ -6,6 +6,8 @@
 
 #include "navAggregate.h"
 
+#include <stdexcept>
+
 /*! This resets the module to original states.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)

--- a/algorithms/navAggregate/navAggregate.h
+++ b/algorithms/navAggregate/navAggregate.h
@@ -7,15 +7,14 @@
 #ifndef F32XIMERA_NAV_AGGREGATE_H
 #define F32XIMERA_NAV_AGGREGATE_H
 
-#include <stdint.h>
-
-#include <array>
-
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
 #include "msgPayloadDef/NavAttMsgF32Payload.h"
 #include "msgPayloadDef/NavTransMsgF32Payload.h"
 #include "navAggregateAlgorithm.h"
+
+#include <stdint.h>
+
 
 /*! structure containing the attitude navigation message name, ID and local buffer*/
 typedef struct {

--- a/algorithms/navAggregate/navAggregate.h
+++ b/algorithms/navAggregate/navAggregate.h
@@ -15,7 +15,6 @@
 
 #include <stdint.h>
 
-
 /*! structure containing the attitude navigation message name, ID and local buffer*/
 typedef struct {
     ReadFunctor<NavAttMsgF32Payload> navAttInMsg; /*!< attitude navigation input message*/

--- a/algorithms/navAggregate/navAggregateAlgorithm.cpp
+++ b/algorithms/navAggregate/navAggregateAlgorithm.cpp
@@ -6,6 +6,9 @@
 
 #include "navAggregateAlgorithm.h"
 
+#include "../freestandingInvalidArgument.h"
+#include <stdio.h>
+
 /**
  * @brief Copy a 3x1 float vector.
  * @param v The vector to be copied.
@@ -63,10 +66,14 @@ AggregateOutput NavAggregateAlgorithm::update(std::array<NavAttMsgF32Payload, MA
  */
 void NavAggregateAlgorithm::setAttTimeIdx(uint32_t idx) {
     if (idx >= MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "attTimeIdx (" + std::to_string(idx) +
-                               ") must be less than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "attTimeIdx (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 idx,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->attTimeIdx = idx;
 }
@@ -83,10 +90,14 @@ uint32_t NavAggregateAlgorithm::getAttTimeIdx() const { return this->attTimeIdx;
  */
 void NavAggregateAlgorithm::setTransTimeIdx(uint32_t idx) {
     if (idx >= MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "transTimeIdx (" + std::to_string(idx) +
-                               ") must be less than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "transTimeIdx (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 idx,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->transTimeIdx = idx;
 }
@@ -103,10 +114,14 @@ uint32_t NavAggregateAlgorithm::getTransTimeIdx() const { return this->transTime
  */
 void NavAggregateAlgorithm::setAttIdx(uint32_t idx) {
     if (idx >= MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "attIdx (" + std::to_string(idx) +
-                               ") must be less than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "attIdx (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 idx,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->attIdx = idx;
 }
@@ -123,10 +138,14 @@ uint32_t NavAggregateAlgorithm::getAttIdx() const { return this->attIdx; }
  */
 void NavAggregateAlgorithm::setRateIdx(uint32_t idx) {
     if (idx >= MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "rateIdx (" + std::to_string(idx) +
-                               ") must be less than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "rateIdx (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 idx,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->rateIdx = idx;
 }
@@ -143,10 +162,14 @@ uint32_t NavAggregateAlgorithm::getRateIdx() const { return this->rateIdx; }
  */
 void NavAggregateAlgorithm::setPosIdx(uint32_t idx) {
     if (idx >= MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "posIdx (" + std::to_string(idx) +
-                               ") must be less than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "posIdx (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 idx,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->posIdx = idx;
 }
@@ -163,10 +186,14 @@ uint32_t NavAggregateAlgorithm::getPosIdx() const { return this->posIdx; }
  */
 void NavAggregateAlgorithm::setVelIdx(uint32_t idx) {
     if (idx >= MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "velIdx (" + std::to_string(idx) +
-                               ") must be less than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "velIdx (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 idx,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->velIdx = idx;
 }
@@ -183,10 +210,14 @@ uint32_t NavAggregateAlgorithm::getVelIdx() const { return this->velIdx; }
  */
 void NavAggregateAlgorithm::setDvIdx(uint32_t idx) {
     if (idx >= MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "dvIdx (" + std::to_string(idx) +
-                               ") must be less than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "dvIdx (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 idx,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->dvIdx = idx;
 }
@@ -203,10 +234,14 @@ uint32_t NavAggregateAlgorithm::getDvIdx() const { return this->dvIdx; }
  */
 void NavAggregateAlgorithm::setSunIdx(uint32_t idx) {
     if (idx >= MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "sunIdx (" + std::to_string(idx) +
-                               ") must be less than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "attMsgCount (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 idx,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->sunIdx = idx;
 }
@@ -223,10 +258,14 @@ uint32_t NavAggregateAlgorithm::getSunIdx() const { return this->sunIdx; }
  */
 void NavAggregateAlgorithm::setAttMsgCount(uint32_t msgCount) {
     if (msgCount > MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "attMsgCount (" + std::to_string(msgCount) +
-                               ") must not be greater than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "attMsgCount (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 msgCount,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->attMsgCount = msgCount;
 }
@@ -243,10 +282,14 @@ uint32_t NavAggregateAlgorithm::getAttMsgCount() const { return this->attMsgCoun
  */
 void NavAggregateAlgorithm::setTransMsgCount(uint32_t msgCount) {
     if (msgCount > MAX_AGG_NAV_MSG) {
-        std::string errorMsg = "transMsgCount (" + std::to_string(msgCount) +
-                               ") must not be greater than maximum navAggregate message size (" +
-                               std::to_string(MAX_AGG_NAV_MSG) + ").";
-        throw std::invalid_argument(errorMsg);
+        char msg[128];
+        snprintf(msg,
+                 128,
+                 "transMsgCount (%u) must be less than maximum navAggregate "
+                 "message size (%d)",
+                 msgCount,
+                 MAX_AGG_NAV_MSG);
+        FS_THROW_INVALID_ARGUMENT(msg);
     }
     this->transMsgCount = msgCount;
 }

--- a/algorithms/navAggregate/navAggregateAlgorithm.h
+++ b/algorithms/navAggregate/navAggregateAlgorithm.h
@@ -8,8 +8,6 @@
 #define F32XIMERA_NAV_AGGREGATE_ALGORITHM_H
 
 #include <stdint.h>
-#include <stdexcept>
-#include <string>
 
 #include <array>
 

--- a/algorithms/rateControl/rateControl.cpp
+++ b/algorithms/rateControl/rateControl.cpp
@@ -9,7 +9,6 @@
 #include <stdint.h>
 #include <stdexcept>
 
-
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
  @return void
@@ -57,11 +56,11 @@ float RateControl::getDerivativeGainP() const { return this->algorithm.getDeriva
  @return void
  @param knownTorquePntB_B [N*m] Known external torque expressed in body frame components
 */
-void RateControl::setKnownTorquePntB_B(const Eigen::Vector3f &knownTorquePntB_B) {
+void RateControl::setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B) {
     this->algorithm.setKnownTorquePntB_B(knownTorquePntB_B);
 }
 
 /*! Getter method for the known torque about point B.
  @return const Eigen::Vector3f
 */
-const Eigen::Vector3f &RateControl::getKnownTorquePntB_B() const { return this->algorithm.getKnownTorquePntB_B(); }
+const Eigen::Vector3f& RateControl::getKnownTorquePntB_B() const { return this->algorithm.getKnownTorquePntB_B(); }

--- a/algorithms/rateControl/rateControl.cpp
+++ b/algorithms/rateControl/rateControl.cpp
@@ -6,6 +6,10 @@
 
 #include "rateControl.h"
 
+#include <stdint.h>
+#include <stdexcept>
+
+
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
  @return void

--- a/algorithms/rateControl/rateControl.h
+++ b/algorithms/rateControl/rateControl.h
@@ -7,17 +7,15 @@
 #ifndef F32XIMERA_RATE_CONTROL_H
 #define F32XIMERA_RATE_CONTROL_H
 
-#include <stdint.h>
-#include <stdexcept>
-
-#include <Eigen/Dense>
+#include "rateControlAlgorithm.h"
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
 #include "msgPayloadDef/AttGuidMsgF32Payload.h"
 #include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
 #include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
-#include "rateControlAlgorithm.h"
+
+#include <Eigen/Core>
 
 class RateControl : public SysModel {
    public:

--- a/algorithms/rateControl/rateControl.h
+++ b/algorithms/rateControl/rateControl.h
@@ -26,8 +26,8 @@ class RateControl : public SysModel {
     void updateState(uint64_t currentSimNanos) override;
     void setDerivativeGainP(float P);
     float getDerivativeGainP() const;
-    void setKnownTorquePntB_B(const Eigen::Vector3f &knownTorquePntB_B);
-    const Eigen::Vector3f &getKnownTorquePntB_B() const;
+    void setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B);
+    const Eigen::Vector3f& getKnownTorquePntB_B() const;
 
     ReadFunctor<AttGuidMsgF32Payload> guidInMsg;             //!< Attitude guidance input message
     ReadFunctor<VehicleConfigMsgF32Payload> vehConfigInMsg;  //!< Vehicle configuration input message

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -6,6 +6,8 @@
 
 #include "rateControlAlgorithm.h"
 
+#include "../freestandingInvalidArgument.h"
+
 /*! This function performs the conversion between an input C array
 3-vector and an output Eigen vector3f. This function is provided
 in order to save an unnecessary conversion between types.
@@ -77,7 +79,7 @@ void RateControlAlgorithm::setSpacecraftInertia(VehicleConfigMsgF32Payload vehic
 */
 void RateControlAlgorithm::setDerivativeGainP(const float P) {
     if (P < 0.0) {
-        throw std::invalid_argument("Feedback gain P must not be negative");
+        FS_THROW_INVALID_ARGUMENT("Feedback gain P must not be negative");
     }
     this->P = P;
 }

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -8,40 +8,7 @@
 
 #include "../freestandingInvalidArgument.h"
 
-/*! This function performs the conversion between an input C array
-3-vector and an output Eigen vector3f. This function is provided
-in order to save an unnecessary conversion between types.
-@return Eigen::Vector3f
-@param inArray The input array (row-major)
-*/
-static Eigen::Vector3f cArray2EigenVector3f(float *inArray) { return Eigen::Map<Eigen::Vector3f>(inArray, 3, 1); }
-
-/*! This function provides a direct conversion between a 3-vector and an
-output C array. We are providing this function to save on the  inline conversion
-and the transpose that would have been performed by the general case.
-@return void
-@param inMat The source Eigen matrix that we are converting
-@param outArray The destination array we copy into
-*/
-static void eigenVector3f2CArray(Eigen::Vector3f &inMat, float *outArray) {
-    memcpy(outArray, inMat.data(), 3 * sizeof(float));
-}
-
-/*! This function performs the general conversion between an input C array
-and an Eigen matrix. Note that to use this function the user MUST size
-the Eigen matrix ahead of time so that the internal map call has enough
-information to ingest the C array.
-@return Eigen::MatrixXf
-@param inArray The input array (row-major)
-@param nRows
-@param nCols
-*/
-static Eigen::MatrixXf cArray2EigenMatrixXf(float *inArray, int nRows, int nCols) {
-    Eigen::MatrixXf outMat;
-    outMat.resize(nRows, nCols);
-    outMat = Eigen::Map<Eigen::MatrixXf>(inArray, outMat.rows(), outMat.cols());
-    return outMat;
-}
+#include "architecture/utilities/eigenSupport.h"
 
 /*! This method takes the attitude and rate errors relative to the reference frame, as well as
 the reference frame angular rates and acceleration, and computes the required control torque Lr.
@@ -52,15 +19,15 @@ CmdTorqueBodyMsgF32Payload RateControlAlgorithm::update(AttGuidMsgF32Payload att
     CmdTorqueBodyMsgF32Payload torqueCmdOut{};
 
     // Compute required attitude control torque vector
-    Eigen::Vector3f omega_BR_B = cArray2EigenVector3f(attGuidIn.omega_BR_B);
-    Eigen::Vector3f omega_RN_B = cArray2EigenVector3f(attGuidIn.omega_RN_B);
+    Eigen::Vector3f omega_BR_B = cArrayAsEigenVector(attGuidIn.omega_BR_B);
+    Eigen::Vector3f omega_RN_B = cArrayAsEigenVector(attGuidIn.omega_RN_B);
     Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
-    Eigen::Vector3f domega_RN_B = cArray2EigenVector3f(attGuidIn.domega_RN_B);
+    Eigen::Vector3f domega_RN_B = cArrayAsEigenVector(attGuidIn.domega_RN_B);
     Eigen::Vector3f Lr = -this->P * omega_BR_B + omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
                          this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
                          this->knownTorquePntB_B;  // [Nm]
 
-    eigenVector3f2CArray(Lr, torqueCmdOut.torqueRequestBody);
+    eigenVectorToCArray(Lr, torqueCmdOut.torqueRequestBody);
 
     return torqueCmdOut;
 }
@@ -70,7 +37,7 @@ CmdTorqueBodyMsgF32Payload RateControlAlgorithm::update(AttGuidMsgF32Payload att
  @param vehicleConfigIn Vehicle config input
 */
 void RateControlAlgorithm::setSpacecraftInertia(VehicleConfigMsgF32Payload vehicleConfigIn) {
-    this->ISCPntB_B = cArray2EigenMatrixXf(vehicleConfigIn.ISCPntB_B, 3, 3);
+    this->ISCPntB_B = cArrayAsEigenMatrix3(vehicleConfigIn.ISCPntB_B);
 }
 
 /*! Setter method for the derivative gain P.

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -17,15 +17,15 @@ the reference frame angular rates and acceleration, and computes the required co
  @return torqueCmdOut
  @param attGuidIn Attitude guidance input
 */
-CmdTorqueBodyMsgF32Payload RateControlAlgorithm::update(AttGuidMsgF32Payload attGuidIn) {
+CmdTorqueBodyMsgF32Payload RateControlAlgorithm::update(AttGuidMsgF32Payload attGuidIn) const {
     CmdTorqueBodyMsgF32Payload torqueCmdOut{};
 
     // Compute required attitude control torque vector
-    Eigen::Vector3f omega_BR_B = cArrayAsEigenVector(attGuidIn.omega_BR_B);
-    Eigen::Vector3f omega_RN_B = cArrayAsEigenVector(attGuidIn.omega_RN_B);
-    Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
-    Eigen::Vector3f domega_RN_B = cArrayAsEigenVector(attGuidIn.domega_RN_B);
-    Eigen::Vector3f Lr = -this->P * omega_BR_B + omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
+    const Eigen::Vector3f omega_BR_B = cArrayAsEigenVector(attGuidIn.omega_BR_B);
+    const Eigen::Vector3f omega_RN_B = cArrayAsEigenVector(attGuidIn.omega_RN_B);
+    const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
+    const Eigen::Vector3f domega_RN_B = cArrayAsEigenVector(attGuidIn.domega_RN_B);
+    const Eigen::Vector3f Lr = -this->P * omega_BR_B + omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
                          this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
                          this->knownTorquePntB_B;  // [Nm]
 

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -26,8 +26,8 @@ CmdTorqueBodyMsgF32Payload RateControlAlgorithm::update(AttGuidMsgF32Payload att
     const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
     const Eigen::Vector3f domega_RN_B = cArrayAsEigenVector(attGuidIn.domega_RN_B);
     const Eigen::Vector3f Lr = -this->P * omega_BR_B + omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
-                         this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
-                         this->knownTorquePntB_B;  // [Nm]
+                               this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
+                               this->knownTorquePntB_B;  // [Nm]
 
     eigenVectorToCArray(Lr, torqueCmdOut.torqueRequestBody);
 
@@ -62,11 +62,11 @@ float RateControlAlgorithm::getDerivativeGainP() const { return this->P; }
  @return void
  @param knownTorquePntB_B [N*m] Known external torque expressed in body frame components
 */
-void RateControlAlgorithm::setKnownTorquePntB_B(const Eigen::Vector3f &knownTorquePntB_B) {
+void RateControlAlgorithm::setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B) {
     this->knownTorquePntB_B = knownTorquePntB_B;
 }
 
 /*! Getter method for the known torque about point B.
  @return const Eigen::Vector3f
 */
-const Eigen::Vector3f &RateControlAlgorithm::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }
+const Eigen::Vector3f& RateControlAlgorithm::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -4,7 +4,7 @@
  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 */
 
-#include "rateControl.h"
+#include "rateControlAlgorithm.h"
 
 /*! This function performs the conversion between an input C array
 3-vector and an output Eigen vector3f. This function is provided

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -10,6 +10,8 @@
 
 #include "architecture/utilities/eigenSupport.h"
 
+#include <Eigen/Geometry>
+
 /*! This method takes the attitude and rate errors relative to the reference frame, as well as
 the reference frame angular rates and acceleration, and computes the required control torque Lr.
  @return torqueCmdOut

--- a/algorithms/rateControl/rateControlAlgorithm.h
+++ b/algorithms/rateControl/rateControlAlgorithm.h
@@ -7,8 +7,6 @@
 #ifndef F32XIMERA_RATE_CONTROL_ALGORITHM_H
 #define F32XIMERA_RATE_CONTROL_ALGORITHM_H
 
-#include <stdexcept>
-
 #include <Eigen/Dense>
 
 #include "msgPayloadDef/AttGuidMsgF32Payload.h"

--- a/algorithms/rateControl/rateControlAlgorithm.h
+++ b/algorithms/rateControl/rateControlAlgorithm.h
@@ -15,7 +15,7 @@
 
 class RateControlAlgorithm {
    public:
-    CmdTorqueBodyMsgF32Payload update(AttGuidMsgF32Payload attGuidIn);
+    CmdTorqueBodyMsgF32Payload update(AttGuidMsgF32Payload attGuidIn) const;
     void setSpacecraftInertia(VehicleConfigMsgF32Payload vehicleConfigIn);
     void setDerivativeGainP(float P);
     float getDerivativeGainP() const;

--- a/algorithms/rateControl/rateControlAlgorithm.h
+++ b/algorithms/rateControl/rateControlAlgorithm.h
@@ -7,11 +7,11 @@
 #ifndef F32XIMERA_RATE_CONTROL_ALGORITHM_H
 #define F32XIMERA_RATE_CONTROL_ALGORITHM_H
 
-#include <Eigen/Dense>
-
 #include "msgPayloadDef/AttGuidMsgF32Payload.h"
 #include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
 #include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
+
+#include <Eigen/Core>
 
 class RateControlAlgorithm {
    public:

--- a/algorithms/sunlineEphem/sunlineEphem.cpp
+++ b/algorithms/sunlineEphem/sunlineEphem.cpp
@@ -6,10 +6,18 @@
 
 #include "sunlineEphem.h"
 
+#include <stdexcept>
+
 void SunlineEphem::reset(uint64_t callTime) {
-    assert(this->sunPositionInMsg.isLinked());
-    assert(this->scPositionInMsg.isLinked());
-    assert(this->scAttitudeInMsg.isLinked());
+    if (!this->sunPositionInMsg.isLinked()) {
+        throw std::invalid_argument("SunlineEphem.sunPositionInMsg is unlinked");
+    }
+    if (!this->scPositionInMsg.isLinked()) {
+        throw std::invalid_argument("SunlineEphem.scPositionInMsg is unlinked");
+    }
+    if (!this->scAttitudeInMsg.isLinked()) {
+        throw std::invalid_argument("SunlineEphem.scAttitudeInMsg is unlinked");
+    }
 }
 
 void SunlineEphem::updateState(uint64_t callTime) {

--- a/algorithms/sunlineEphem/sunlineEphem.cpp
+++ b/algorithms/sunlineEphem/sunlineEphem.cpp
@@ -21,9 +21,9 @@ void SunlineEphem::reset(uint64_t callTime) {
 }
 
 void SunlineEphem::updateState(uint64_t callTime) {
-    EphemerisMsgF32Payload sunPos = this->sunPositionInMsg();
-    NavTransMsgF32Payload scPos = this->scPositionInMsg();
-    NavAttMsgF32Payload scAtt = this->scAttitudeInMsg();
+    const EphemerisMsgF32Payload sunPos = this->sunPositionInMsg();
+    const NavTransMsgF32Payload scPos = this->scPositionInMsg();
+    const NavAttMsgF32Payload scAtt = this->scAttitudeInMsg();
     auto outputSunline = this->algorithm.updateState(sunPos, scPos, scAtt);
     this->navStateOutMsg.write(&outputSunline, this->moduleID, callTime);
 }

--- a/algorithms/sunlineEphem/sunlineEphemAlgorithm.cpp
+++ b/algorithms/sunlineEphem/sunlineEphemAlgorithm.cpp
@@ -6,6 +6,10 @@
 
 #include "sunlineEphemAlgorithm.h"
 
+#include "architecture/utilities/rigidBodyKinematics.hpp"
+
+#include <Eigen/Core>
+
 NavAttMsgF32Payload SunlineEphemAlgorithm::updateState(const EphemerisMsgF32Payload &sunPos,
                                                        const NavTransMsgF32Payload &scPos,
                                                        const NavAttMsgF32Payload &scAtt) const {

--- a/algorithms/sunlineEphem/sunlineEphemAlgorithm.cpp
+++ b/algorithms/sunlineEphem/sunlineEphemAlgorithm.cpp
@@ -10,9 +10,9 @@
 
 #include <Eigen/Core>
 
-NavAttMsgF32Payload SunlineEphemAlgorithm::updateState(const EphemerisMsgF32Payload &sunPos,
-                                                       const NavTransMsgF32Payload &scPos,
-                                                       const NavAttMsgF32Payload &scAtt) const {
+NavAttMsgF32Payload SunlineEphemAlgorithm::updateState(const EphemerisMsgF32Payload& sunPos,
+                                                       const NavTransMsgF32Payload& scPos,
+                                                       const NavAttMsgF32Payload& scAtt) const {
     // Get sun position
     const Eigen::Vector3f rSun(sunPos.r_BdyZero_N[0], sunPos.r_BdyZero_N[1], sunPos.r_BdyZero_N[2]);
     const Eigen::Vector3f rSc(scPos.r_BN_N[0], scPos.r_BN_N[1], scPos.r_BN_N[2]);

--- a/algorithms/sunlineEphem/sunlineEphemAlgorithm.h
+++ b/algorithms/sunlineEphem/sunlineEphemAlgorithm.h
@@ -7,11 +7,6 @@
 #ifndef F32XIMERA_SUNLINE_EPHEM_ALGORITHM_H
 #define F32XIMERA_SUNLINE_EPHEM_ALGORITHM_H
 
-#include <assert.h>
-#include <stdint.h>
-#include <Eigen/Core>
-
-#include "architecture/utilities/rigidBodyKinematics.hpp"
 #include "msgPayloadDef/EphemerisMsgF32Payload.h"
 #include "msgPayloadDef/NavAttMsgF32Payload.h"
 #include "msgPayloadDef/NavTransMsgF32Payload.h"

--- a/algorithms/sunlineEphem/sunlineEphemAlgorithm.h
+++ b/algorithms/sunlineEphem/sunlineEphemAlgorithm.h
@@ -13,9 +13,9 @@
 
 class SunlineEphemAlgorithm {
    public:
-    NavAttMsgF32Payload updateState(const EphemerisMsgF32Payload &sunPos,
-                                    const NavTransMsgF32Payload &scPos,
-                                    const NavAttMsgF32Payload &scAtt) const;
+    NavAttMsgF32Payload updateState(const EphemerisMsgF32Payload& sunPos,
+                                    const NavTransMsgF32Payload& scPos,
+                                    const NavAttMsgF32Payload& scAtt) const;
 };
 
 #endif

--- a/architecture/utilities/CMakeLists.txt
+++ b/architecture/utilities/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB source_files
-     "${CMAKE_CURRENT_SOURCE_DIR}/avsEigenSupport.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/eigenSupport.h"
      "${CMAKE_CURRENT_SOURCE_DIR}/rigidBodyKinematics.hpp"
      "${CMAKE_CURRENT_SOURCE_DIR}/messageConversationHelpers.cpp")
 

--- a/architecture/utilities/eigenMRP.h
+++ b/architecture/utilities/eigenMRP.h
@@ -1,0 +1,805 @@
+/*
+ ISC License
+
+ Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+/// \cond DO_NOT_DOCUMENT
+
+#ifndef EIGEN_MRP_H
+#define EIGEN_MRP_H
+
+#include <Eigen/Geometry>
+
+namespace Eigen {
+template <typename Scalar, int Options = AutoAlign>
+class MRP;
+
+/***************************************************************************
+ * Definition of MRPBase<Derived>
+ * The implementation is at the end of the file
+ ***************************************************************************/
+
+namespace internal {
+template <typename Other, int OtherRows = Other::RowsAtCompileTime, int OtherCols = Other::ColsAtCompileTime>
+struct MRPbase_assign_impl;
+}
+
+/** \geometry_module \ingroup Geometry_Module
+ * \class MRPBase
+ * \brief Base class for MRP expressions
+ * \tparam Derived derived type (CRTP)
+ * \sa class MRP
+ */
+template <class Derived>
+class MRPBase : public RotationBase<Derived, 3> {
+    typedef RotationBase<Derived, 3> Base;
+
+   public:
+    using Base::operator*;
+    using Base::derived;
+
+    typedef typename internal::traits<Derived>::Scalar Scalar;              //!< variable
+    typedef typename NumTraits<Scalar>::Real RealScalar;                    //!< variable
+    typedef typename internal::traits<Derived>::Coefficients Coefficients;  //!< variable
+    enum { Flags = Eigen::internal::traits<Derived>::Flags };
+
+    // typedef typename Matrix<Scalar,3,1> Coefficients;
+    /** the type of a 3D vector */
+    typedef Matrix<Scalar, 3, 1> Vector3;
+    /** the equivalent rotation matrix type */
+    typedef Matrix<Scalar, 3, 3> Matrix3;
+    /** the equivalent angle-axis type */
+    typedef AngleAxis<Scalar> AngleAxisType;
+
+    /** default constructor */
+    MRPBase() = default;
+    /** copy constructor */
+    MRPBase(const MRPBase<Derived>& /*rhs*/) = default;
+
+    /** \returns the \c x coefficient */
+    inline Scalar x() const { return this->derived().coeffs().coeff(0); }
+    /** \returns the \c y coefficient */
+    inline Scalar y() const { return this->derived().coeffs().coeff(1); }
+    /** \returns the \c z coefficient */
+    inline Scalar z() const { return this->derived().coeffs().coeff(2); }
+
+    /** \returns a reference to the \c x coefficient */
+    inline Scalar& x() { return this->derived().coeffs().coeffRef(0); }
+    /** \returns a reference to the \c y coefficient */
+    inline Scalar& y() { return this->derived().coeffs().coeffRef(1); }
+    /** \returns a reference to the \c z coefficient */
+    inline Scalar& z() { return this->derived().coeffs().coeffRef(2); }
+
+    /** \returns a read-only vector expression of the imaginary part (x,y,z) */
+    inline const VectorBlock<const Coefficients, 3> vec() const { return coeffs().template head<3>(); }
+
+    /** \returns a vector expression of the imaginary part (x,y,z) */
+    inline VectorBlock<Coefficients, 3> vec() { return coeffs().template head<3>(); }
+
+    /** \returns a read-only vector expression of the coefficients (x,y,z) */
+    inline const typename internal::traits<Derived>::Coefficients& coeffs() const { return derived().coeffs(); }
+
+    /** \returns a vector expression of the coefficients (x,y,z) */
+    inline typename internal::traits<Derived>::Coefficients& coeffs() { return derived().coeffs(); }
+
+    EIGEN_STRONG_INLINE MRPBase<Derived>& operator=(const MRPBase<Derived>& other);  //!< method
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE Derived& operator=(const MRPBase<OtherDerived>& other);  //!< method
+
+    // disabled this copy operator as it is giving very strange compilation errors when compiling
+    // test_stdvector with GCC 4.4.2. This looks like a GCC bug though, so feel free to re-enable it if it's
+    // useful; however notice that we already have the templated operator= above and e.g. in MatrixBase
+    // we didn't have to add, in addition to templated operator=, such a non-templated copy operator.
+    //  Derived& operator=(const MRPBase& other)
+    //  { return operator=<Derived>(other); }
+
+    Derived& operator=(const AngleAxisType& aa);
+    template <class OtherDerived>
+    Derived& operator=(const MatrixBase<OtherDerived>& m);  //!< method
+
+    /** \returns a MRP representing an identity rotation
+     * \sa MatrixBase::Identity()
+     */
+    static inline MRP<Scalar> Identity() { return MRP<Scalar>(Scalar(1), Scalar(0), Scalar(0), Scalar(0)); }
+
+    /** \sa MRPBase::Identity(), MatrixBase::setIdentity()
+     */
+    inline MRPBase& setIdentity() {
+        coeffs() << Scalar(0), Scalar(0), Scalar(0);
+        return *this;
+    }
+
+    /** \returns the squared norm of the MRP's coefficients
+     * \sa MRPBase::norm(), MatrixBase::squaredNorm()
+     */
+    inline Scalar squaredNorm() const { return coeffs().squaredNorm(); }
+
+    /** \returns the norm of the MRP's coefficients
+     * \sa MRPBase::squaredNorm(), MatrixBase::norm()
+     */
+    inline Scalar norm() const { return coeffs().norm(); }
+
+    /** Normalizes the MRP \c *this
+     * \sa normalized(), MatrixBase::normalize() */
+    inline void normalize() { coeffs().normalize(); }
+    /** \returns a normalized copy of \c *this
+     * \sa normalize(), MatrixBase::normalized() */
+    inline MRP<Scalar> normalized() const { return MRP<Scalar>(coeffs().normalized()); }
+
+    /** \returns the dot product of \c *this and \a other
+     * Geometrically speaking, the dot product of two unit MRPs
+     * corresponds to the cosine of half the angle between the two rotations.
+     * \sa angularDistance()
+     */
+    template <class OtherDerived>
+    inline Scalar dot(const MRPBase<OtherDerived>& other) const {
+        return coeffs().dot(other.coeffs());
+    }
+
+    template <class OtherDerived>
+    Scalar angularDistance(const MRPBase<OtherDerived>& other) const;  //!< method
+
+    /** \returns an equivalent 3x3 rotation matrix */
+    Matrix3 toRotationMatrix() const;
+
+    /** \returns the MRP which transform \a a into \a b through a rotation */
+    template <typename Derived1, typename Derived2>
+    Derived& setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
+
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE MRP<Scalar> operator*(const MRPBase<OtherDerived>& q) const;  //!< method
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE Derived& operator*=(const MRPBase<OtherDerived>& q);
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE Derived& operator+=(const MRPBase<OtherDerived>& q);
+    template <class OtherDerived>
+    EIGEN_STRONG_INLINE Derived& operator-=(const MRPBase<OtherDerived>& q);
+
+    /** \returns the MRP describing the shadow set */
+    MRP<Scalar> shadow() const;
+
+    /** \returns 3x3 [B] matrix for the MRP differential kinematic equations */
+    Matrix3 Bmat() const;
+
+    /** \returns the MRP describing the inverse rotation */
+    MRP<Scalar> inverse() const;
+
+    /** \returns the conjugated MRP */
+    MRP<Scalar> conjugate() const;
+
+    //        template<class OtherDerived> MRP<Scalar> slerp(const Scalar& t, const MRPBase<OtherDerived>& other) const;
+
+    /** \returns \c true if \c *this is approximately equal to \a other, within the precision
+     * determined by \a prec.
+     *
+     * \sa MatrixBase::isApprox() */
+    template <class OtherDerived>
+    bool isApprox(const MRPBase<OtherDerived>& other,
+                  const RealScalar& prec = NumTraits<Scalar>::dummy_precision()) const {
+        return coeffs().isApprox(other.coeffs(), prec);
+    }
+
+    /** return the result vector of \a v through the rotation*/
+    EIGEN_STRONG_INLINE Vector3 _transformVector(const Vector3& v) const;
+
+    /** \returns \c *this with scalar type casted to \a NewScalarType
+     *
+     * Note that if \a NewScalarType is equal to the current scalar type of \c *this
+     * then this function smartly returns a const reference to \c *this.
+     */
+    template <typename NewScalarType>
+    inline typename internal::cast_return_type<Derived, MRP<NewScalarType> >::type cast() const {
+        return typename internal::cast_return_type<Derived, MRP<NewScalarType> >::type(derived());
+    }
+};
+
+/***************************************************************************
+ * Definition/implementation of MRP<Scalar>
+ ***************************************************************************/
+
+/** \geometry_module \ingroup Geometry_Module
+ *
+ * \class MRP
+ *
+ * \brief The MRP class used to represent 3D orientations and rotations
+ *
+ * \tparam _Scalar the scalar type, i.e., the type of the coefficients
+ * \tparam _Options controls the memory alignment of the coefficients. Can be \# AutoAlign or \# DontAlign. Default is
+ * AutoAlign.
+ *
+ * This class represents a MRP \f$ (x,y,z) \f$ that is a convenient representation of
+ * orientations and rotations of objects in three dimensions. Compared to other representations
+ * like Euler angles or 3x3 matrices, MRPs offer the following advantages:
+ * \li \b compact storage (3 scalars)
+ * \li \b efficient to compose (28 flops),
+ *
+ * The following two typedefs are provided for convenience:
+ * \li \c MRPf for \c float
+ * \li \c MRPd for \c double
+ *
+ * \warning Operations interpreting the MRP as rotation have undefined behavior if the MRP is not normalized.
+ *
+ * \sa  class AngleAxis, class Transform
+ */
+
+namespace internal {
+template <typename _Scalar, int _Options>
+/*! structure definition */
+struct traits<MRP<_Scalar, _Options> > {
+    typedef MRP<_Scalar, _Options> PlainObject;
+    typedef _Scalar Scalar;
+    typedef Matrix<_Scalar, 3, 1, _Options> Coefficients;
+    enum {
+        IsAligned = internal::traits<Coefficients>::Flags & PacketAccessBit,
+        Flags = IsAligned ? (PacketAccessBit | LvalueBit) : LvalueBit
+    };
+};
+}  // namespace internal
+
+template <typename _Scalar, int _Options>
+class MRP : public MRPBase<MRP<_Scalar, _Options> > {
+    typedef MRPBase<MRP<_Scalar, _Options> > Base;
+    enum { IsAligned = internal::traits<MRP>::IsAligned };
+
+   public:
+    typedef _Scalar Scalar;  //!< variable
+
+    EIGEN_INHERIT_ASSIGNMENT_OPERATORS(MRP)
+    using Base::operator*=;
+
+    typedef typename internal::traits<MRP>::Coefficients Coefficients;  //!< variable
+    typedef typename Base::AngleAxisType AngleAxisType;                 //!< variable
+
+    /** Default constructor leaving the MRP uninitialized. */
+    inline MRP() {}
+
+    /** Constructs and initializes the MRP \f$ (x,y,z) \f$ from
+     * its four coefficients \a x, \a y and \a z.
+     */
+    inline MRP(const Scalar& x, const Scalar& y, const Scalar& z) : m_coeffs(x, y, z) {}
+
+    /** Constructs and initialize a MRP from the array data */
+    inline MRP(const Scalar* data) : m_coeffs(data) {}
+
+    /** Copy constructor */
+    template <class Derived>
+    EIGEN_STRONG_INLINE MRP(const MRPBase<Derived>& other) {
+        this->Base::operator=(other);
+    }
+
+    /** Constructs and initializes a MRP from the angle-axis \a aa */
+    explicit inline MRP(const AngleAxisType& aa) { *this = aa; }
+
+    /** Constructs and initializes a MRP from either:
+     *  - a rotation matrix expression,
+     *  - a 3D vector expression representing MRP coefficients.
+     */
+    template <typename Derived>
+    explicit inline MRP(const MatrixBase<Derived>& other) {
+        *this = other;
+    }
+
+    /** Explicit copy constructor with scalar conversion */
+    //        template<typename OtherScalar, int OtherOptions>
+    //        explicit inline MRP(const MRP<OtherScalar, OtherOptions>& other)
+    //        { m_coeffs = other.coeffs().template cast<Scalar>(); }
+
+    template <typename Derived1, typename Derived2>
+    static MRP FromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
+
+    inline Coefficients& coeffs() { return m_coeffs; }              //!< method
+    inline const Coefficients& coeffs() const { return m_coeffs; }  //!< method
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF(bool(IsAligned))
+
+   protected:
+    Coefficients m_coeffs;  //!< variable
+
+#ifndef EIGEN_PARSED_BY_DOXYGEN
+    static EIGEN_STRONG_INLINE void _check_template_params()  //!< method
+    {
+        EIGEN_STATIC_ASSERT((_Options & DontAlign) == _Options, INVALID_MATRIX_TEMPLATE_PARAMETERS)
+    }
+#endif
+};
+
+/** \ingroup Geometry_Module
+ * single precision MRP type */
+typedef MRP<float> MRPf;
+/** \ingroup Geometry_Module
+ * double precision MRP type */
+typedef MRP<double> MRPd;
+
+/***************************************************************************
+ * Specialization of Map<MRP<Scalar>>
+ ***************************************************************************/
+
+namespace internal {
+template <typename _Scalar, int _Options>
+/*! struct definition */
+struct traits<Map<MRP<_Scalar>, _Options> >
+    : traits<MRP<_Scalar, (int(_Options) & Aligned) == Aligned ? AutoAlign : DontAlign> > {
+    typedef Map<Matrix<_Scalar, 3, 1>, _Options> Coefficients;
+};
+}  // namespace internal
+
+namespace internal {
+template <typename _Scalar, int _Options>
+/*! struct definition */
+struct traits<Map<const MRP<_Scalar>, _Options> >
+    : traits<MRP<_Scalar, (int(_Options) & Aligned) == Aligned ? AutoAlign : DontAlign> > {
+    typedef Map<const Matrix<_Scalar, 3, 1>, _Options> Coefficients;
+    typedef traits<MRP<_Scalar, (int(_Options) & Aligned) == Aligned ? AutoAlign : DontAlign> > TraitsBase;
+    enum { Flags = TraitsBase::Flags & ~LvalueBit };
+};
+}  // namespace internal
+
+/** \ingroup Geometry_Module
+ * \brief MRP expression mapping a constant memory buffer
+ *
+ * \tparam _Scalar the type of the MRP coefficients
+ * \tparam _Options see class Map
+ *
+ * This is a specialization of class Map for MRP. This class allows to view
+ * a 3 scalar memory buffer as an Eigen's MRP object.
+ *
+ * \sa class Map, class MRP, class MRPBase
+ */
+template <typename _Scalar, int _Options>
+class Map<const MRP<_Scalar>, _Options> : public MRPBase<Map<const MRP<_Scalar>, _Options> > {
+    typedef MRPBase<Map<const MRP<_Scalar>, _Options> > Base;
+
+   public:
+    typedef _Scalar Scalar;                                             //!< variable
+    typedef typename internal::traits<Map>::Coefficients Coefficients;  //!< variable
+    EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Map)
+    using Base::operator*=;
+
+    /** Constructs a Mapped MRP object from the pointer \a coeffs
+     *
+     * The pointer \a coeffs must reference the three coefficients of MRP in the following order:
+     * \code *coeffs == {x, y, z} \endcode
+     *
+     * If the template parameter _Options is set to #Aligned, then the pointer coeffs must be aligned. */
+    EIGEN_STRONG_INLINE Map(const Scalar* coeffs) : m_coeffs(coeffs) {}
+
+    inline const Coefficients& coeffs() const { return m_coeffs; }  //!< method
+
+   protected:
+    const Coefficients m_coeffs;  //!< variable
+};
+
+/** \ingroup Geometry_Module
+ * \brief Expression of a MRP from a memory buffer
+ *
+ * \tparam _Scalar the type of the MRP coefficients
+ * \tparam _Options see class Map
+ *
+ * This is a specialization of class Map for MRP. This class allows to view
+ * a 3 scalar memory buffer as an Eigen's  MRP object.
+ *
+ * \sa class Map, class MRP, class MRPBase
+ */
+template <typename _Scalar, int _Options>
+class Map<MRP<_Scalar>, _Options> : public MRPBase<Map<MRP<_Scalar>, _Options> > {
+    typedef MRPBase<Map<MRP<_Scalar>, _Options> > Base;
+
+   public:
+    typedef _Scalar Scalar;                                             //!< variable
+    typedef typename internal::traits<Map>::Coefficients Coefficients;  //!< variable
+    EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Map)
+    using Base::operator*=;
+
+    /** Constructs a Mapped MRP object from the pointer \a coeffs
+     *
+     * The pointer \a coeffs must reference the three coefficients of MRP in the following order:
+     * \code *coeffs == {x, y, z} \endcode
+     *
+     * If the template parameter _Options is set to #Aligned, then the pointer coeffs must be aligned. */
+    EIGEN_STRONG_INLINE Map(Scalar* coeffs) : m_coeffs(coeffs) {}
+
+    inline Coefficients& coeffs() { return m_coeffs; }              //!< method
+    inline const Coefficients& coeffs() const { return m_coeffs; }  //!< method
+
+   protected:
+    Coefficients m_coeffs;  //!< variable
+};
+
+/** \ingroup Geometry_Module
+ * Map an unaligned array of single precision scalars as a MRP */
+typedef Map<MRP<float>, 0> MRPMapf;
+/** \ingroup Geometry_Module
+ * Map an unaligned array of double precision scalars as a MRP */
+typedef Map<MRP<double>, 0> MRPMapd;
+/** \ingroup Geometry_Module
+ * Map a 16-byte aligned array of single precision scalars as a MRP */
+typedef Map<MRP<float>, Aligned> MRPMapAlignedf;
+/** \ingroup Geometry_Module
+ * Map a 16-byte aligned array of double precision scalars as a MRP */
+typedef Map<MRP<double>, Aligned> MRPMapAlignedd;
+
+/***************************************************************************
+ * Implementation of MRPBase methods
+ ***************************************************************************/
+
+// Generic MRP * MRP product
+// This product can be specialized for a given architecture via the Arch template argument.
+namespace internal {
+/*! template definition */
+template <int Arch, class Derived1, class Derived2, typename Scalar, int _Options>
+struct mrp_product {
+    static EIGEN_STRONG_INLINE MRP<Scalar> run(const MRPBase<Derived1>& a, const MRPBase<Derived2>& b) {
+        Scalar det;   //!< variable
+        Scalar s1N2;  //!< variable
+        Scalar s2N2;  //!< variable
+        MRP<Scalar> s2 = b;
+        MRP<Scalar> answer;
+        s1N2 = a.squaredNorm();
+        s2N2 = s2.squaredNorm();
+        det = Scalar(1.0) + s1N2 * s2N2 - 2 * a.dot(b);
+        if (det < 0.01) {
+            s2 = s2.shadow();
+            s2N2 = s2.squaredNorm();
+            det = Scalar(1.0) + s1N2 * s2N2 - 2 * a.dot(b);
+        }
+        answer = MRP<Scalar>(((1 - s1N2) * s2.vec() + (1 - s2N2) * a.vec() - 2 * b.vec().cross(a.vec())) / det);
+        if (answer.squaredNorm() > 1) answer = answer.shadow();
+        return answer;
+    }
+};
+}  // namespace internal
+
+/** \returns the concatenation of two rotations as a MRP-MRP product */
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::operator*(
+    const MRPBase<OtherDerived>& other) const {
+    EIGEN_STATIC_ASSERT(
+        (internal::is_same<typename Derived::Scalar, typename OtherDerived::Scalar>::value),
+        YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_TYPES_EXPLICITLY)
+    return internal::mrp_product < Architecture::Target, Derived, OtherDerived,
+           typename internal::traits<Derived>::Scalar,
+           internal::traits<Derived>::IsAligned && internal::traits<OtherDerived>::IsAligned > ::run(*this, other);
+}
+
+/** \sa operator*(MRP) */
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator*=(const MRPBase<OtherDerived>& other) {
+    derived() = derived() * other.derived();
+    return derived();
+}
+
+/** \sa operator*(MRP) */
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator+=(const MRPBase<OtherDerived>& other) {
+    derived().coeffs() = derived().coeffs() + other.derived().coeffs();
+    return derived();
+}
+/** \sa operator*(MRP) */
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator-=(const MRPBase<OtherDerived>& other) {
+    derived().coeffs() = derived().coeffs() - other.derived().coeffs();
+    return derived();
+}
+
+/** Rotation of a vector by a MRP.
+ * \remarks If the MRP is used to rotate several points (>1)
+ * then it is much more efficient to first convert it to a 3x3 Matrix.
+ * Comparison of the operation cost for n transformations:
+ *   - MRP2:    30n
+ *   - Via a Matrix3: 24 + 15n
+ */
+template <class Derived>
+EIGEN_STRONG_INLINE typename MRPBase<Derived>::Vector3 MRPBase<Derived>::_transformVector(const Vector3& v) const {
+    // Note that this algorithm comes from the optimization by hand
+    // of the conversion to a Matrix followed by a Matrix/Vector product.
+    // It appears to be much faster than the common algorithm found
+    // in the literature (30 versus 39 flops). It also requires two
+    // Vector3 as temporaries.
+    Vector3 uv = this->vec().cross(v);
+    uv += uv;
+    return v + this->w() * uv + this->vec().cross(uv);
+}
+
+template <class Derived>
+EIGEN_STRONG_INLINE MRPBase<Derived>& MRPBase<Derived>::operator=(const MRPBase<Derived>& other) {
+    coeffs() = other.coeffs();
+    return derived();
+}
+
+template <class Derived>
+template <class OtherDerived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator=(const MRPBase<OtherDerived>& other) {
+    coeffs() = other.coeffs();
+    return derived();
+}
+
+/** Set \c *this from an angle-axis \a aa and returns a reference to \c *this
+ */
+template <class Derived>
+EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator=(const AngleAxisType& aa) {
+    using std::tan;
+    Scalar tanPhi = Scalar(0.25) * aa.angle();  // Scalar(0.25) to suppress precision loss warnings
+    this->vec() = tanPhi * aa.axis();
+    return derived();
+}
+
+/** Set \c *this from the expression \a xpr:
+ *   - if \a xpr is a 3x1 vector, then \a xpr is assumed to be a MRP
+ *   - if \a xpr is a 3x3 matrix, then \a xpr is assumed to be rotation matrix
+ *     and \a xpr is converted to a MRP
+ */
+
+template <class Derived>
+template <class MatrixDerived>
+inline Derived& MRPBase<Derived>::operator=(const MatrixBase<MatrixDerived>& xpr) {
+    EIGEN_STATIC_ASSERT(
+        (internal::is_same<typename Derived::Scalar, typename MatrixDerived::Scalar>::value),
+        YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_TYPES_EXPLICITLY)
+    internal::MRPbase_assign_impl<MatrixDerived>::run(*this, xpr.derived());
+    return derived();
+}
+
+/** Convert the MRP sigma_B/N to a 3x3 rotation matrix [NB].
+ */
+template <class Derived>
+inline typename MRPBase<Derived>::Matrix3 MRPBase<Derived>::toRotationMatrix(void) const {
+    // NOTE if inlined, then gcc 4.2 and 4.4 get rid of the temporary (not gcc 4.3 !!)
+    // if not inlined then the cost of the return by value is huge ~ +35%,
+    // however, not inlining this function is an order of magnitude slower, so
+    // it has to be inlined, and so the return by value is not an issue
+    Matrix3 res;
+
+    const Scalar ps2 = Scalar(1) + this->coeffs().squaredNorm();
+    const Scalar ms2 = Scalar(1) - this->coeffs().squaredNorm();
+    const Scalar ms2Sq = ms2 * ms2;
+    const Scalar s1s2 = Scalar(8) * this->x() * this->y();
+    const Scalar s1s3 = Scalar(8) * this->x() * this->z();
+    const Scalar s2s3 = Scalar(8) * this->y() * this->z();
+    const Scalar s1Sq = this->x() * this->x();
+    const Scalar s2Sq = this->y() * this->y();
+    const Scalar s3Sq = this->z() * this->z();
+
+    res.coeffRef(0, 0) = Scalar(4) * (+s1Sq - s2Sq - s3Sq) + ms2Sq;
+    res.coeffRef(0, 1) = s1s2 - Scalar(4) * this->z() * ms2;
+    res.coeffRef(0, 2) = s1s3 + Scalar(4) * this->y() * ms2;
+    res.coeffRef(1, 0) = s1s2 + Scalar(4) * this->z() * ms2;
+    res.coeffRef(1, 1) = Scalar(4) * (-s1Sq + s2Sq - s3Sq) + ms2Sq;
+    res.coeffRef(1, 2) = s2s3 - Scalar(4) * this->x() * ms2;
+    res.coeffRef(2, 0) = s1s3 - Scalar(4) * this->y() * ms2;
+    res.coeffRef(2, 1) = s2s3 + Scalar(4) * this->x() * ms2;
+    res.coeffRef(2, 2) = Scalar(4) * (-s1Sq - s2Sq + s3Sq) + ms2Sq;
+    res = res / ps2 / ps2;
+
+    return res;
+}
+
+/** Sets \c *this to be a MRP representing a rotation between
+ * the two arbitrary vectors \a a and \a b. In other words, the built
+ * rotation represent a rotation sending the line of direction \a a
+ * to the line of direction \a b, both lines passing through the origin.
+ *
+ * \returns a reference to \c *this.
+ *
+ * Note that the two input vectors do \b not have to be normalized, and
+ * do not need to have the same norm.
+ */
+template <class Derived>
+template <typename Derived1, typename Derived2>
+inline Derived& MRPBase<Derived>::setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b) {
+    using std::acos;
+    using std::tan;
+
+    Vector3 v0 = a.normalized();
+    Vector3 v1 = b.normalized();
+    Scalar c = v1.dot(v0);
+
+    if (c <= 1 && c >= -1) {
+        Vector3 axis = v0.cross(v1);
+        axis.normalize();
+
+        this->vec() = axis * tan(acos(c) / Scalar(4.0));
+    } else {
+        this->vec() << 0., 0., 0.;
+    }
+    return derived();
+}
+
+/** Returns a MRP representing a rotation between
+ * the two arbitrary vectors \a a and \a b. In other words, the built
+ * rotation represent a rotation sending the line of direction \a a
+ * to the line of direction \a b, both lines passing through the origin.
+ *
+ * \returns resulting MRP
+ *
+ * Note that the two input vectors do \b not have to be normalized, and
+ * do not need to have the same norm.
+ */
+template <typename Scalar, int Options>
+template <typename Derived1, typename Derived2>
+MRP<Scalar, Options> MRP<Scalar, Options>::FromTwoVectors(const MatrixBase<Derived1>& a,
+                                                          const MatrixBase<Derived2>& b) {
+    MRP sig;
+    sig.setFromTwoVectors(a, b);
+    return sig;
+}
+
+/** \returns the MRP Shadow set of \c *this
+ *
+ * \sa MRPBase::shadow()
+ */
+template <class Derived>
+inline MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::shadow() const {
+    Scalar n2 = this->squaredNorm();
+    if (n2 > Scalar(0))
+        return MRP<Scalar>(-this->coeffs() / n2);
+    else {
+        return MRP<Scalar>(0., 0., 0.);
+    }
+}
+
+/** \returns the MRP [B] matrix of \c *this
+ * This is used in
+ *
+ *  d(sigmda_B/N) = 1/4 [B(sigma_B/N)] omega_BN_B
+ *
+ * \sa MRPBase::shadow()
+ */
+template <class Derived>
+inline typename MRPBase<Derived>::Matrix3 MRPBase<Derived>::Bmat() const {
+    Matrix3 B;
+    Scalar ms2, s1s2, s1s3, s2s3;
+
+    ms2 = Scalar(1) - this->coeffs().squaredNorm();
+    s1s2 = this->x() * this->y();
+    s1s3 = this->x() * this->z();
+    s2s3 = this->y() * this->z();
+
+    B.coeffRef(0, 0) = ms2 + Scalar(2) * this->x() * this->x();
+    B.coeffRef(0, 1) = Scalar(2) * (s1s2 - this->z());
+    B.coeffRef(0, 2) = Scalar(2) * (s1s3 + this->y());
+    B.coeffRef(1, 0) = Scalar(2) * (s1s2 + this->z());
+    B.coeffRef(1, 1) = ms2 + Scalar(2) * this->y() * this->y();
+    B.coeffRef(1, 2) = Scalar(2) * (s2s3 - this->x());
+    B.coeffRef(2, 0) = Scalar(2) * (s1s3 - this->y());
+    B.coeffRef(2, 1) = Scalar(2) * (s2s3 + this->x());
+    B.coeffRef(2, 2) = ms2 + Scalar(2) * this->z() * this->z();
+
+    return B;
+}
+
+/** \returns the multiplicative inverse of \c *this
+ * Note that in most cases, i.e., if you simply want the opposite rotation,
+ * and/or the MRP is normalized, then it is enough to use the conjugate.
+ *
+ * \sa MRPBase::conjugate()
+ */
+template <class Derived>
+inline MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::inverse() const {
+    return MRP<Scalar>(-this->coeffs());
+}
+
+/** \returns the conjugate of the \c *this which is equal to the multiplicative inverse
+ * if the MRP is normalized.
+ * The conjugate of a MRP represents the opposite rotation.
+ *
+ * \sa MRP2::inverse()
+ */
+template <class Derived>
+inline MRP<typename internal::traits<Derived>::Scalar> MRPBase<Derived>::conjugate() const {
+    return MRP<Scalar>(-this->coeffs());
+}
+
+/** \returns the angle (in radian) between two rotations
+ * \sa dot()
+ */
+template <class Derived>
+template <class OtherDerived>
+inline typename internal::traits<Derived>::Scalar MRPBase<Derived>::angularDistance(
+    const MRPBase<OtherDerived>& other) const {
+    using std::abs;
+    using std::atan;
+    MRP<Scalar> d = (*this) * other.conjugate();
+    return Scalar(4) * atan(d.norm());
+}
+
+//    /** \returns the spherical linear interpolation between the two MRPs
+//     * \c *this and \a other at the parameter \a t in [0;1].
+//     *
+//     * This represents an interpolation for a constant motion between \c *this and \a other,
+//     * see also http://en.wikipedia.org/wiki/Slerp.
+//     */
+//    template <class Derived>
+//    template <class OtherDerived>
+//    MRP<typename internal::traits<Derived>::Scalar>
+//    MRPBase<Derived>::slerp(const Scalar& t, const MRPBase<OtherDerived>& other) const
+//    {
+//        using std::acos;
+//        using std::sin;
+//        using std::abs;
+//        static const Scalar one = Scalar(1) - NumTraits<Scalar>::epsilon();
+//        Scalar d = this->dot(other);
+//        Scalar absD = abs(d);
+//
+//        Scalar scale0;
+//        Scalar scale1;
+//
+//        if(absD>=one)
+//        {
+//            scale0 = Scalar(1) - t;
+//            scale1 = t;
+//        }
+//        else
+//        {
+//            // theta is the angle between the 2 MRPs
+//            Scalar theta = acos(absD);
+//            Scalar sinTheta = sin(theta);
+//
+//            scale0 = sin( ( Scalar(1) - t ) * theta) / sinTheta;
+//            scale1 = sin( ( t * theta) ) / sinTheta;
+//        }
+//        if(d<Scalar(0)) scale1 = -scale1;
+//
+//        return MRP<Scalar>(scale0 * coeffs() + scale1 * other.coeffs());
+//    }
+
+namespace internal {
+
+// set from a rotation matrix
+// this maps the [NB] DCM to the equivalent sigma_B/N set
+template <typename Other>
+/*! struct definition */
+struct MRPbase_assign_impl<Other, 3, 3> {
+    typedef typename Other::Scalar Scalar;  //!< variable
+    typedef DenseIndex Index;               //!< variable
+    template <class Derived>
+    static inline void run(MRPBase<Derived>& sig, const Other& mat) {
+        Quaternion<Scalar> q;
+        Scalar num;
+
+        /* convert DCM to quaternions */
+        q = mat;
+        num = Scalar(1) + q.w();
+
+        /* convert quaternions to MRP */
+        sig.x() = q.x() / num;
+        sig.y() = q.y() / num;
+        sig.z() = q.z() / num;
+    }
+};
+
+// set from a vector of coefficients assumed to be a MRP
+template <typename Other>
+/*! struct definition */
+struct MRPbase_assign_impl<Other, 3, 1> {
+    typedef typename Other::Scalar Scalar;  //!< variable
+    template <class Derived>
+    static inline void run(MRPBase<Derived>& q, const Other& vec) {
+        q.coeffs() = vec;
+    }
+};
+
+}  // end namespace internal
+
+}  // end namespace Eigen
+
+#endif  // EIGEN_MRP_H
+
+/// \endcond

--- a/architecture/utilities/eigenSupport.h
+++ b/architecture/utilities/eigenSupport.h
@@ -1,0 +1,421 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef EIGENSUPPORT
+#define EIGENSUPPORT
+
+#include "eigenMRP.h"
+
+#include <Eigen/Core>
+#include <cstring>
+#include <exception>
+
+template <class Derived>
+constexpr bool is_row_major_v = (Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0;
+
+template <class Derived>
+inline constexpr bool is_fixed_v =
+    (Derived::RowsAtCompileTime != Eigen::Dynamic) && (Derived::ColsAtCompileTime != Eigen::Dynamic);
+
+/**
+ * @brief Copy a fixed-size Eigen matrix into a row-major C array.
+ *
+ * Works for compile-time sized matrices or expressions. Values are flattened
+ * in row-major order. Column-major inputs are internally transposed to produce
+ * the desired layout.
+ *
+ * @tparam Derived Fixed-size Eigen expression type.
+ * @tparam Size Extent of the destination array (rows × cols).
+ * @param inMat Matrix to copy from.
+ * @param out Destination array that receives the flattened entries.
+ */
+template <class Derived, std::size_t Size>
+void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Size]) {
+    static_assert(Derived::RowsAtCompileTime != Eigen::Dynamic && Derived::ColsAtCompileTime != Eigen::Dynamic,
+                  "Input must be a fixed-size Eigen type.");
+
+    using Scalar = typename Derived::Scalar;
+    constexpr int Rows = Derived::RowsAtCompileTime;
+    constexpr int Cols = Derived::ColsAtCompileTime;
+
+    static_assert(static_cast<std::size_t>(Rows) * static_cast<std::size_t>(Cols) == Size,
+                  "Output array size must equal rows*cols of input.");
+
+    if constexpr ((Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0) {
+        Eigen::Matrix<Scalar, Rows, Cols, Eigen::RowMajor> tmp = inMat;
+        std::memcpy(out, tmp.data(), Size * sizeof(Scalar));
+    } else {
+        Eigen::Matrix<Scalar, Cols, Rows> tmpT = inMat.transpose();
+        std::memcpy(out, tmpT.data(), Size * sizeof(Scalar));
+    }
+}
+
+/**
+ * @brief Copy a dynamic-size Eigen matrix into a row-major C array.
+ *
+ * Only the first `inMat.size()` elements of `out` are written, allowing the
+ * destination buffer to be larger than the matrix. If the buffer is too small,
+ * the function terminates the program.
+ *
+ * @tparam Derived Eigen dynamic expression type.
+ * @tparam Size Compile-time extent of the destination buffer.
+ * @param inMat Matrix to copy from.
+ * @param out Destination array that must hold at least `inMat.size()` values.
+ */
+template <class Derived, std::size_t Size>
+void eigenMatrixXToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Size]) {
+    using Scalar = typename Derived::Scalar;
+
+    // Runtime capacity check against compile-time size
+    if (static_cast<std::size_t>(inMat.size()) > Size) {
+        std::terminate();
+    }
+
+    // Make a contiguous row-major buffer regardless of input layout
+    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
+    const auto count = static_cast<std::size_t>(inMat.size());
+    std::memcpy(out, rm.data(), count * sizeof(Scalar));
+}
+
+/**
+ * @brief Copy a fixed-size Eigen matrix into a 2-D C array.
+ *
+ * Performs compile-time shape checks and ensures the row-major layout is
+ * preserved. Column-major inputs incur a transpose so that the C array receives
+ * data in row-major order.
+ *
+ * @tparam Derived Fixed-size Eigen expression type.
+ * @tparam N Number of rows in the destination array.
+ * @tparam M Number of columns in the destination array.
+ * @param inMat Matrix to copy from.
+ * @param out Destination 2-D array `out[N][M]`.
+ */
+template <class Derived, std::size_t N, std::size_t M>
+void eigenMatrixToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[N][M]) {
+    static_assert(Derived::RowsAtCompileTime != Eigen::Dynamic && Derived::ColsAtCompileTime != Eigen::Dynamic,
+                  "Input must be a fixed-size Eigen type.");
+
+    using Scalar = typename Derived::Scalar;
+    constexpr int R = Derived::RowsAtCompileTime;
+    constexpr int C = Derived::ColsAtCompileTime;
+
+    static_assert(static_cast<std::size_t>(R) == N && static_cast<std::size_t>(C) == M,
+                  "2D output shape must match input rows x cols.");
+
+    if constexpr ((Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0) {
+        Eigen::Matrix<Scalar, R, C, Eigen::RowMajor> tmp = inMat;
+        std::memcpy(out, tmp.data(), N * M * sizeof(Scalar));
+    } else {
+        Eigen::Matrix<Scalar, C, R> tmpT = inMat.transpose();
+        std::memcpy(out, tmpT.data(), N * M * sizeof(Scalar));
+    }
+}
+
+/**
+ * @brief Copy a dynamic Eigen matrix into a 2-D C array with runtime checks.
+ *
+ * Validates that the requested 2-D output dimensions match `inMat.rows()` and
+ * `inMat.cols()`. If they do not, the function terminates. Data are laid out in
+ * row-major order in the destination buffer.
+ *
+ * @tparam Derived Eigen dynamic expression type.
+ * @tparam Rows Expected number of rows in the destination array.
+ * @tparam Cols Expected number of columns in the destination array.
+ * @param inMat Matrix to copy from.
+ * @param out Destination 2-D array `out[Rows][Cols]`.
+ */
+template <class Derived, std::size_t Rows, std::size_t Cols>
+void eigenMatrixXToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Rows][Cols]) {
+    using Scalar = typename Derived::Scalar;
+
+    // Enforce shape at runtime (safer for 2-D indexing)
+    if (inMat.rows() != static_cast<int>(Rows) || inMat.cols() != static_cast<int>(Cols)) {
+        std::terminate();
+    }
+
+    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
+    std::memcpy(&out[0][0], rm.data(), Rows * Cols * sizeof(Scalar));
+}
+
+/**
+ * @brief Insert a flattened Eigen matrix into a strided C array slice.
+ *
+ * The matrix is flattened in row-major order and written starting at `offset`.
+ * Elements are spaced by `stride`. If `stride` is zero and more than one value
+ * would be written, the function terminates. Capacity violations also
+ * terminate execution.
+ *
+ * @tparam Derived Eigen expression type.
+ * @tparam Size Compile-time extent of the destination array.
+ * @param inMat Matrix supplying the values.
+ * @param out Destination array that receives the data.
+ * @param offset Starting index in `out` for the first element.
+ * @param stride Number of indices to skip between elements (default 1).
+ */
+template <class Derived, std::size_t Size>
+void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
+                              typename Derived::Scalar (&out)[Size],
+                              std::size_t offset,
+                              const std::size_t stride = 1) {
+    using Scalar = typename Derived::Scalar;
+
+    const auto count = static_cast<std::size_t>(inMat.size());
+    if (count == 0) return;
+
+    if (stride == 0 && count > 1) {
+        std::terminate();
+    }
+
+    // Capacity check: last index must be < N
+    const std::size_t last_index = offset + (count - 1) * stride;
+    if (last_index >= Size) {
+        std::terminate();
+    }
+
+    // Make a contiguous row-major buffer regardless of input layout
+    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
+
+    if (stride == 1) {
+        std::memcpy(out + offset, rm.data(), count * sizeof(Scalar));
+    } else {
+        const Scalar* src = rm.data();
+        std::size_t idx = offset;
+        for (std::size_t i = 0; i < count; ++i) {
+            out[idx] = src[i];
+            idx += stride;
+        }
+    }
+}
+
+/**
+ * @brief Copy a fixed-size Eigen vector into a contiguous C array.
+ *
+ * @tparam ScalarT Scalar type stored in the vector.
+ * @tparam size Compile-time number of elements.
+ * @param inVec Vector whose contents should be copied.
+ * @param outArray Pointer to a C array with at least `size` elements.
+ */
+template <typename ScalarT, int size>
+void eigenVectorToCArray(const Eigen::Vector<ScalarT, size>& inVec, ScalarT* outArray) {
+    memcpy(outArray, inVec.data(), size * sizeof(ScalarT));
+}
+
+/**
+ * @brief Map a row-major C array onto a fixed-size Eigen matrix.
+ *
+ * @tparam ScalarT Scalar type of the matrix.
+ * @tparam rows Number of rows in the output matrix.
+ * @tparam cols Number of columns in the output matrix.
+ * @param inArray Pointer to `rows * cols` elements in row-major order.
+ * @return Eigen matrix populated with the values from `inArray`.
+ */
+template <typename ScalarT, int rows, int cols>
+Eigen::Matrix<ScalarT, rows, cols> cArrayAsEigenMatrix(ScalarT* inArray) {
+    Eigen::Matrix<ScalarT, rows, cols> outMat;
+    outMat = Eigen::Map<Eigen::Matrix<ScalarT, rows, cols>>(inArray, outMat.rows(), outMat.cols());
+    return outMat;
+}
+
+/**
+ * @brief Map a row-major C array onto a dynamic Eigen matrix.
+ *
+ * @tparam ScalarT Scalar type of the matrix.
+ * @param inArray Pointer to `nRows * nCols` elements in row-major order.
+ * @param nRows Desired number of rows of the output matrix.
+ * @param nCols Desired number of columns of the output matrix.
+ * @return Eigen dynamic matrix containing the mapped values.
+ */
+template <typename ScalarT>
+Eigen::MatrixX<ScalarT> cArrayAsEigenMatrixX(ScalarT* inArray, int nRows, int nCols) {
+    Eigen::MatrixX<ScalarT> outMat;
+    outMat.resize(nRows, nCols);
+    outMat = Eigen::Map<Eigen::MatrixX<ScalarT>>(inArray, outMat.rows(), outMat.cols());
+    return outMat;
+}
+
+/**
+ * @brief Map a C array onto a fixed-size Eigen vector.
+ *
+ * @tparam ScalarT Scalar type of the vector.
+ * @tparam size Compile-time number of elements.
+ * @param inArray Reference to the C array holding the coefficients.
+ * @return Eigen vector whose contents match the input array.
+ */
+template <typename ScalarT, std::size_t size>
+Eigen::Vector<ScalarT, size> cArrayAsEigenVector(ScalarT (&inArray)[size]) {
+    return Eigen::Map<Eigen::Vector<ScalarT, size>>(inArray);
+}
+
+/**
+ * @brief Convert a three-element C array into an Eigen 3-vector.
+ *
+ * @tparam ScalarT Scalar type of the vector.
+ * @param inArray Pointer to three consecutive elements.
+ * @return Eigen::Vector3 populated from the input data.
+ */
+template <typename ScalarT>
+Eigen::Vector3<ScalarT> cArrayAsEigenVector3(ScalarT* inArray) {
+    return Eigen::Map<Eigen::Vector3<ScalarT>>(inArray);
+}
+
+/**
+ * @brief Convert a three-element C array into an Eigen modified Rodrigues parameter.
+ *
+ * @tparam ScalarT Scalar type of the MRP coefficients.
+ * @param inArray Pointer to three elements representing the MRP components.
+ * @return Eigen::MRP constructed from the input.
+ */
+template <typename ScalarT>
+Eigen::MRP<ScalarT> cArrayAsEigenMrp(ScalarT* inArray) {
+    Eigen::MRP<ScalarT> sigma_Eigen;
+    sigma_Eigen = Eigen::Map<Eigen::Vector<ScalarT, 3>>(inArray);
+
+    return sigma_Eigen;
+}
+
+/**
+ * @brief Convert a row-major C array into an Eigen 3×3 matrix.
+ *
+ * @tparam ScalarT Scalar type of the matrix.
+ * @param inArray Pointer to nine elements stored in row-major order.
+ * @return Eigen::Matrix3 with the copied values.
+ */
+template <typename ScalarT>
+Eigen::Matrix3<ScalarT> cArrayAsEigenMatrix3(ScalarT* inArray) {
+    return Eigen::Map<Eigen::Matrix3<ScalarT>>(inArray, 3, 3).transpose();
+}
+
+/**
+ * @brief Copy a 3×3 C two-dimensional array into an Eigen 3×3 matrix.
+ *
+ * @tparam ScalarT Scalar type of the matrix.
+ * @param in2DArray Source array with bounds `[3][3]`.
+ * @return Eigen::Matrix3 containing the same entries.
+ */
+template <typename ScalarT>
+Eigen::Matrix3<ScalarT> c2DArrayAsEigenMatrix3(ScalarT in2DArray[3][3]) {
+    Eigen::Matrix3<ScalarT> outMat;
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            outMat(i, j) = in2DArray[i][j];
+        }
+    }
+
+    return outMat;
+}
+
+/**
+ * @brief Convert an Eigen MRP to a three-component vector.
+ *
+ * @tparam ScalarT Scalar type of the MRP.
+ * @param mrp Modified Rodrigues parameter to convert.
+ * @return Eigen::Vector3 containing the MRP coefficients.
+ */
+template <typename ScalarT>
+Eigen::Vector3<ScalarT> eigenMrpToVector3(const Eigen::MRP<ScalarT> mrp) {
+    Eigen::Vector3<ScalarT> vec3;
+
+    vec3[0] = mrp.x();
+    vec3[1] = mrp.y();
+    vec3[2] = mrp.z();
+
+    return vec3;
+}
+
+/**
+ * @brief Create the DCM for a positive rotation about the body X-axis.
+ *
+ * @tparam ScalarT Scalar type representing the angle.
+ * @param angle Rotation angle in radians.
+ * @return Eigen::Matrix3 representing the rotation.
+ */
+template <typename ScalarT>
+Eigen::Matrix3<ScalarT> eigenM1(const ScalarT angle) {
+    Eigen::Matrix3<ScalarT> mOut = Eigen::Matrix3<ScalarT>::Identity();
+
+    mOut(1, 1) = std::cos(angle);
+    mOut(1, 2) = std::sin(angle);
+    mOut(2, 1) = -std::sin(angle);
+    mOut(2, 2) = std::cos(angle);
+
+    return mOut;
+}
+
+/**
+ * @brief Create the DCM for a positive rotation about the body Y-axis.
+ *
+ * @tparam ScalarT Scalar type representing the angle.
+ * @param angle Rotation angle in radians.
+ * @return Eigen::Matrix3 representing the rotation.
+ */
+template <typename ScalarT>
+Eigen::Matrix3<ScalarT> eigenM2(const ScalarT angle) {
+    Eigen::Matrix3<ScalarT> mOut = Eigen::Matrix3<ScalarT>::Identity();
+
+    mOut(0, 0) = std::cos(angle);
+    mOut(0, 2) = -std::sin(angle);
+    mOut(2, 0) = std::sin(angle);
+    mOut(2, 2) = std::cos(angle);
+
+    return mOut;
+}
+
+/**
+ * @brief Create the DCM for a positive rotation about the body Z-axis.
+ *
+ * @tparam ScalarT Scalar type representing the angle.
+ * @param angle Rotation angle in radians.
+ * @return Eigen::Matrix3 representing the rotation.
+ */
+template <typename ScalarT>
+Eigen::Matrix3<ScalarT> eigenM3(const ScalarT angle) {
+    Eigen::Matrix3<ScalarT> mOut = Eigen::Matrix3<ScalarT>::Identity();
+
+    mOut(0, 0) = std::cos(angle);
+    mOut(0, 1) = std::sin(angle);
+    mOut(1, 0) = -std::sin(angle);
+    mOut(1, 1) = std::cos(angle);
+
+    return mOut;
+}
+
+/**
+ * @brief Construct the skew-symmetric matrix such that `[tilde(vec)] * b = vec × b`.
+ *
+ * @tparam Derived Eigen vector expression type.
+ * @param vec Vector whose associated tilde matrix is requested.
+ * @return Eigen::Matrix3 representing the skew-symmetric cross-product matrix.
+ */
+template <typename Derived>
+Eigen::Matrix3<typename Eigen::MatrixBase<Derived>::Scalar> eigenTilde(const Eigen::MatrixBase<Derived>& vec) {
+    using Scalar = typename Eigen::MatrixBase<Derived>::Scalar;
+
+    Eigen::Matrix3<Scalar> mOut = Eigen::Matrix3<Scalar>::Zero();
+
+    mOut(0, 1) = -vec(2);
+    mOut(1, 0) = vec(2);
+    mOut(0, 2) = vec(1);
+    mOut(2, 0) = -vec(1);
+    mOut(1, 2) = -vec(0);
+    mOut(2, 1) = vec(0);
+
+    return mOut;
+}
+
+#endif  // EIGENSUPPORT


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR adds a custom invalid parameter exception macro based on `<exception>`. Freestanding C++ environments do not provide `<stdexcept>` and so we need to create a custom exception class that inherits from `<exception>`. When exceptions are enabled during compilation the macro uses of the custom exception. When exceptions are disabled the macro inserts an abort.

## Verification
The exception is tested manually. 

## Documentation
None needed, none invalidated.

## Future work
None
