### PR TITLE
Add utilities lib to build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,13 +80,17 @@ if(NOT CMAKE_CROSSCOMPILING)
 endif()
 
 # 4) Eigen include (always /home/user/eigen) and project headers
-if (DEFINED CACHE{EIGEN3_DIR})
-  set(EIGEN3_DIR $ENV{EIGEN3_DIR})
-else()
-  set(EIGEN3_DIR "/home/user/eigen")
-  if(NOT EXISTS "${EIGEN3_DIR}/Eigen")
-    message(FATAL_ERROR "Eigen not found under ${EIGEN3_DIR}")
-  endif()
+# Let user override via -DEIGEN3_DIR=... or environment
+set(EIGEN3_DIR "$ENV{EIGEN3_DIR}" CACHE PATH "Path to Eigen root (directory containing 'Eigen/')")
+# Fallback default if not provided
+if(NOT EIGEN3_DIR)
+  set(EIGEN3_DIR "/home/user/eigen" CACHE PATH "Path to Eigen root" FORCE)
+endif()
+# Normalize to absolute so generators don’t see it as relative
+get_filename_component(EIGEN3_DIR "${EIGEN3_DIR}" ABSOLUTE)
+# Sanity check
+if(NOT IS_DIRECTORY "${EIGEN3_DIR}/Eigen")
+  message(FATAL_ERROR "Eigen not found under ${EIGEN3_DIR}")
 endif()
 
 #set(algorithms "attTrackingError" "rateDamp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ if(NOT IS_DIRECTORY "${EIGEN3_DIR}/Eigen")
   message(FATAL_ERROR "Eigen not found under ${EIGEN3_DIR}")
 endif()
 
-#set(algorithms "attTrackingError" "rateDamp")
 set(algorithms "attTrackingError")
 foreach(algorithm_name IN LISTS algorithms)
   add_algorithm(${algorithm_name})
@@ -111,6 +110,9 @@ add_library(gncAlgorithms STATIC ${combined_objects})
 set_target_properties(gncAlgorithms PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
 )
+
+add_subdirectory("architecture/utilities")
+target_link_libraries(gncAlgorithms PUBLIC utilities)
 
 # 8) Generate Ada bindings (always, for both Linux and RISC-V)
 set(BINDINGS_DIR "${PROJECT_BINARY_DIR}/bindings")

--- a/architecture/utilities/CMakeLists.txt
+++ b/architecture/utilities/CMakeLists.txt
@@ -1,0 +1,20 @@
+file(GLOB source_files
+     "${CMAKE_CURRENT_SOURCE_DIR}/avsEigenSupport.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/rigidBodyKinematics.hpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/messageConversationHelpers.cpp")
+
+add_library(utilities OBJECT ${source_files})
+
+target_include_directories(utilities PRIVATE
+                           "${PROJECT_SOURCE_DIR}"
+                           "${EIGEN3_DIR}"
+)
+
+# Included via -include to ensure it's included before any other translation unit
+target_compile_options(utilities PRIVATE
+    -include "${EIGEN3_DIR}/Eigen/src/Freestanding/all_freestanding.hpp"
+)
+
+set_target_properties(utilities PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+
+target_compile_definitions(utilities PRIVATE EIGEN_FREESTANDING=1)

--- a/architecture/utilities/avsEigenSupport.cpp
+++ b/architecture/utilities/avsEigenSupport.cpp
@@ -29,7 +29,7 @@ in a lot of cases.
 @param inMat The source Eigen matrix that we are converting
 @param outArray The destination array (sized by the user!) we copy into
 */
-void eigenMatrixXd2CArray(Eigen::MatrixXd inMat, double *outArray) {
+void eigenMatrixXd2CArray(Eigen::MatrixXd inMat, double* outArray) {
     Eigen::MatrixXd tempMat = inMat.transpose();
     memcpy(outArray, tempMat.data(), inMat.rows() * inMat.cols() * sizeof(double));
 }
@@ -42,7 +42,7 @@ in a lot of cases.
 @param inMat The source Eigen matrix that we are converting
 @param outArray The destination array (sized by the user!) we copy into
 */
-void eigenMatrixXi2CArray(Eigen::MatrixXi inMat, int *outArray) {
+void eigenMatrixXi2CArray(Eigen::MatrixXi inMat, int* outArray) {
     Eigen::MatrixXi tempMat = inMat.transpose();
     memcpy(outArray, tempMat.data(), inMat.rows() * inMat.cols() * sizeof(int));
 }
@@ -54,7 +54,7 @@ and the transpose that would have been performed by the general case.
 @param inMat The source Eigen matrix that we are converting
 @param outArray The destination array we copy into
 */
-void eigenVector3d2CArray(Eigen::Vector3d &inMat, double *outArray) {
+void eigenVector3d2CArray(Eigen::Vector3d& inMat, double* outArray) {
     memcpy(outArray, inMat.data(), 3 * sizeof(double));
 }
 
@@ -66,7 +66,7 @@ and the transpose that would have been performed by the general case.
 @param outArray The destination array we copy into
 */
 
-void eigenVector3f2CArray(Eigen::Vector3f &inMat, float *outArray) {
+void eigenVector3f2CArray(Eigen::Vector3f& inMat, float* outArray) {
     memcpy(outArray, inMat.data(), 3 * sizeof(float));
 }
 
@@ -77,7 +77,7 @@ and the transpose that would have been performed by the general case.
 @param inMat The source Eigen matrix that we are converting
 @param outArray The destination array we copy into
 */
-void eigenVector4d2CArray(Eigen::Vector4d &inMat, double *outArray) {
+void eigenVector4d2CArray(Eigen::Vector4d& inMat, double* outArray) {
     memcpy(outArray, inMat.data(), 4 * sizeof(double));
 }
 
@@ -88,7 +88,7 @@ and the transpose that would have been performed by the general case.
 @param inMat The source Eigen MRP that we are converting
 @param outArray The destination array we copy into
 */
-void eigenMRPd2CArray(Eigen::Vector3d &inMat, double *outArray) { memcpy(outArray, inMat.data(), 3 * sizeof(double)); }
+void eigenMRPd2CArray(Eigen::Vector3d& inMat, double* outArray) { memcpy(outArray, inMat.data(), 3 * sizeof(double)); }
 
 /*! This function provides a direct conversion between a 3x3 matrix and an
 output C array. We are providing this function to save on the inline conversion
@@ -97,7 +97,7 @@ that would have been performed by the general case.
 @param inMat The source Eigen matrix that we are converting
 @param outArray The destination array we copy into
 */
-void eigenMatrix3d2CArray(Eigen::Matrix3d &inMat, double *outArray) {
+void eigenMatrix3d2CArray(Eigen::Matrix3d& inMat, double* outArray) {
     Eigen::MatrixXd tempMat = inMat.transpose();
     memcpy(outArray, tempMat.data(), 9 * sizeof(double));
 }
@@ -111,7 +111,7 @@ information to ingest the C array.
 @param nRows
 @param nCols
 */
-Eigen::MatrixXd cArray2EigenMatrixXd(double *inArray, int nRows, int nCols) {
+Eigen::MatrixXd cArray2EigenMatrixXd(double* inArray, int nRows, int nCols) {
     Eigen::MatrixXd outMat;
     outMat.resize(nRows, nCols);
     outMat = Eigen::Map<Eigen::MatrixXd>(inArray, outMat.rows(), outMat.cols());
@@ -124,7 +124,7 @@ in order to save an unnecessary conversion between types.
 @return Eigen::Vector3d
 @param inArray The input array (row-major)
 */
-Eigen::Vector3d cArray2EigenVector3d(double *inArray) { return Eigen::Map<Eigen::Vector3d>(inArray, 3, 1); }
+Eigen::Vector3d cArray2EigenVector3d(double* inArray) { return Eigen::Map<Eigen::Vector3d>(inArray, 3, 1); }
 
 /*! This function performs the conversion between an input C array
 3-float-vector and an output Eigen vector3f. This function is provided
@@ -132,7 +132,7 @@ in order to save an unnecessary conversion between types.
 @return Eigen::Vector3f
 @param inArray The input float array (row-major)
 */
-Eigen::Vector3f cArray2EigenVector3f(float *inArray) { return Eigen::Map<Eigen::Vector3f>(inArray, 3, 1); }
+Eigen::Vector3f cArray2EigenVector3f(float* inArray) { return Eigen::Map<Eigen::Vector3f>(inArray, 3, 1); }
 
 /*! This function performs the conversion between an input C array
 4-vector and an output Eigen vector4d. This function is provided
@@ -140,7 +140,7 @@ in order to save an unnecessary conversion between types.
 @return Eigen::Vector4d
 @param inArray The input array (row-major)
 */
-Eigen::Vector4d cArray2EigenVector4d(double *inArray) { return Eigen::Map<Eigen::Vector4d>(inArray, 4, 1); }
+Eigen::Vector4d cArray2EigenVector4d(double* inArray) { return Eigen::Map<Eigen::Vector4d>(inArray, 4, 1); }
 
 /*! This function performs the conversion between an input C array
 3-vector and an output Eigen MRPd. This function is provided
@@ -148,7 +148,7 @@ in order to save an unnecessary conversion between types.
 @return Eigen::MRPd
 @param inArray The input array (row-major)
 */
-Eigen::MRPd cArray2EigenMRPd(double *inArray) {
+Eigen::MRPd cArray2EigenMRPd(double* inArray) {
     Eigen::MRPd sigma_Eigen;
     sigma_Eigen = cArray2EigenVector3d(inArray);
 
@@ -161,7 +161,7 @@ in order to save an unnecessary conversion between types.
 @return Eigen::Matrix3d
 @param inArray The input array (row-major)
 */
-Eigen::Matrix3d cArray2EigenMatrix3d(double *inArray) { return Eigen::Map<Eigen::Matrix3d>(inArray, 3, 3).transpose(); }
+Eigen::Matrix3d cArray2EigenMatrix3d(double* inArray) { return Eigen::Map<Eigen::Matrix3d>(inArray, 3, 3).transpose(); }
 
 /*! This function performs the conversion between an input C 3x3
 2D-array and an output Eigen vector3d. This function is provided

--- a/architecture/utilities/avsEigenSupport.cpp
+++ b/architecture/utilities/avsEigenSupport.cpp
@@ -19,8 +19,6 @@
 
 #include "avsEigenSupport.h"
 
-#include <math.h>
-
 #include "architecture/utilities/rigidBodyKinematics.hpp"
 
 /*! This function provides a general conversion between an Eigen matrix and
@@ -212,8 +210,8 @@ Eigen::Matrix3d eigenM2(double angle) {
 
     mOut.setIdentity();
 
-    mOut(0, 0) = cos(angle);
-    mOut(0, 2) = -sin(angle);
+    mOut(0, 0) = std::cos(angle);
+    mOut(0, 2) = -std::sin(angle);
     mOut(2, 0) = -mOut(0, 2);
     mOut(2, 2) = mOut(0, 0);
 
@@ -231,8 +229,8 @@ Eigen::Matrix3d eigenM3(double angle) {
 
     mOut.setIdentity();
 
-    mOut(0, 0) = cos(angle);
-    mOut(0, 1) = sin(angle);
+    mOut(0, 0) = std::cos(angle);
+    mOut(0, 1) = std::sin(angle);
     mOut(1, 0) = -mOut(0, 1);
     mOut(1, 1) = mOut(0, 0);
 


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The utilities directory is added as a library target to the build. The `utilities` library is used when compiling the algorithms library for the production target. A small edit was made to the eigen support file to remove the inclusion of `<math.h>`. A standalone/freestanding target environment doesn't provide `<cmath>` and when compiling test builds on linux (hosted environment) `<math.h>` resolves to `<cmath>` which fails at compilation due to the internal `bits/requires_hosted.h` check introduced in GCC 13.1 (for the interested reader https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109814)

## Verification
This has been tested on the production target build system (which will soon be integrated into the CI on this repository).

## Documentation
None needed, none invalidated.

## Future work
None
