### PR TITLE
Feature/1841 ephemerides recenter floats

### DIFF
--- a/algorithms/CMakeLists.txt
+++ b/algorithms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(msgPayloadDef)
 
 add_subdirectory(attTrackingError)
+add_subdirectory(ephemeridesRecenter)
 add_subdirectory(ephemNavConverter)
 add_subdirectory(inertial3D)
 add_subdirectory(navAggregate)

--- a/algorithms/attTrackingError/_tests/test_attTrackingError.py
+++ b/algorithms/attTrackingError/_tests/test_attTrackingError.py
@@ -4,11 +4,11 @@
 
 import numpy as np
 
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.fp32 import attTrackingErrorF32
-from Basilisk.utilities import macros
-from Basilisk.utilities import RigidBodyKinematics as rbk
-from Basilisk.architecture import messaging
+from xmera.utilities import SimulationBaseClass
+from xmera.fp32 import attTrackingErrorF32
+from xmera.utilities import macros
+from xmera.utilities import RigidBodyKinematics as rbk
+from xmera.architecture import messaging
 
 def test_attTrackingError():
     unitTaskName = "unitTask"

--- a/algorithms/ephemNavConverter/_tests/test_ephemNavConverter.py
+++ b/algorithms/ephemNavConverter/_tests/test_ephemNavConverter.py
@@ -7,10 +7,10 @@ import os
 
 import numpy as np
 
-from Basilisk.architecture import messaging
-from Basilisk.fp32 import ephemNavConverterF32
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
-from Basilisk.utilities import astroFunctions
+from xmera.architecture import messaging
+from xmera.fp32 import ephemNavConverterF32
+from xmera.utilities import SimulationBaseClass, unitTestSupport, macros
+from xmera.utilities import astroFunctions
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))

--- a/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.cpp
+++ b/algorithms/ephemNavConverter/ephemNavConverterAlgorithm.cpp
@@ -6,7 +6,13 @@
 
 #include "ephemNavConverterAlgorithm.h"
 
-static void v3Copy(float const v[3], float result[3]) {
+/**
+ * @brief Copy a 3x1 vector.
+ * @param v The vector to be copied.
+ * @param result The vector copy.
+ */
+template <typename ScalarT>
+static void v3Copy(ScalarT const v[3], ScalarT result[3]) {
     result[0] = v[0];
     result[1] = v[1];
     result[2] = v[2];

--- a/algorithms/ephemeridesRecenter/CMakeLists.txt
+++ b/algorithms/ephemeridesRecenter/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(module "fswAlgorithms.transDetermination.ephemeridesRecenter")
+xmera_is_module_enabled("${module}" _is_enabled)
+if(NOT _is_enabled)
+  return()
+endif()
+
+xmera_add_swig_module("${module}")
+target_sources("${module}" PRIVATE
+  ephemeridesRecenter.cpp
+  ephemeridesRecenterAlgorithm.cpp
+)
+
+target_link_libraries("${module}" PRIVATE
+  Eigen3::Eigen
+)

--- a/algorithms/ephemeridesRecenter/CMakeLists.txt
+++ b/algorithms/ephemeridesRecenter/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(module "fswAlgorithms.transDetermination.ephemeridesRecenter")
+set(module "fp32.ephemeridesRecenterF32")
 xmera_is_module_enabled("${module}" _is_enabled)
 if(NOT _is_enabled)
   return()

--- a/algorithms/ephemeridesRecenter/CMakeLists.txt
+++ b/algorithms/ephemeridesRecenter/CMakeLists.txt
@@ -10,6 +10,8 @@ target_sources("${module}" PRIVATE
   ephemeridesRecenterAlgorithm.cpp
 )
 
+target_include_directories("${module}" PUBLIC "..")
+
 target_link_libraries("${module}" PRIVATE
   Eigen3::Eigen
 )

--- a/algorithms/ephemeridesRecenter/_tests/test_ephemeridesRecenter.py
+++ b/algorithms/ephemeridesRecenter/_tests/test_ephemeridesRecenter.py
@@ -22,7 +22,7 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
 from xmera.utilities import SimulationBaseClass
-from xmera.fswAlgorithms import ephemeridesRecenter
+from xmera.fp32 import ephemeridesRecenterF32
 from xmera.architecture import messaging
 
 def test_body_recenter():
@@ -47,13 +47,13 @@ def mars_central_body():
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName,  int(0.5e9)))
 
-    ephemRecenter = ephemeridesRecenter.EphemeridesRecenter()
+    ephemRecenter = ephemeridesRecenterF32.EphemeridesRecenter()
     ephemRecenter.modelTag = "ephemeridesRecenter"
     unitTestSim.AddModelToTask(unitTaskName, ephemRecenter)
 
     list_of_bodies = []
     # Create bodies to add to the module
-    sunBody = ephemeridesRecenter.BodyEphemeris()
+    sunBody = ephemeridesRecenterF32.BodyEphemeris()
     sunInputPayload = messaging.EphemerisMsgPayload()
     position = [0,0,0]
     velocity = [0,0,0]
@@ -67,7 +67,7 @@ def mars_central_body():
     list_of_bodies.append(sunBody)
 
     # Set this message
-    earthBody = ephemeridesRecenter.BodyEphemeris()
+    earthBody = ephemeridesRecenterF32.BodyEphemeris()
     earthInputPayload = messaging.EphemerisMsgPayload()
     position = [1000, -200, 100]
     velocity = [10, 0, -8]
@@ -80,7 +80,7 @@ def mars_central_body():
     earthBody.originalCentralBodyName = "sun"
     list_of_bodies.append(earthBody)
 
-    marsBody = ephemeridesRecenter.BodyEphemeris()
+    marsBody = ephemeridesRecenterF32.BodyEphemeris()
     marsInputPayload = messaging.EphemerisMsgPayload()
     position = [-4000, 3000, 10000]
     velocity = [-1, -2, 1]
@@ -93,7 +93,7 @@ def mars_central_body():
     marsBody.originalCentralBodyName = "sun"
     list_of_bodies.append(marsBody)
 
-    moonBody = ephemeridesRecenter.BodyEphemeris()
+    moonBody = ephemeridesRecenterF32.BodyEphemeris()
     moonInputPayload = messaging.EphemerisMsgPayload()
     position = [-50, 30, 100]
     velocity = [-0.5, -0.2, 0.1]
@@ -185,13 +185,13 @@ def moon_central_body():
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName,  int(0.5e9)))
 
-    ephemRecenter = ephemeridesRecenter.EphemeridesRecenter()
+    ephemRecenter = ephemeridesRecenterF32.EphemeridesRecenter()
     ephemRecenter.modelTag = "ephemeridesRecenter"
     unitTestSim.AddModelToTask(unitTaskName, ephemRecenter)
 
     list_of_bodies = []
     # Create bodies to add to the module
-    sunBody = ephemeridesRecenter.BodyEphemeris()
+    sunBody = ephemeridesRecenterF32.BodyEphemeris()
     sunInputPayload = messaging.EphemerisMsgPayload()
     position = [80000, 10000, -9000]
     velocity = [-5, 2, -0.9]
@@ -205,7 +205,7 @@ def moon_central_body():
     list_of_bodies.append(sunBody)
 
     # Set this message
-    earthBody = ephemeridesRecenter.BodyEphemeris()
+    earthBody = ephemeridesRecenterF32.BodyEphemeris()
     earthInputPayload = messaging.EphemerisMsgPayload()
     position = [1000, -200, 100]
     velocity = [10, 0, -8]
@@ -218,7 +218,7 @@ def moon_central_body():
     earthBody.originalCentralBodyName = "saturn"
     list_of_bodies.append(earthBody)
 
-    marsBody = ephemeridesRecenter.BodyEphemeris()
+    marsBody = ephemeridesRecenterF32.BodyEphemeris()
     marsInputPayload = messaging.EphemerisMsgPayload()
     position = [-4000, 3000, 10000]
     velocity = [-1, -2, 1]
@@ -231,7 +231,7 @@ def moon_central_body():
     marsBody.originalCentralBodyName = "saturn"
     list_of_bodies.append(marsBody)
 
-    moonBody = ephemeridesRecenter.BodyEphemeris()
+    moonBody = ephemeridesRecenterF32.BodyEphemeris()
     moonInputPayload = messaging.EphemerisMsgPayload()
     position = [-50, 30, 100]
     velocity = [-0.5, -0.2, 0.1]
@@ -244,7 +244,7 @@ def moon_central_body():
     moonBody.originalCentralBodyName = "earth"
     list_of_bodies.append(moonBody)
 
-    saturnBody = ephemeridesRecenter.BodyEphemeris()
+    saturnBody = ephemeridesRecenterF32.BodyEphemeris()
     saturnInputPayload = messaging.EphemerisMsgPayload()
     position = [0,0,0]
     velocity = [0,0,0]
@@ -336,13 +336,13 @@ def clearing_values():
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName,  int(0.5e9)))
 
-    ephemRecenter = ephemeridesRecenter.EphemeridesRecenter()
+    ephemRecenter = ephemeridesRecenterF32.EphemeridesRecenter()
     ephemRecenter.modelTag = "ephemeridesRecenter"
     unitTestSim.AddModelToTask(unitTaskName, ephemRecenter)
 
     list_of_bodies = []
     # Create bodies to add to the module
-    sunBody = ephemeridesRecenter.BodyEphemeris()
+    sunBody = ephemeridesRecenterF32.BodyEphemeris()
     sunInputPayload = messaging.EphemerisMsgPayload()
     position = [0,0,0]
     velocity = [0,0,0]
@@ -356,7 +356,7 @@ def clearing_values():
     list_of_bodies.append(sunBody)
 
     # Set this message
-    earthBody = ephemeridesRecenter.BodyEphemeris()
+    earthBody = ephemeridesRecenterF32.BodyEphemeris()
     earthInputPayload = messaging.EphemerisMsgPayload()
     position = [1000, -200, 100]
     velocity = [10, 0, -8]
@@ -369,7 +369,7 @@ def clearing_values():
     earthBody.originalCentralBodyName = "sun"
     list_of_bodies.append(earthBody)
 
-    marsBody = ephemeridesRecenter.BodyEphemeris()
+    marsBody = ephemeridesRecenterF32.BodyEphemeris()
     marsInputPayload = messaging.EphemerisMsgPayload()
     position = [-4000, 3000, 10000]
     velocity = [-1, -2, 1]
@@ -382,7 +382,7 @@ def clearing_values():
     marsBody.originalCentralBodyName = "sun"
     list_of_bodies.append(marsBody)
 
-    moonBody = ephemeridesRecenter.BodyEphemeris()
+    moonBody = ephemeridesRecenterF32.BodyEphemeris()
     moonInputPayload = messaging.EphemerisMsgPayload()
     position = [-50, 30, 100]
     velocity = [-0.5, -0.2, 0.1]

--- a/algorithms/ephemeridesRecenter/_tests/test_ephemeridesRecenter.py
+++ b/algorithms/ephemeridesRecenter/_tests/test_ephemeridesRecenter.py
@@ -54,13 +54,13 @@ def mars_central_body():
     list_of_bodies = []
     # Create bodies to add to the module
     sunBody = ephemeridesRecenterF32.BodyEphemeris()
-    sunInputPayload = messaging.EphemerisMsgPayload()
+    sunInputPayload = messaging.EphemerisMsgF32Payload()
     position = [0,0,0]
     velocity = [0,0,0]
     sunInputPayload.r_BdyZero_N = position
     sunInputPayload.v_BdyZero_N = velocity
     sunInputPayload.timeTag = 1234.0
-    sunInputMessage = messaging.EphemerisMsg().write(sunInputPayload)
+    sunInputMessage = messaging.EphemerisMsgF32().write(sunInputPayload)
     sunBody.inputEphemerisMsg.subscribeTo(sunInputMessage)
     sunBody.bodySpiceName = "sun"
     sunBody.originalCentralBodyName = "sun"
@@ -68,39 +68,39 @@ def mars_central_body():
 
     # Set this message
     earthBody = ephemeridesRecenterF32.BodyEphemeris()
-    earthInputPayload = messaging.EphemerisMsgPayload()
+    earthInputPayload = messaging.EphemerisMsgF32Payload()
     position = [1000, -200, 100]
     velocity = [10, 0, -8]
     earthInputPayload.r_BdyZero_N = position
     earthInputPayload.v_BdyZero_N = velocity
     earthInputPayload.timeTag = 1234.0
-    earthInputMessage = messaging.EphemerisMsg().write(earthInputPayload)
+    earthInputMessage = messaging.EphemerisMsgF32().write(earthInputPayload)
     earthBody.inputEphemerisMsg.subscribeTo(earthInputMessage)
     earthBody.bodySpiceName = "earth"
     earthBody.originalCentralBodyName = "sun"
     list_of_bodies.append(earthBody)
 
     marsBody = ephemeridesRecenterF32.BodyEphemeris()
-    marsInputPayload = messaging.EphemerisMsgPayload()
+    marsInputPayload = messaging.EphemerisMsgF32Payload()
     position = [-4000, 3000, 10000]
     velocity = [-1, -2, 1]
     marsInputPayload.r_BdyZero_N = position
     marsInputPayload.v_BdyZero_N = velocity
     marsInputPayload.timeTag = 1234.0
-    marsInputMessage = messaging.EphemerisMsg().write(marsInputPayload)
+    marsInputMessage = messaging.EphemerisMsgF32().write(marsInputPayload)
     marsBody.inputEphemerisMsg.subscribeTo(marsInputMessage)
     marsBody.bodySpiceName = "mars"
     marsBody.originalCentralBodyName = "sun"
     list_of_bodies.append(marsBody)
 
     moonBody = ephemeridesRecenterF32.BodyEphemeris()
-    moonInputPayload = messaging.EphemerisMsgPayload()
+    moonInputPayload = messaging.EphemerisMsgF32Payload()
     position = [-50, 30, 100]
     velocity = [-0.5, -0.2, 0.1]
     moonInputPayload.r_BdyZero_N = position
     moonInputPayload.v_BdyZero_N = velocity
     moonInputPayload.timeTag = 1234.0
-    moonInputMessage = messaging.EphemerisMsg().write(moonInputPayload)
+    moonInputMessage = messaging.EphemerisMsgF32().write(moonInputPayload)
     moonBody.inputEphemerisMsg.subscribeTo(moonInputMessage)
     moonBody.bodySpiceName = "moon"
     moonBody.originalCentralBodyName = "earth"
@@ -192,13 +192,13 @@ def moon_central_body():
     list_of_bodies = []
     # Create bodies to add to the module
     sunBody = ephemeridesRecenterF32.BodyEphemeris()
-    sunInputPayload = messaging.EphemerisMsgPayload()
+    sunInputPayload = messaging.EphemerisMsgF32Payload()
     position = [80000, 10000, -9000]
     velocity = [-5, 2, -0.9]
     sunInputPayload.r_BdyZero_N = position
     sunInputPayload.v_BdyZero_N = velocity
     sunInputPayload.timeTag = 1234.0
-    sunInputMessage = messaging.EphemerisMsg().write(sunInputPayload)
+    sunInputMessage = messaging.EphemerisMsgF32().write(sunInputPayload)
     sunBody.inputEphemerisMsg.subscribeTo(sunInputMessage)
     sunBody.bodySpiceName = "sun"
     sunBody.originalCentralBodyName = "saturn"
@@ -206,52 +206,52 @@ def moon_central_body():
 
     # Set this message
     earthBody = ephemeridesRecenterF32.BodyEphemeris()
-    earthInputPayload = messaging.EphemerisMsgPayload()
+    earthInputPayload = messaging.EphemerisMsgF32Payload()
     position = [1000, -200, 100]
     velocity = [10, 0, -8]
     earthInputPayload.r_BdyZero_N = position
     earthInputPayload.v_BdyZero_N = velocity
     earthInputPayload.timeTag = 1234.0
-    earthInputMessage = messaging.EphemerisMsg().write(earthInputPayload)
+    earthInputMessage = messaging.EphemerisMsgF32().write(earthInputPayload)
     earthBody.inputEphemerisMsg.subscribeTo(earthInputMessage)
     earthBody.bodySpiceName = "earth"
     earthBody.originalCentralBodyName = "saturn"
     list_of_bodies.append(earthBody)
 
     marsBody = ephemeridesRecenterF32.BodyEphemeris()
-    marsInputPayload = messaging.EphemerisMsgPayload()
+    marsInputPayload = messaging.EphemerisMsgF32Payload()
     position = [-4000, 3000, 10000]
     velocity = [-1, -2, 1]
     marsInputPayload.r_BdyZero_N = position
     marsInputPayload.v_BdyZero_N = velocity
     marsInputPayload.timeTag = 1234.0
-    marsInputMessage = messaging.EphemerisMsg().write(marsInputPayload)
+    marsInputMessage = messaging.EphemerisMsgF32().write(marsInputPayload)
     marsBody.inputEphemerisMsg.subscribeTo(marsInputMessage)
     marsBody.bodySpiceName = "mars"
     marsBody.originalCentralBodyName = "saturn"
     list_of_bodies.append(marsBody)
 
     moonBody = ephemeridesRecenterF32.BodyEphemeris()
-    moonInputPayload = messaging.EphemerisMsgPayload()
+    moonInputPayload = messaging.EphemerisMsgF32Payload()
     position = [-50, 30, 100]
     velocity = [-0.5, -0.2, 0.1]
     moonInputPayload.r_BdyZero_N = position
     moonInputPayload.v_BdyZero_N = velocity
     moonInputPayload.timeTag = 1234.0
-    moonInputMessage = messaging.EphemerisMsg().write(moonInputPayload)
+    moonInputMessage = messaging.EphemerisMsgF32().write(moonInputPayload)
     moonBody.inputEphemerisMsg.subscribeTo(moonInputMessage)
     moonBody.bodySpiceName = "moon"
     moonBody.originalCentralBodyName = "earth"
     list_of_bodies.append(moonBody)
 
     saturnBody = ephemeridesRecenterF32.BodyEphemeris()
-    saturnInputPayload = messaging.EphemerisMsgPayload()
+    saturnInputPayload = messaging.EphemerisMsgF32Payload()
     position = [0,0,0]
     velocity = [0,0,0]
     saturnInputPayload.r_BdyZero_N = position
     saturnInputPayload.v_BdyZero_N = velocity
     saturnInputPayload.timeTag = 1234.0
-    saturnInputMessage = messaging.EphemerisMsg().write(saturnInputPayload)
+    saturnInputMessage = messaging.EphemerisMsgF32().write(saturnInputPayload)
     saturnBody.inputEphemerisMsg.subscribeTo(saturnInputMessage)
     saturnBody.bodySpiceName = "saturn"
     saturnBody.originalCentralBodyName = "saturn"
@@ -343,13 +343,13 @@ def clearing_values():
     list_of_bodies = []
     # Create bodies to add to the module
     sunBody = ephemeridesRecenterF32.BodyEphemeris()
-    sunInputPayload = messaging.EphemerisMsgPayload()
+    sunInputPayload = messaging.EphemerisMsgF32Payload()
     position = [0,0,0]
     velocity = [0,0,0]
     sunInputPayload.r_BdyZero_N = position
     sunInputPayload.v_BdyZero_N = velocity
     sunInputPayload.timeTag = 1234.0
-    sunInputMessage = messaging.EphemerisMsg().write(sunInputPayload)
+    sunInputMessage = messaging.EphemerisMsgF32().write(sunInputPayload)
     sunBody.inputEphemerisMsg.subscribeTo(sunInputMessage)
     sunBody.bodySpiceName = "sun"
     sunBody.originalCentralBodyName = "sun"
@@ -357,39 +357,39 @@ def clearing_values():
 
     # Set this message
     earthBody = ephemeridesRecenterF32.BodyEphemeris()
-    earthInputPayload = messaging.EphemerisMsgPayload()
+    earthInputPayload = messaging.EphemerisMsgF32Payload()
     position = [1000, -200, 100]
     velocity = [10, 0, -8]
     earthInputPayload.r_BdyZero_N = position
     earthInputPayload.v_BdyZero_N = velocity
     earthInputPayload.timeTag = 1234.0
-    earthInputMessage = messaging.EphemerisMsg().write(earthInputPayload)
+    earthInputMessage = messaging.EphemerisMsgF32().write(earthInputPayload)
     earthBody.inputEphemerisMsg.subscribeTo(earthInputMessage)
     earthBody.bodySpiceName = "earth"
     earthBody.originalCentralBodyName = "sun"
     list_of_bodies.append(earthBody)
 
     marsBody = ephemeridesRecenterF32.BodyEphemeris()
-    marsInputPayload = messaging.EphemerisMsgPayload()
+    marsInputPayload = messaging.EphemerisMsgF32Payload()
     position = [-4000, 3000, 10000]
     velocity = [-1, -2, 1]
     marsInputPayload.r_BdyZero_N = position
     marsInputPayload.v_BdyZero_N = velocity
     marsInputPayload.timeTag = 1234.0
-    marsInputMessage = messaging.EphemerisMsg().write(marsInputPayload)
+    marsInputMessage = messaging.EphemerisMsgF32().write(marsInputPayload)
     marsBody.inputEphemerisMsg.subscribeTo(marsInputMessage)
     marsBody.bodySpiceName = "mars"
     marsBody.originalCentralBodyName = "sun"
     list_of_bodies.append(marsBody)
 
     moonBody = ephemeridesRecenterF32.BodyEphemeris()
-    moonInputPayload = messaging.EphemerisMsgPayload()
+    moonInputPayload = messaging.EphemerisMsgF32Payload()
     position = [-50, 30, 100]
     velocity = [-0.5, -0.2, 0.1]
     moonInputPayload.r_BdyZero_N = position
     moonInputPayload.v_BdyZero_N = velocity
     moonInputPayload.timeTag = 1234.0
-    moonInputMessage = messaging.EphemerisMsg().write(moonInputPayload)
+    moonInputMessage = messaging.EphemerisMsgF32().write(moonInputPayload)
     moonBody.inputEphemerisMsg.subscribeTo(moonInputMessage)
     moonBody.bodySpiceName = "moon"
     moonBody.originalCentralBodyName = "earth"

--- a/algorithms/ephemeridesRecenter/_tests/test_ephemeridesRecenter.py
+++ b/algorithms/ephemeridesRecenter/_tests/test_ephemeridesRecenter.py
@@ -1,18 +1,6 @@
-# ISC License
+# MIT License
 #
-# Copyright (c) 2025, Laboratory for Atmospheric Space Physics, University of Colorado at Boulder
-#
-# Permission to use, copy, modify, and/or distribute this software for any
-# purpose with or without fee is hereby granted, provided that the above
-# copyright notice and this permission notice appear in all copies.
-#
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+# Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
 import inspect
 import os

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
@@ -1,0 +1,127 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "ephemeridesRecenter.h"
+
+/*! @brief This method resets the module.
+ @return void
+ @param callTime : The clock time at which the function was called (nanoseconds)
+ */
+void EphemeridesRecenter::reset(uint64_t callTime) {
+    for (auto i = 0; i < this->ephemeridesNumber; ++i) {
+        if (!this->ephemerides[i].inputEphemerisMsg.isLinked()) {
+            throw std::invalid_argument("Input ephemeris message was not connected for " +
+                                        this->ephemerides[i].bodySpiceName);
+        }
+    }
+    this->ephemeridesNumber = this->getNumberOfBodies();
+    this->algorithm.reset();
+}
+
+/*! @brief This method recomputes the body positions and velocities relative to
+    the base body ephemeris and writes out updated ephemeris position and velocity
+    for each body.
+ @return void
+ @param callTime : The clock time at which the function was called (nanoseconds)
+ */
+void EphemeridesRecenter::updateState(uint64_t callTime) {
+    std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> bodyPayloads{};
+    for (auto i = 0; i < this->ephemeridesNumber; ++i) {
+        BodyEphemerisPayload newBodyPayload{};
+        newBodyPayload.bodySpiceName = this->ephemerides[i].bodySpiceName;
+        newBodyPayload.originalCentralBodyName = this->ephemerides[i].originalCentralBodyName;
+        newBodyPayload.inputEphemerisPayload = this->ephemerides[i].inputEphemerisMsg();
+        bodyPayloads[i] = newBodyPayload;
+    }
+
+    auto outputPayloads = this->algorithm.updateState(bodyPayloads);
+
+    for (auto i = 0; i < this->ephemeridesNumber; ++i) {
+        this->recenteredEphemerisOutputMsgs[i]->write(
+            &outputPayloads[i].outputEphemerisPayload, this->moduleID, callTime);
+    }
+}
+
+/*! @brief Add a body to be re-centered.
+ @return void
+ @param ephemerisBody BodyEphemeris : A new celestial body instance
+ */
+void EphemeridesRecenter::addBodyEphemerisToRecenter(const BodyEphemeris& ephemerisBody) {
+    if (this->ephemeridesNumber + 1 > MAX_NUM_CHANGE_BODIES) {
+        throw std::invalid_argument("Adding one body too many to the list");
+    }
+    this->recenteredEphemerisOutputMsgs.push_back(new Message<EphemerisMsgPayload>);
+    this->ephemerides[this->ephemeridesNumber] = ephemerisBody;
+    this->ephemeridesNumber += 1;
+    this->algorithm.addBodyEphemerisToRecenter(ephemerisBody.bodySpiceName);
+}
+
+/*! @brief Set a new celestial body center by name
+ @return void
+ @param bodyName std::string : the new zero base
+ */
+void EphemeridesRecenter::setNewZeroBase(const std::string& bodyName) { this->algorithm.setNewZeroBaseName(bodyName); }
+
+/*! @brief Get the new celestial body center by name
+ @return std::string : the new zero base
+ */
+std::string EphemeridesRecenter::getNewZeroBase() const { return this->algorithm.getNewZeroBase(); }
+
+/*! @brief Set the previous common zero base of all the celestial bodies entered
+ @param bodyName std::string : the new zero base
+ */
+void EphemeridesRecenter::setPreviousCommonZeroBase(const std::string& bodyName) {
+    this->algorithm.setPreviousCommonZeroBase(bodyName);
+}
+
+/*! @brief Get the previous common zero base of all the celestial bodies entered
+ @return std::string : the new zero base
+ */
+std::string EphemeridesRecenter::getPreviousCommonZeroBase() const {
+    return this->algorithm.getPreviousCommonZeroBase();
+}
+
+/*! @brief Get the number of bodies that were entered into the module
+ @return size_t : the number of bodies
+ */
+size_t EphemeridesRecenter::getNumberOfBodies() const { return this->algorithm.getNumberOfBodies(); }
+
+/*! @brief Get the index of a body
+ @param celestialBodyName std::string : celestial body name
+ @return size_t : whether or not the index was found
+ */
+size_t EphemeridesRecenter::getBodyIndexFromName(const std::string& celestialBodyName) const {
+    return this->algorithm.getBodyIndexFromName(celestialBodyName);
+}
+
+/*! @brief Get all the names of the bodies entered
+ @return std::array<std::string, MAX_NUM_CHANGE_BODIES> : an array of names
+ */
+std::array<std::string, MAX_NUM_CHANGE_BODIES> EphemeridesRecenter::getAllNames() const {
+    return this->algorithm.getAllNames();
+}
+
+/*! @brief Clear all the bodies from the current list
+ */
+void EphemeridesRecenter::clearAllBodies() {
+    BodyEphemeris emptyBody{};
+    std::fill(this->ephemerides.begin(), this->ephemerides.end(), emptyBody);
+    this->ephemeridesNumber = 0;
+    this->algorithm.clearAllBodies();
+}

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
@@ -23,7 +23,7 @@
  @return void
  @param callTime : The clock time at which the function was called (nanoseconds)
  */
-void EphemeridesRecenter::reset(uint64_t callTime) {
+void EphemeridesRecenter::reset(const uint64_t callTime) {
     for (auto i = 0; i < this->ephemeridesNumber; ++i) {
         if (!this->ephemerides[i].inputEphemerisMsg.isLinked()) {
             throw std::invalid_argument("Input ephemeris message was not connected for " +
@@ -40,7 +40,7 @@ void EphemeridesRecenter::reset(uint64_t callTime) {
  @return void
  @param callTime : The clock time at which the function was called (nanoseconds)
  */
-void EphemeridesRecenter::updateState(uint64_t callTime) {
+void EphemeridesRecenter::updateState(const uint64_t callTime) {
     std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> bodyPayloads{};
     for (auto i = 0; i < this->ephemeridesNumber; ++i) {
         BodyEphemerisPayload newBodyPayload{};

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
@@ -1,20 +1,7 @@
 /*
- ISC License
+ MIT License
 
  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
-
- Permission to use, copy, modify, and/or distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
-
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
  */
 
 #include "ephemeridesRecenter.h"

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "ephemeridesRecenter.h"
+#include <stdexcept>
 
 /*! @brief This method resets the module.
  @return void

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
@@ -66,7 +66,7 @@ void EphemeridesRecenter::addBodyEphemerisToRecenter(const BodyEphemeris& epheme
     if (this->ephemeridesNumber + 1 > MAX_NUM_CHANGE_BODIES) {
         throw std::invalid_argument("Adding one body too many to the list");
     }
-    this->recenteredEphemerisOutputMsgs.push_back(new Message<EphemerisMsgPayload>);
+    this->recenteredEphemerisOutputMsgs.push_back(new Message<EphemerisMsgF32Payload>);
     this->ephemerides[this->ephemeridesNumber] = ephemerisBody;
     this->ephemeridesNumber += 1;
     this->algorithm.addBodyEphemerisToRecenter(ephemerisBody.bodySpiceName);

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
@@ -23,7 +23,6 @@
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
 #include "ephemeridesRecenterAlgorithm.h"
-#include <assert.h>
 #include <Eigen/Core>
 #include <array>
 

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
@@ -7,9 +7,9 @@
 #ifndef F32XIMERA_EPHEM_RECENTER_H
 #define F32XIMERA_EPHEM_RECENTER_H
 
+#include "ephemeridesRecenterAlgorithm.h"
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
-#include "ephemeridesRecenterAlgorithm.h"
 #include <Eigen/Core>
 #include <array>
 

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
@@ -17,8 +17,8 @@
 
  */
 
-#ifndef _EPHEM_RECENTER_H_
-#define _EPHEM_RECENTER_H_
+#ifndef F32XIMERA_EPHEM_RECENTER_H
+#define F32XIMERA_EPHEM_RECENTER_H
 
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
@@ -1,0 +1,62 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _EPHEM_RECENTER_H_
+#define _EPHEM_RECENTER_H_
+
+#include <architecture/_GeneralModuleFiles/sys_model.h>
+#include <architecture/messaging/messaging.h>
+#include "ephemeridesRecenterAlgorithm.h"
+#include <assert.h>
+#include <Eigen/Core>
+#include <array>
+
+/*! @brief Container class for the input and output messages that will be re-centered on the base ephemeris. */
+class BodyEphemeris {
+   public:
+    std::string bodySpiceName;
+    std::string originalCentralBodyName;
+    ReadFunctor<EphemerisMsgPayload> inputEphemerisMsg{};
+    Message<EphemerisMsgPayload> outputEphemerisMsg{};
+};
+
+/*! @brief Ephemerides Recenter Basilisk Model */
+class EphemeridesRecenter : public SysModel {
+   public:
+    void updateState(uint64_t callTime) override;
+    void reset(uint64_t callTime) override;
+
+    void addBodyEphemerisToRecenter(const BodyEphemeris& ephemerisBody);
+    void setNewZeroBase(const std::string& bodyName);
+    std::string getNewZeroBase() const;
+    void setPreviousCommonZeroBase(const std::string& bodyName);
+    std::string getPreviousCommonZeroBase() const;
+    std::array<std::string, MAX_NUM_CHANGE_BODIES> getAllNames() const;
+    size_t getBodyIndexFromName(const std::string& celestialBodyName) const;
+    size_t getNumberOfBodies() const;
+    void clearAllBodies();
+    std::vector<Message<EphemerisMsgPayload>*> recenteredEphemerisOutputMsgs{};
+
+   private:
+    size_t ephemeridesNumber{};
+    std::array<BodyEphemeris, MAX_NUM_CHANGE_BODIES> ephemerides{};
+    EphemeridesRecenterAlgorithm algorithm{};
+};
+
+#endif

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
@@ -1,20 +1,7 @@
 /*
- ISC License
+ MIT License
 
  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
-
- Permission to use, copy, modify, and/or distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
-
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
  */
 
 #ifndef F32XIMERA_EPHEM_RECENTER_H

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.h
@@ -32,8 +32,8 @@ class BodyEphemeris {
    public:
     std::string bodySpiceName;
     std::string originalCentralBodyName;
-    ReadFunctor<EphemerisMsgPayload> inputEphemerisMsg{};
-    Message<EphemerisMsgPayload> outputEphemerisMsg{};
+    ReadFunctor<EphemerisMsgF32Payload> inputEphemerisMsg{};
+    Message<EphemerisMsgF32Payload> outputEphemerisMsg{};
 };
 
 /*! @brief Ephemerides Recenter Basilisk Model */
@@ -51,7 +51,7 @@ class EphemeridesRecenter : public SysModel {
     size_t getBodyIndexFromName(const std::string& celestialBodyName) const;
     size_t getNumberOfBodies() const;
     void clearAllBodies();
-    std::vector<Message<EphemerisMsgPayload>*> recenteredEphemerisOutputMsgs{};
+    std::vector<Message<EphemerisMsgF32Payload>*> recenteredEphemerisOutputMsgs{};
 
    private:
     size_t ephemeridesNumber{};

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.i
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.i
@@ -1,0 +1,32 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module ephemeridesRecenter
+%{
+   #include "ephemeridesRecenter.h"
+%}
+
+%include <architecture/_GeneralModuleFiles/sys_model.i>
+%include <architecture/_GeneralModuleFiles/swig_conly_data.i>
+%include <std_vector.i>
+%include <std_string.i>
+%include <std_array.i>
+%template(StringArray10) std::array<std::string, MAX_NUM_CHANGE_BODIES>;
+
+%include "ephemeridesRecenter.h"
+%include <architecture/msgPayloadDef/EphemerisMsgPayload.h>

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.rst
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.rst
@@ -1,0 +1,66 @@
+Ephemerides Recenter
+=============================
+
+This module provides functionality to transform the ephemerides of a collection of bodies
+so that they are expressed relative to a new central body, rather than their original reference (e.g., Sun or Earth).
+
+Assumptions and Limitations
+---------------
+
+The module should be used in the following circumstances: when creating a simulation with ephemeris tables mostly all
+generated with respect to a central body like the Sun or Earth, but with the spacecraft table in the simulation
+centered on one of these bodies. This module allows to recenter all the bodies around the desired central body.
+
+The module works with planets around the Sun, and with a single moon around one of those planets. Furthermore all
+of the bodies must be relative to the original zero base, except one moon per body if applicable (in which case the
+moon is relative to its parent body).
+
+Module Overview
+---------------
+
+The module is implemented in C++ and consists of:
+
+- ``BodyEphemeris``: A container representing a body and its ephemeris messages.
+- ``EphemeridesRecenter``: The module class
+
+When building a body with the BodyEphemeris class, use:
+
+- ``bodySpiceName``: the name of the new body
+- ``originalCentralBodyName``: its original zero-base (of the input message data)
+- add it to the CelestialEphemerisRecenter module with ``addBodyEphemerisToRecenter``
+
+When setting up the module:
+
+- ``setNewZeroBase``: sets the zero base that the spacecraft is using and for all the other bodies to switch to
+- ``setPreviousCommonZeroBase``: identify the previous zero base
+
+Usage Example
+-------------
+
+Below is an example of using the Python interface (mocked for testing) to interact with the C++ module:
+
+.. code-block:: python
+
+    from celestialEphemerisRecenter import CelestialEphemerisRecenter, BodyEphemeris
+
+    # Create module and celestial body
+    module = CelestialEphemerisRecenter()
+    body = BodyEphemeris()
+    body.bodySpiceName = "Mars"
+    body.originalCentralBodyName = "Sun"
+
+    # Attach message functors (e.g., input/output links in Basilisk)
+    body.inputEphemerisMsg = YourInputMsgFunctor()
+    body.outputEphemerisMsg = YourOutputMsg()
+
+    # Register body and configure module
+    module.addBodyEphemerisToRecenter(body)
+    module.setNewZeroBase("Mars")
+    module.setPreviousCommonZeroBase("Sun")
+
+    # Run module (e.g., in Basilisk dynamics loop)
+    module.updateState(callTime)
+
+Notes
+-----
+\- The maximum number of bodies is limited to 20.

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
@@ -1,20 +1,8 @@
 /*
- ISC License
+ MIT License
 
  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
-
- Permission to use, copy, modify, and/or distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
-
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-*/
+ */
 
 #include "ephemeridesRecenterAlgorithm.h"
 #include "../freestandingInvalidArgument.h"

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
@@ -53,7 +53,7 @@ std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgor
     this->celestialBodies = newBodies;
 
     auto newCentralBody = this->celestialBodies[this->newCentralIndex];
-    EphemerisMsgPayload newCentralBodyPayload = newCentralBody.inputEphemerisPayload;
+    EphemerisMsgF32Payload newCentralBodyPayload = newCentralBody.inputEphemerisPayload;
     /* - If the new central body is a moon (its original central body is not the common central body but another body in
      * the list) first re-center the moon around the common central body so that every body is relative to the common
      * center*/
@@ -71,7 +71,7 @@ std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgor
         /* Moons get re-centered along with their central body and shouldn't be re-centered in this main loop */
         if (!recenteredBodies[i].isMoon) {
             recenteredBodies[i] = BodyEphemerisPayload{};
-            EphemerisMsgPayload newEphemerisToRecenterPayload = newBodies[i].inputEphemerisPayload;
+            EphemerisMsgF32Payload newEphemerisToRecenterPayload = newBodies[i].inputEphemerisPayload;
             if (this->celestialBodies[i].originalCentralBodyName != newCentralBody.bodySpiceName &&
                 this->celestialBodies[i].originalCentralBodyName == this->previousCentralBodyName) {
                 vectorSubtraction(newEphemerisToRecenterPayload.r_BdyZero_N,
@@ -83,7 +83,7 @@ std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgor
 
                 if (size_t moonIndex{}; this->findMoonOfBody(this->celestialBodies[i], &moonIndex) &&
                                         this->celestialBodies[i].bodySpiceName != this->previousCentralBodyName) {
-                    EphemerisMsgPayload moonOfBodyPayload = this->celestialBodies[moonIndex].inputEphemerisPayload;
+                    EphemerisMsgF32Payload moonOfBodyPayload = this->celestialBodies[moonIndex].inputEphemerisPayload;
                     vectorAddition(newEphemerisToRecenterPayload.r_BdyZero_N,
                                    moonOfBodyPayload.r_BdyZero_N,
                                    moonOfBodyPayload.r_BdyZero_N);

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
@@ -53,7 +53,7 @@ std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgor
     const std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES>& newBodies) {
     this->celestialBodies = newBodies;
 
-    auto newCentralBody = this->celestialBodies[this->newCentralIndex];
+    const auto newCentralBody = this->celestialBodies[this->newCentralIndex];
     EphemerisMsgF32Payload newCentralBodyPayload = newCentralBody.inputEphemerisPayload;
     /* - If the new central body is a moon (its original central body is not the common central body but another body in
      * the list) first re-center the moon around the common central body so that every body is relative to the common

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
@@ -1,0 +1,229 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "ephemeridesRecenterAlgorithm.h"
+
+/*! @brief Subtract two C-array vectors
+ @param v1 double[3] : vector 1
+ @param v2 double[3] : vector 2
+ @param result double[3] : subtracted vectors
+ */
+static void vectorSubtraction(const double v1[3], const double v2[3], double result[3]) {
+    for (int i = 0; i < 3; ++i) {
+        result[i] = v1[i] - v2[i];
+    }
+}
+
+/*! @brief Add two C-array vectors
+ @param v1 double[3] : vector 1
+ @param v2 double[3] : vector 2
+ @param result double[3] : added vectors
+ */
+static void vectorAddition(const double v1[3], const double v2[3], double result[3]) {
+    for (int i = 0; i < 3; ++i) {
+        result[i] = v1[i] + v2[i];
+    }
+}
+
+void EphemeridesRecenterAlgorithm::reset() {
+    this->newCentralIndex = this->findNewZeroBaseIndex(this->newCentralBodyName);
+}
+
+/*! @brief Recenter the ephemerides
+ @param newBodies std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> : input bodies
+ @return std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> : re-centered bodies
+ */
+std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgorithm::updateState(
+    const std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES>& newBodies) {
+    this->celestialBodies = newBodies;
+
+    auto newCentralBody = this->celestialBodies[this->newCentralIndex];
+    EphemerisMsgPayload newCentralBodyPayload = newCentralBody.inputEphemerisPayload;
+    /* - If the new central body is a moon (its original central body is not the common central body but another body in
+     * the list) first re-center the moon around the common central body so that every body is relative to the common
+     * center*/
+    if (newCentralBody.originalCentralBodyName != this->previousCentralBodyName) {
+        auto moonCentralBodyIndex = this->getBodyIndexFromName(newCentralBody.originalCentralBodyName);
+        auto moonCentralBodyInput = this->celestialBodies[moonCentralBodyIndex].inputEphemerisPayload;
+        vectorAddition(
+            newCentralBodyPayload.r_BdyZero_N, moonCentralBodyInput.r_BdyZero_N, newCentralBodyPayload.r_BdyZero_N);
+        vectorAddition(
+            newCentralBodyPayload.v_BdyZero_N, moonCentralBodyInput.v_BdyZero_N, newCentralBodyPayload.v_BdyZero_N);
+    }
+
+    std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> recenteredBodies{};
+    for (size_t i = 0; i < this->celestialBodyCount; ++i) {
+        /* Moons get re-centered along with their central body and shouldn't be re-centered in this main loop */
+        if (!recenteredBodies[i].isMoon) {
+            recenteredBodies[i] = BodyEphemerisPayload{};
+            EphemerisMsgPayload newEphemerisToRecenterPayload = newBodies[i].inputEphemerisPayload;
+            if (this->celestialBodies[i].originalCentralBodyName != newCentralBody.bodySpiceName &&
+                this->celestialBodies[i].originalCentralBodyName == this->previousCentralBodyName) {
+                vectorSubtraction(newEphemerisToRecenterPayload.r_BdyZero_N,
+                                  newCentralBodyPayload.r_BdyZero_N,
+                                  newEphemerisToRecenterPayload.r_BdyZero_N);
+                vectorSubtraction(newEphemerisToRecenterPayload.v_BdyZero_N,
+                                  newCentralBodyPayload.v_BdyZero_N,
+                                  newEphemerisToRecenterPayload.v_BdyZero_N);
+
+                if (size_t moonIndex{}; this->findMoonOfBody(this->celestialBodies[i], &moonIndex) &&
+                                        this->celestialBodies[i].bodySpiceName != this->previousCentralBodyName) {
+                    EphemerisMsgPayload moonOfBodyPayload = this->celestialBodies[moonIndex].inputEphemerisPayload;
+                    vectorAddition(newEphemerisToRecenterPayload.r_BdyZero_N,
+                                   moonOfBodyPayload.r_BdyZero_N,
+                                   moonOfBodyPayload.r_BdyZero_N);
+                    vectorAddition(newEphemerisToRecenterPayload.v_BdyZero_N,
+                                   moonOfBodyPayload.v_BdyZero_N,
+                                   moonOfBodyPayload.v_BdyZero_N);
+
+                    recenteredBodies[moonIndex].bodySpiceName = this->celestialBodies[moonIndex].bodySpiceName;
+                    recenteredBodies[moonIndex].isMoon = true;
+                    recenteredBodies[moonIndex].originalCentralBodyName =
+                        this->celestialBodies[moonIndex].originalCentralBodyName;
+                    recenteredBodies[moonIndex].inputEphemerisPayload =
+                        this->celestialBodies[moonIndex].inputEphemerisPayload;
+                    recenteredBodies[moonIndex].outputEphemerisPayload = moonOfBodyPayload;
+                }
+            }
+            recenteredBodies[i] = newBodies[i];
+            recenteredBodies[i].outputEphemerisPayload = newEphemerisToRecenterPayload;
+        }
+    }
+    return recenteredBodies;
+}
+
+/*! @brief Find the moon index of a given body
+ @param celestialBody std::string : celestial body name
+ @param index size_t* : index
+ @return bool : whether the index was found
+ */
+bool EphemeridesRecenterAlgorithm::findMoonOfBody(const BodyEphemerisPayload& celestialBody, size_t* index) const {
+    if (this->celestialBodyCount == 0) {
+        throw std::invalid_argument("Requesting a body index but the current celestial body count is 0");
+    }
+    for (size_t i = 0; i < this->celestialBodyCount; ++i) {
+        if (this->celestialBodies[i].originalCentralBodyName == celestialBody.bodySpiceName) {
+            *index = i;
+            return true;
+        }
+    }
+    return false;
+}
+
+/*! @brief Get the index of a body
+ @param celestialBodyName std::string : celestial body name
+ @return size_t : index
+ */
+size_t EphemeridesRecenterAlgorithm::getBodyIndexFromName(const std::string& celestialBodyName) const {
+    if (this->celestialBodyCount == 0) {
+        throw std::invalid_argument("Requesting a body index but the current celestial body count is 0");
+    }
+    for (size_t i = 0; i < this->celestialBodyCount; ++i) {
+        if (this->bodyNames[i] == celestialBodyName) {
+            return i;
+        }
+    }
+    throw std::invalid_argument("Requesting a body index but the current celestial body count is 0");
+}
+
+/*! @brief Set the new zero base body type by name
+ @param bodyName std::string : the new zero base
+ */
+void EphemeridesRecenterAlgorithm::setNewZeroBaseName(const std::string& bodyName) {
+    this->newCentralBodyName = bodyName;
+}
+
+/*! @brief Find the new zero base body type by name
+ @param bodyName std::string : the new zero base
+ */
+size_t EphemeridesRecenterAlgorithm::findNewZeroBaseIndex(const std::string& bodyName) {
+    if (auto indexOfNewZeroBase = std::find(this->bodyNames.begin(), this->bodyNames.end(), bodyName);
+        indexOfNewZeroBase == this->bodyNames.end()) {
+        throw std::invalid_argument("New zero base body was not in the list of existing bodies");
+    } else {
+        return std::distance(this->bodyNames.begin(), indexOfNewZeroBase);
+    }
+}
+
+/*! @brief Get the new celestial body center by name
+ @return std::string : the new zero base
+ */
+std::string EphemeridesRecenterAlgorithm::getNewZeroBase() const { return this->newCentralBodyName; }
+
+/*! @brief Set the previous common zero base of all the celestial bodies entered
+ @param bodyName std::string : the new zero base
+ */
+void EphemeridesRecenterAlgorithm::setPreviousCommonZeroBase(const std::string& bodyName) {
+    if (auto indexOfPreviousZeroBase = std::find(this->bodyNames.begin(), this->bodyNames.end(), bodyName);
+        indexOfPreviousZeroBase == this->bodyNames.end()) {
+        throw std::invalid_argument("Previous zero base body was not in the list of existing bodies");
+    }
+
+    this->previousCentralBodyName = bodyName;
+}
+
+/*! @brief Get the previous common zero base of all the celestial bodies entered
+ @return std::string : the new zero base
+ */
+std::string EphemeridesRecenterAlgorithm::getPreviousCommonZeroBase() const { return this->previousCentralBodyName; }
+
+/*! @brief Get the number of bodies that were entered into the module
+ @return size_t : the number of bodies
+ */
+size_t EphemeridesRecenterAlgorithm::getNumberOfBodies() const { return this->celestialBodyCount; }
+
+/*! @brief Get all the names of the bodies entered
+ @return std::array<std::string, MAX_NUM_CHANGE_BODIES> : an array of names
+ */
+std::array<std::string, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgorithm::getAllNames() const {
+    if (this->celestialBodyCount == 0) {
+        throw std::invalid_argument("Requesting all body names but the current celestial body count is 0");
+    }
+    std::array<std::string, MAX_NUM_CHANGE_BODIES> names{};
+    for (size_t i = 0; i < this->celestialBodyCount; ++i) {
+        if (!this->bodyNames[i].empty()) {
+            names[i] = this->bodyNames[i];
+        }
+    }
+    return names;
+}
+
+/*! @brief Add celestial body by name
+ @param bodyName std::string : the body name to add
+ */
+void EphemeridesRecenterAlgorithm::addBodyEphemerisToRecenter(const std::string& bodyName) {
+    if (this->celestialBodyCount + 1 > MAX_NUM_CHANGE_BODIES) {
+        throw std::invalid_argument("Adding one body too many to the list");
+    }
+    if (auto indexInList = std::find(this->bodyNames.begin(), this->bodyNames.end(), bodyName);
+        indexInList != this->bodyNames.end()) {
+        throw std::invalid_argument("Body already added to list");
+    }
+    this->bodyNames[this->celestialBodyCount] = bodyName;
+    this->celestialBodyCount += 1;
+}
+
+/*! @brief Clear all the bodies from the current list
+ */
+void EphemeridesRecenterAlgorithm::clearAllBodies() {
+    BodyEphemerisPayload emptyBody{};
+    const std::string emptyString{};
+    std::fill(this->celestialBodies.begin(), this->celestialBodies.end(), emptyBody);
+    std::fill(this->bodyNames.begin(), this->bodyNames.end(), emptyString);
+    this->celestialBodyCount = 0;
+}

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
@@ -18,6 +18,7 @@
 
 #include "ephemeridesRecenterAlgorithm.h"
 #include "../freestandingInvalidArgument.h"
+#include <algorithm>
 
 /*! @brief Subtract two C-array vectors
  @param v1 double[3] : vector 1

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "ephemeridesRecenterAlgorithm.h"
+#include "../freestandingInvalidArgument.h"
 
 /*! @brief Subtract two C-array vectors
  @param v1 double[3] : vector 1
@@ -114,7 +115,7 @@ std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgor
  */
 bool EphemeridesRecenterAlgorithm::findMoonOfBody(const BodyEphemerisPayload& celestialBody, size_t* index) const {
     if (this->celestialBodyCount == 0) {
-        throw std::invalid_argument("Requesting a body index but the current celestial body count is 0");
+        FS_THROW_INVALID_ARGUMENT("Requesting a body index but the current celestial body count is 0");
     }
     for (size_t i = 0; i < this->celestialBodyCount; ++i) {
         if (this->celestialBodies[i].originalCentralBodyName == celestialBody.bodySpiceName) {
@@ -131,14 +132,14 @@ bool EphemeridesRecenterAlgorithm::findMoonOfBody(const BodyEphemerisPayload& ce
  */
 size_t EphemeridesRecenterAlgorithm::getBodyIndexFromName(const std::string& celestialBodyName) const {
     if (this->celestialBodyCount == 0) {
-        throw std::invalid_argument("Requesting a body index but the current celestial body count is 0");
+        FS_THROW_INVALID_ARGUMENT("Requesting a body index but the current celestial body count is 0");
     }
     for (size_t i = 0; i < this->celestialBodyCount; ++i) {
         if (this->bodyNames[i] == celestialBodyName) {
             return i;
         }
     }
-    throw std::invalid_argument("Requesting a body index but the current celestial body count is 0");
+    FS_THROW_INVALID_ARGUMENT("Requesting a body index but the current celestial body count is 0");
 }
 
 /*! @brief Set the new zero base body type by name
@@ -154,7 +155,7 @@ void EphemeridesRecenterAlgorithm::setNewZeroBaseName(const std::string& bodyNam
 size_t EphemeridesRecenterAlgorithm::findNewZeroBaseIndex(const std::string& bodyName) {
     if (auto indexOfNewZeroBase = std::find(this->bodyNames.begin(), this->bodyNames.end(), bodyName);
         indexOfNewZeroBase == this->bodyNames.end()) {
-        throw std::invalid_argument("New zero base body was not in the list of existing bodies");
+        FS_THROW_INVALID_ARGUMENT("New zero base body was not in the list of existing bodies");
     } else {
         return std::distance(this->bodyNames.begin(), indexOfNewZeroBase);
     }
@@ -171,7 +172,7 @@ std::string EphemeridesRecenterAlgorithm::getNewZeroBase() const { return this->
 void EphemeridesRecenterAlgorithm::setPreviousCommonZeroBase(const std::string& bodyName) {
     if (auto indexOfPreviousZeroBase = std::find(this->bodyNames.begin(), this->bodyNames.end(), bodyName);
         indexOfPreviousZeroBase == this->bodyNames.end()) {
-        throw std::invalid_argument("Previous zero base body was not in the list of existing bodies");
+        FS_THROW_INVALID_ARGUMENT("Previous zero base body was not in the list of existing bodies");
     }
 
     this->previousCentralBodyName = bodyName;
@@ -192,7 +193,7 @@ size_t EphemeridesRecenterAlgorithm::getNumberOfBodies() const { return this->ce
  */
 std::array<std::string, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgorithm::getAllNames() const {
     if (this->celestialBodyCount == 0) {
-        throw std::invalid_argument("Requesting all body names but the current celestial body count is 0");
+        FS_THROW_INVALID_ARGUMENT("Requesting all body names but the current celestial body count is 0");
     }
     std::array<std::string, MAX_NUM_CHANGE_BODIES> names{};
     for (size_t i = 0; i < this->celestialBodyCount; ++i) {
@@ -208,11 +209,11 @@ std::array<std::string, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgorithm::get
  */
 void EphemeridesRecenterAlgorithm::addBodyEphemerisToRecenter(const std::string& bodyName) {
     if (this->celestialBodyCount + 1 > MAX_NUM_CHANGE_BODIES) {
-        throw std::invalid_argument("Adding one body too many to the list");
+        FS_THROW_INVALID_ARGUMENT("Adding one body too many to the list");
     }
     if (auto indexInList = std::find(this->bodyNames.begin(), this->bodyNames.end(), bodyName);
         indexInList != this->bodyNames.end()) {
-        throw std::invalid_argument("Body already added to list");
+        FS_THROW_INVALID_ARGUMENT("Body already added to list");
     }
     this->bodyNames[this->celestialBodyCount] = bodyName;
     this->celestialBodyCount += 1;

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -19,7 +19,6 @@
 #ifndef F32XIMERA_EPHEM_RECENTER_ALGORITHM_H
 #define F32XIMERA_EPHEM_RECENTER_ALGORITHM_H
 
-#include <architecture/messaging/messaging.h>
 #include "msgPayloadDef/EphemerisMsgF32Payload.h"
 #include <Eigen/Core>
 #include <array>
@@ -59,8 +58,6 @@ class EphemeridesRecenterAlgorithm {
     std::array<std::string, MAX_NUM_CHANGE_BODIES> getAllNames() const;
     void addBodyEphemerisToRecenter(const std::string& bodyName);
     void clearAllBodies();
-
-    ReadFunctor<EphemerisMsgF32Payload> ephBaseInMsg;  //!< Base ephemeris input message
 
    private:
     bool findMoonOfBody(const BodyEphemerisPayload& celestialBody, size_t* index) const;

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -8,6 +8,7 @@
 #define F32XIMERA_EPHEM_RECENTER_ALGORITHM_H
 
 #include "msgPayloadDef/EphemerisMsgF32Payload.h"
+#include <architecture/messaging/messaging.h>
 #include <array>
 #include <string>
 
@@ -18,11 +19,12 @@ inline constexpr int MAX_NUM_CHANGE_BODIES = 20;
  */
 class BodyEphemerisPayload {
    public:
-    std::string bodySpiceName;                                          //!< SPICE name of the body
-    std::string originalCentralBodyName;                                //!< Original reference body for ephemeris data
-    bool isMoon{false};                                                 //!< Body is moon of another body in the list
-    EphemerisMsgF32Payload inputEphemerisPayload{EphemerisMsgF32Payload{}};   //!< Input ephemeris message
-    EphemerisMsgF32Payload outputEphemerisPayload{EphemerisMsgF32Payload{}};  //!< Output ephemeris message after recentering
+    std::string bodySpiceName;            //!< SPICE name of the body
+    std::string originalCentralBodyName;  //!< Original reference body for ephemeris data
+    bool isMoon{false};                   //!< Body is moon of another body in the list
+    EphemerisMsgF32Payload inputEphemerisPayload{EphemerisMsgF32Payload{}};  //!< Input ephemeris message
+    EphemerisMsgF32Payload outputEphemerisPayload{
+        EphemerisMsgF32Payload{}};  //!< Output ephemeris message after recentering
 };
 
 /**

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -20,8 +20,8 @@
 #define F32XIMERA_EPHEM_RECENTER_ALGORITHM_H
 
 #include "msgPayloadDef/EphemerisMsgF32Payload.h"
-#include <Eigen/Core>
 #include <array>
+#include <string>
 
 inline constexpr int MAX_NUM_CHANGE_BODIES = 20;
 

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -1,0 +1,72 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include <architecture/messaging/messaging.h>
+#include <architecture/msgPayloadDef/EphemerisMsgPayload.h>
+#include <Eigen/Core>
+#include <array>
+
+inline constexpr int MAX_NUM_CHANGE_BODIES = 20;
+
+/**
+ * @brief Container for input/output ephemeris messages used in recentering.
+ */
+class BodyEphemerisPayload {
+   public:
+    std::string bodySpiceName;                                          //!< SPICE name of the body
+    std::string originalCentralBodyName;                                //!< Original reference body for ephemeris data
+    bool isMoon{false};                                                 //!< Body is moon of another body in the list
+    EphemerisMsgPayload inputEphemerisPayload{EphemerisMsgPayload{}};   //!< Input ephemeris message
+    EphemerisMsgPayload outputEphemerisPayload{EphemerisMsgPayload{}};  //!< Output ephemeris message after recentering
+};
+
+/**
+ * @brief Basilisk model to recenter ephemeris data from one central body to another.
+ *
+ * This class processes a set of body ephemerides and recomputes their
+ * positions and velocities relative to a new central body.
+ */
+class EphemeridesRecenterAlgorithm {
+   public:
+    void reset();
+    std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> updateState(
+        const std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES>& newBody);
+    size_t getBodyIndexFromName(const std::string& celestialBodyName) const;
+    void setNewZeroBaseName(const std::string& bodyName);
+    size_t findNewZeroBaseIndex(const std::string& bodyName);
+    std::string getNewZeroBase() const;
+    void setPreviousCommonZeroBase(const std::string& bodyName);
+    std::string getPreviousCommonZeroBase() const;
+    size_t getNumberOfBodies() const;
+    std::array<std::string, MAX_NUM_CHANGE_BODIES> getAllNames() const;
+    void addBodyEphemerisToRecenter(const std::string& bodyName);
+    void clearAllBodies();
+
+    ReadFunctor<EphemerisMsgPayload> ephBaseInMsg;  //!< Base ephemeris input message
+
+   private:
+    bool findMoonOfBody(const BodyEphemerisPayload& celestialBody, size_t* index) const;
+
+    std::string newCentralBodyName{};
+    std::array<std::string, MAX_NUM_CHANGE_BODIES> bodyNames{};
+    size_t celestialBodyCount{};  //!< Number of primary bodies
+    size_t newCentralIndex{};
+    std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> celestialBodies{};  //!< All celestial bodies involved
+    BodyEphemerisPayload previousCentralBody{};                                 //!< Previous reference body
+    std::string previousCentralBodyName{};
+};

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -16,6 +16,9 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
+#ifndef F32XIMERA_EPHEM_RECENTER_ALGORITHM_H
+#define F32XIMERA_EPHEM_RECENTER_ALGORITHM_H
+
 #include <architecture/messaging/messaging.h>
 #include <architecture/msgPayloadDef/EphemerisMsgPayload.h>
 #include <Eigen/Core>
@@ -70,3 +73,5 @@ class EphemeridesRecenterAlgorithm {
     BodyEphemerisPayload previousCentralBody{};                                 //!< Previous reference body
     std::string previousCentralBodyName{};
 };
+
+#endif

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -20,7 +20,7 @@
 #define F32XIMERA_EPHEM_RECENTER_ALGORITHM_H
 
 #include <architecture/messaging/messaging.h>
-#include <architecture/msgPayloadDef/EphemerisMsgPayload.h>
+#include "msgPayloadDef/EphemerisMsgF32Payload.h"
 #include <Eigen/Core>
 #include <array>
 
@@ -34,8 +34,8 @@ class BodyEphemerisPayload {
     std::string bodySpiceName;                                          //!< SPICE name of the body
     std::string originalCentralBodyName;                                //!< Original reference body for ephemeris data
     bool isMoon{false};                                                 //!< Body is moon of another body in the list
-    EphemerisMsgPayload inputEphemerisPayload{EphemerisMsgPayload{}};   //!< Input ephemeris message
-    EphemerisMsgPayload outputEphemerisPayload{EphemerisMsgPayload{}};  //!< Output ephemeris message after recentering
+    EphemerisMsgF32Payload inputEphemerisPayload{EphemerisMsgF32Payload{}};   //!< Input ephemeris message
+    EphemerisMsgF32Payload outputEphemerisPayload{EphemerisMsgF32Payload{}};  //!< Output ephemeris message after recentering
 };
 
 /**
@@ -60,7 +60,7 @@ class EphemeridesRecenterAlgorithm {
     void addBodyEphemerisToRecenter(const std::string& bodyName);
     void clearAllBodies();
 
-    ReadFunctor<EphemerisMsgPayload> ephBaseInMsg;  //!< Base ephemeris input message
+    ReadFunctor<EphemerisMsgF32Payload> ephBaseInMsg;  //!< Base ephemeris input message
 
    private:
     bool findMoonOfBody(const BodyEphemerisPayload& celestialBody, size_t* index) const;

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -1,20 +1,8 @@
 /*
- ISC License
+ MIT License
 
  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
-
- Permission to use, copy, modify, and/or distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
-
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-*/
+ */
 
 #ifndef F32XIMERA_EPHEM_RECENTER_ALGORITHM_H
 #define F32XIMERA_EPHEM_RECENTER_ALGORITHM_H

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterF32.i
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterF32.i
@@ -16,7 +16,7 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
-%module ephemeridesRecenter
+%module ephemeridesRecenterF32
 %{
    #include "ephemeridesRecenter.h"
 %}

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterF32.i
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterF32.i
@@ -1,21 +1,9 @@
 /*
- ISC License
+ MIT License
 
  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
-
- Permission to use, copy, modify, and/or distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
-
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
  */
+
 %module ephemeridesRecenterF32
 %{
    #include "ephemeridesRecenter.h"

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterF32.i
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterF32.i
@@ -29,4 +29,4 @@
 %template(StringArray10) std::array<std::string, MAX_NUM_CHANGE_BODIES>;
 
 %include "ephemeridesRecenter.h"
-%include <architecture/msgPayloadDef/EphemerisMsgPayload.h>
+%include "msgPayloadDef/EphemerisMsgF32Payload.h"

--- a/algorithms/ephemeridesRecenter/test/test_ephemeridesRecenter.py
+++ b/algorithms/ephemeridesRecenter/test/test_ephemeridesRecenter.py
@@ -1,0 +1,418 @@
+# ISC License
+#
+# Copyright (c) 2025, Laboratory for Atmospheric Space Physics, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import inspect
+import os
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+
+from xmera.utilities import SimulationBaseClass
+from xmera.fswAlgorithms import ephemeridesRecenter
+from xmera.architecture import messaging
+
+def test_body_recenter():
+    """ Test ephemeridesRecenter. """
+    mars_central_body()
+
+def test_moon_recenter():
+    """ Test ephemeridesRecenter. """
+    moon_central_body()
+
+def test_clear_recenter():
+    """ Test ephemeridesRecenter. """
+    clearing_values()
+
+def mars_central_body():
+    """ Test the ephemeridesRecenter module. Setup a simulation, """
+
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName,  int(0.5e9)))
+
+    ephemRecenter = ephemeridesRecenter.EphemeridesRecenter()
+    ephemRecenter.modelTag = "ephemeridesRecenter"
+    unitTestSim.AddModelToTask(unitTaskName, ephemRecenter)
+
+    list_of_bodies = []
+    # Create bodies to add to the module
+    sunBody = ephemeridesRecenter.BodyEphemeris()
+    sunInputPayload = messaging.EphemerisMsgPayload()
+    position = [0,0,0]
+    velocity = [0,0,0]
+    sunInputPayload.r_BdyZero_N = position
+    sunInputPayload.v_BdyZero_N = velocity
+    sunInputPayload.timeTag = 1234.0
+    sunInputMessage = messaging.EphemerisMsg().write(sunInputPayload)
+    sunBody.inputEphemerisMsg.subscribeTo(sunInputMessage)
+    sunBody.bodySpiceName = "sun"
+    sunBody.originalCentralBodyName = "sun"
+    list_of_bodies.append(sunBody)
+
+    # Set this message
+    earthBody = ephemeridesRecenter.BodyEphemeris()
+    earthInputPayload = messaging.EphemerisMsgPayload()
+    position = [1000, -200, 100]
+    velocity = [10, 0, -8]
+    earthInputPayload.r_BdyZero_N = position
+    earthInputPayload.v_BdyZero_N = velocity
+    earthInputPayload.timeTag = 1234.0
+    earthInputMessage = messaging.EphemerisMsg().write(earthInputPayload)
+    earthBody.inputEphemerisMsg.subscribeTo(earthInputMessage)
+    earthBody.bodySpiceName = "earth"
+    earthBody.originalCentralBodyName = "sun"
+    list_of_bodies.append(earthBody)
+
+    marsBody = ephemeridesRecenter.BodyEphemeris()
+    marsInputPayload = messaging.EphemerisMsgPayload()
+    position = [-4000, 3000, 10000]
+    velocity = [-1, -2, 1]
+    marsInputPayload.r_BdyZero_N = position
+    marsInputPayload.v_BdyZero_N = velocity
+    marsInputPayload.timeTag = 1234.0
+    marsInputMessage = messaging.EphemerisMsg().write(marsInputPayload)
+    marsBody.inputEphemerisMsg.subscribeTo(marsInputMessage)
+    marsBody.bodySpiceName = "mars"
+    marsBody.originalCentralBodyName = "sun"
+    list_of_bodies.append(marsBody)
+
+    moonBody = ephemeridesRecenter.BodyEphemeris()
+    moonInputPayload = messaging.EphemerisMsgPayload()
+    position = [-50, 30, 100]
+    velocity = [-0.5, -0.2, 0.1]
+    moonInputPayload.r_BdyZero_N = position
+    moonInputPayload.v_BdyZero_N = velocity
+    moonInputPayload.timeTag = 1234.0
+    moonInputMessage = messaging.EphemerisMsg().write(moonInputPayload)
+    moonBody.inputEphemerisMsg.subscribeTo(moonInputMessage)
+    moonBody.bodySpiceName = "moon"
+    moonBody.originalCentralBodyName = "earth"
+    list_of_bodies.append(moonBody)
+
+    dataLogList = list()
+    names = []
+    for body in list_of_bodies:
+        ephemRecenter.addBodyEphemerisToRecenter(body)
+        names.append(body.bodySpiceName)
+    for body in list_of_bodies:
+        index = ephemRecenter.getBodyIndexFromName(body.bodySpiceName)
+        rec = ephemRecenter.recenteredEphemerisOutputMsgs[index].recorder()
+        dataLogList.append(rec)
+        unitTestSim.AddModelToTask(unitTaskName, rec)
+
+    ephemRecenter.setPreviousCommonZeroBase("sun")
+    ephemRecenter.setNewZeroBase("mars")
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(0)
+    unitTestSim.ExecuteSimulation()
+
+    mars_r_recentered = np.array(dataLogList[2].r_BdyZero_N).reshape([3,])
+    mars_v_recentered = np.array(dataLogList[2].v_BdyZero_N).reshape([3,])
+    mars_time_tag = dataLogList[2].timeTag
+
+    np.testing.assert_array_almost_equal(mars_r_recentered, np.zeros(3), 15, "Mars position error")
+    np.testing.assert_array_almost_equal(mars_v_recentered, np.zeros(3), 15, "Mars velocity error")
+    np.testing.assert_equal(mars_time_tag, marsInputPayload.timeTag, "Mars time tag error")
+
+    earth_r_recentered = np.array(dataLogList[1].r_BdyZero_N).reshape([3,])
+    earth_v_recentered = np.array(dataLogList[1].v_BdyZero_N).reshape([3,])
+    earth_time_tag = dataLogList[1].timeTag
+
+    np.testing.assert_array_almost_equal(earth_r_recentered,
+                                  np.array(earthInputPayload.r_BdyZero_N) - np.array(marsInputPayload.r_BdyZero_N),
+                                         15,
+                                  "Earth position error")
+    np.testing.assert_array_almost_equal(earth_v_recentered,
+                                  np.array(earthInputPayload.v_BdyZero_N) - np.array(marsInputPayload.v_BdyZero_N),
+                                         15,
+                                  "Earth velocity error")
+    np.testing.assert_equal(earth_time_tag, earthInputPayload.timeTag, "Earth time tag error")
+
+    sun_r_recentered = np.array(dataLogList[0].r_BdyZero_N).reshape([3,])
+    sun_v_recentered = np.array(dataLogList[0].v_BdyZero_N).reshape([3,])
+    sun_time_tag = dataLogList[0].timeTag
+
+    np.testing.assert_array_almost_equal(sun_r_recentered,
+                                  np.array(sunInputPayload.r_BdyZero_N) - np.array(marsInputPayload.r_BdyZero_N),
+                                         15,
+                                  "Sun position error")
+    np.testing.assert_array_almost_equal(sun_v_recentered,
+                                  np.array(sunInputPayload.v_BdyZero_N) - np.array(marsInputPayload.v_BdyZero_N),
+                                         15,
+                                  "Sun velocity error")
+    np.testing.assert_equal(sun_time_tag, sunInputPayload.timeTag, "Sun time tag error")
+
+    moon_r_recentered = np.array(dataLogList[3].r_BdyZero_N).reshape([3,])
+    moon_v_recentered = np.array(dataLogList[3].v_BdyZero_N).reshape([3,])
+    moon_time_tag = dataLogList[3].timeTag
+
+    np.testing.assert_array_almost_equal(moon_r_recentered,
+                                  np.array(earthInputPayload.r_BdyZero_N) - np.array(marsInputPayload.r_BdyZero_N)
+                                  + np.array(moonInputPayload.r_BdyZero_N),
+                                         15,
+                                  "Moon position error")
+    np.testing.assert_array_almost_equal(moon_v_recentered,
+                                  np.array(earthInputPayload.v_BdyZero_N) - np.array(marsInputPayload.v_BdyZero_N)
+                                  +np.array(moonInputPayload.v_BdyZero_N),
+                                         15,
+                                  "Moon velocity error")
+    np.testing.assert_equal(moon_time_tag, moonInputPayload.timeTag, "Moon time tag error")
+
+def moon_central_body():
+    """ Test the ephemeridesRecenter module. Setup a simulation, """
+
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName,  int(0.5e9)))
+
+    ephemRecenter = ephemeridesRecenter.EphemeridesRecenter()
+    ephemRecenter.modelTag = "ephemeridesRecenter"
+    unitTestSim.AddModelToTask(unitTaskName, ephemRecenter)
+
+    list_of_bodies = []
+    # Create bodies to add to the module
+    sunBody = ephemeridesRecenter.BodyEphemeris()
+    sunInputPayload = messaging.EphemerisMsgPayload()
+    position = [80000, 10000, -9000]
+    velocity = [-5, 2, -0.9]
+    sunInputPayload.r_BdyZero_N = position
+    sunInputPayload.v_BdyZero_N = velocity
+    sunInputPayload.timeTag = 1234.0
+    sunInputMessage = messaging.EphemerisMsg().write(sunInputPayload)
+    sunBody.inputEphemerisMsg.subscribeTo(sunInputMessage)
+    sunBody.bodySpiceName = "sun"
+    sunBody.originalCentralBodyName = "saturn"
+    list_of_bodies.append(sunBody)
+
+    # Set this message
+    earthBody = ephemeridesRecenter.BodyEphemeris()
+    earthInputPayload = messaging.EphemerisMsgPayload()
+    position = [1000, -200, 100]
+    velocity = [10, 0, -8]
+    earthInputPayload.r_BdyZero_N = position
+    earthInputPayload.v_BdyZero_N = velocity
+    earthInputPayload.timeTag = 1234.0
+    earthInputMessage = messaging.EphemerisMsg().write(earthInputPayload)
+    earthBody.inputEphemerisMsg.subscribeTo(earthInputMessage)
+    earthBody.bodySpiceName = "earth"
+    earthBody.originalCentralBodyName = "saturn"
+    list_of_bodies.append(earthBody)
+
+    marsBody = ephemeridesRecenter.BodyEphemeris()
+    marsInputPayload = messaging.EphemerisMsgPayload()
+    position = [-4000, 3000, 10000]
+    velocity = [-1, -2, 1]
+    marsInputPayload.r_BdyZero_N = position
+    marsInputPayload.v_BdyZero_N = velocity
+    marsInputPayload.timeTag = 1234.0
+    marsInputMessage = messaging.EphemerisMsg().write(marsInputPayload)
+    marsBody.inputEphemerisMsg.subscribeTo(marsInputMessage)
+    marsBody.bodySpiceName = "mars"
+    marsBody.originalCentralBodyName = "saturn"
+    list_of_bodies.append(marsBody)
+
+    moonBody = ephemeridesRecenter.BodyEphemeris()
+    moonInputPayload = messaging.EphemerisMsgPayload()
+    position = [-50, 30, 100]
+    velocity = [-0.5, -0.2, 0.1]
+    moonInputPayload.r_BdyZero_N = position
+    moonInputPayload.v_BdyZero_N = velocity
+    moonInputPayload.timeTag = 1234.0
+    moonInputMessage = messaging.EphemerisMsg().write(moonInputPayload)
+    moonBody.inputEphemerisMsg.subscribeTo(moonInputMessage)
+    moonBody.bodySpiceName = "moon"
+    moonBody.originalCentralBodyName = "earth"
+    list_of_bodies.append(moonBody)
+
+    saturnBody = ephemeridesRecenter.BodyEphemeris()
+    saturnInputPayload = messaging.EphemerisMsgPayload()
+    position = [0,0,0]
+    velocity = [0,0,0]
+    saturnInputPayload.r_BdyZero_N = position
+    saturnInputPayload.v_BdyZero_N = velocity
+    saturnInputPayload.timeTag = 1234.0
+    saturnInputMessage = messaging.EphemerisMsg().write(saturnInputPayload)
+    saturnBody.inputEphemerisMsg.subscribeTo(saturnInputMessage)
+    saturnBody.bodySpiceName = "saturn"
+    saturnBody.originalCentralBodyName = "saturn"
+    list_of_bodies.append(saturnBody)
+
+    dataLogList = list()
+    names = []
+    for body in list_of_bodies:
+        ephemRecenter.addBodyEphemerisToRecenter(body)
+        names.append(body.bodySpiceName)
+    for body in list_of_bodies:
+        index = ephemRecenter.getBodyIndexFromName(body.bodySpiceName)
+        rec = ephemRecenter.recenteredEphemerisOutputMsgs[index].recorder()
+        dataLogList.append(rec)
+        unitTestSim.AddModelToTask(unitTaskName, rec)
+
+    ephemRecenter.setPreviousCommonZeroBase("saturn")
+    ephemRecenter.setNewZeroBase("moon")
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(0)
+    unitTestSim.ExecuteSimulation()
+
+    moon_r_recentered = np.array(dataLogList[3].r_BdyZero_N).reshape([3,])
+    moon_v_recentered = np.array(dataLogList[3].v_BdyZero_N).reshape([3,])
+    moon_time_tag = dataLogList[3].timeTag
+
+    np.testing.assert_array_almost_equal(moon_r_recentered, np.zeros(3), 15,"Moon position error")
+    np.testing.assert_array_almost_equal(moon_v_recentered, np.zeros(3), 15, "Moon velocity error")
+    np.testing.assert_equal(moon_time_tag, moonInputPayload.timeTag, "Moon time tag error")
+
+    earth_r_recentered = np.array(dataLogList[1].r_BdyZero_N).reshape([3,])
+    earth_v_recentered = np.array(dataLogList[1].v_BdyZero_N).reshape([3,])
+    earth_time_tag = dataLogList[1].timeTag
+
+    np.testing.assert_array_almost_equal(earth_r_recentered,
+                                  - np.array(moonInputPayload.r_BdyZero_N),
+                                         15,
+                                  "Earth position error")
+    np.testing.assert_array_almost_equal(earth_v_recentered,
+                                  - np.array(moonInputPayload.v_BdyZero_N),
+                                         15,
+                                  "Earth velocity error")
+    np.testing.assert_array_almost_equal(earth_time_tag, earthInputPayload.timeTag, 15, "Earth time tag error")
+
+    sun_r_recentered = np.array(dataLogList[0].r_BdyZero_N).reshape([3,])
+    sun_v_recentered = np.array(dataLogList[0].v_BdyZero_N).reshape([3,])
+    sun_time_tag = dataLogList[0].timeTag
+
+    np.testing.assert_array_almost_equal(sun_r_recentered,
+                                  np.array(sunInputPayload.r_BdyZero_N) -
+                                  (np.array(moonInputPayload.r_BdyZero_N) + np.array(earthInputPayload.r_BdyZero_N)),
+                                         15,
+                                  "Sun position error")
+    np.testing.assert_array_almost_equal(sun_v_recentered,
+                                  np.array(sunInputPayload.v_BdyZero_N) -
+                                  (np.array(moonInputPayload.v_BdyZero_N) + np.array(earthInputPayload.v_BdyZero_N)),
+                                         15,
+                                  "Sun velocity error")
+    np.testing.assert_equal(sun_time_tag, sunInputPayload.timeTag, "Sun time tag error")
+
+    saturn_r_recentered = np.array(dataLogList[4].r_BdyZero_N).reshape([3,])
+    saturn_v_recentered = np.array(dataLogList[4].v_BdyZero_N).reshape([3,])
+    saturn_time_tag = dataLogList[3].timeTag
+
+    np.testing.assert_array_almost_equal(saturn_r_recentered,
+                                  np.array(saturnInputPayload.r_BdyZero_N) -
+                                  (np.array(moonInputPayload.r_BdyZero_N) + np.array(earthInputPayload.r_BdyZero_N)),
+                                         15,
+                                  "Saturn position error")
+    np.testing.assert_array_almost_equal(saturn_v_recentered,
+                                  np.array(saturnInputPayload.v_BdyZero_N) -
+                                  (np.array(moonInputPayload.v_BdyZero_N) + np.array(earthInputPayload.v_BdyZero_N)),
+                                         15,
+                                  "Saturn velocity error")
+    np.testing.assert_equal(saturn_time_tag, saturnInputPayload.timeTag, "Saturn time tag error")
+
+def clearing_values():
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName,  int(0.5e9)))
+
+    ephemRecenter = ephemeridesRecenter.EphemeridesRecenter()
+    ephemRecenter.modelTag = "ephemeridesRecenter"
+    unitTestSim.AddModelToTask(unitTaskName, ephemRecenter)
+
+    list_of_bodies = []
+    # Create bodies to add to the module
+    sunBody = ephemeridesRecenter.BodyEphemeris()
+    sunInputPayload = messaging.EphemerisMsgPayload()
+    position = [0,0,0]
+    velocity = [0,0,0]
+    sunInputPayload.r_BdyZero_N = position
+    sunInputPayload.v_BdyZero_N = velocity
+    sunInputPayload.timeTag = 1234.0
+    sunInputMessage = messaging.EphemerisMsg().write(sunInputPayload)
+    sunBody.inputEphemerisMsg.subscribeTo(sunInputMessage)
+    sunBody.bodySpiceName = "sun"
+    sunBody.originalCentralBodyName = "sun"
+    list_of_bodies.append(sunBody)
+
+    # Set this message
+    earthBody = ephemeridesRecenter.BodyEphemeris()
+    earthInputPayload = messaging.EphemerisMsgPayload()
+    position = [1000, -200, 100]
+    velocity = [10, 0, -8]
+    earthInputPayload.r_BdyZero_N = position
+    earthInputPayload.v_BdyZero_N = velocity
+    earthInputPayload.timeTag = 1234.0
+    earthInputMessage = messaging.EphemerisMsg().write(earthInputPayload)
+    earthBody.inputEphemerisMsg.subscribeTo(earthInputMessage)
+    earthBody.bodySpiceName = "earth"
+    earthBody.originalCentralBodyName = "sun"
+    list_of_bodies.append(earthBody)
+
+    marsBody = ephemeridesRecenter.BodyEphemeris()
+    marsInputPayload = messaging.EphemerisMsgPayload()
+    position = [-4000, 3000, 10000]
+    velocity = [-1, -2, 1]
+    marsInputPayload.r_BdyZero_N = position
+    marsInputPayload.v_BdyZero_N = velocity
+    marsInputPayload.timeTag = 1234.0
+    marsInputMessage = messaging.EphemerisMsg().write(marsInputPayload)
+    marsBody.inputEphemerisMsg.subscribeTo(marsInputMessage)
+    marsBody.bodySpiceName = "mars"
+    marsBody.originalCentralBodyName = "sun"
+    list_of_bodies.append(marsBody)
+
+    moonBody = ephemeridesRecenter.BodyEphemeris()
+    moonInputPayload = messaging.EphemerisMsgPayload()
+    position = [-50, 30, 100]
+    velocity = [-0.5, -0.2, 0.1]
+    moonInputPayload.r_BdyZero_N = position
+    moonInputPayload.v_BdyZero_N = velocity
+    moonInputPayload.timeTag = 1234.0
+    moonInputMessage = messaging.EphemerisMsg().write(moonInputPayload)
+    moonBody.inputEphemerisMsg.subscribeTo(moonInputMessage)
+    moonBody.bodySpiceName = "moon"
+    moonBody.originalCentralBodyName = "earth"
+    list_of_bodies.append(moonBody)
+
+    names = []
+    for body in list_of_bodies:
+        ephemRecenter.addBodyEphemerisToRecenter(body)
+        names.append(body.bodySpiceName)
+
+    ephemRecenter.setPreviousCommonZeroBase("sun")
+    ephemRecenter.setNewZeroBase("mars")
+
+    np.testing.assert_equal(ephemRecenter.getNumberOfBodies(), len(list_of_bodies), "Wrong number of bodies")
+    np.testing.assert_equal(ephemRecenter.getAllNames()[:ephemRecenter.getNumberOfBodies()], names, "Wrong names for bodies")
+
+    np.testing.assert_equal(ephemRecenter.getNewZeroBase(), "mars", "Wrong new zero base")
+    np.testing.assert_equal(ephemRecenter.getPreviousCommonZeroBase(), "sun", "Wrong previous zero base")
+
+    ephemRecenter.clearAllBodies()
+    np.testing.assert_equal(ephemRecenter.getNumberOfBodies(), 0, "Clear bodies did no work")
+
+
+
+if __name__ == '__main__':
+    mars_central_body()

--- a/algorithms/inertial3D/_tests/test_inertial3D.py
+++ b/algorithms/inertial3D/_tests/test_inertial3D.py
@@ -12,11 +12,11 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
 # Import all of the modules that we are going to be called in this simulation
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport                  # general support file with common unit test functions
-from Basilisk.fp32 import inertial3DF32                   # import the module that is to be tested
-from Basilisk.utilities import macros
-from Basilisk.architecture import messaging
+from xmera.utilities import SimulationBaseClass
+from xmera.utilities import unitTestSupport                  # general support file with common unit test functions
+from xmera.fp32 import inertial3DF32                   # import the module that is to be tested
+from xmera.utilities import macros
+from xmera.architecture import messaging
 
 
 @pytest.mark.parametrize("set_SigmaRN", [True, False])

--- a/algorithms/msgPayloadDef/EphemerisMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/EphemerisMsgF32Payload.h
@@ -9,11 +9,11 @@
 
 /*! @brief Message structure used to write ephemeris states out to other modules*/
 typedef struct {
-    double r_BdyZero_N[3]; //!< [m] Position of orbital body
-    double v_BdyZero_N[3]; //!< [m/s] Velocity of orbital body
-    float sigma_BN[3];     //!< MRP attitude of the orbital body fixed frame relative to inertial
-    float omega_BN_B[3];   //!< [r/s] angular velocity of the orbital body relative to inertial
-    double timeTag;        //!< [s] vehicle Time-tag for state
+    double r_BdyZero_N[3];  //!< [m] Position of orbital body
+    double v_BdyZero_N[3];  //!< [m/s] Velocity of orbital body
+    float sigma_BN[3];      //!< MRP attitude of the orbital body fixed frame relative to inertial
+    float omega_BN_B[3];    //!< [r/s] angular velocity of the orbital body relative to inertial
+    double timeTag;         //!< [s] vehicle Time-tag for state
 } EphemerisMsgF32Payload;
 
 #endif

--- a/algorithms/msgPayloadDef/EphemerisMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/EphemerisMsgF32Payload.h
@@ -9,11 +9,11 @@
 
 /*! @brief Message structure used to write ephemeris states out to other modules*/
 typedef struct {
-    float r_BdyZero_N[3];  //!< [m] Position of orbital body
-    float v_BdyZero_N[3];  //!< [m/s] Velocity of orbital body
+    double r_BdyZero_N[3]; //!< [m] Position of orbital body
+    double v_BdyZero_N[3]; //!< [m/s] Velocity of orbital body
     float sigma_BN[3];     //!< MRP attitude of the orbital body fixed frame relative to inertial
     float omega_BN_B[3];   //!< [r/s] angular velocity of the orbital body relative to inertial
-    float timeTag;         //!< [s] vehicle Time-tag for state
+    double timeTag;        //!< [s] vehicle Time-tag for state
 } EphemerisMsgF32Payload;
 
 #endif

--- a/algorithms/msgPayloadDef/NavAttMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/NavAttMsgF32Payload.h
@@ -9,7 +9,7 @@
 
 /*! @brief Structure used to define the output definition for attitude guidance*/
 typedef struct {
-    float timeTag;          //!< [s]   Current vehicle time-tag associated with measurements*/
+    double timeTag;         //!< [s]   Current vehicle time-tag associated with measurements*/
     float sigma_BN[3];      //!<       Current spacecraft attitude (MRPs) of body relative to inertial */
     float omega_BN_B[3];    //!< [r/s] Current spacecraft angular velocity vector of body frame B relative to inertial frame N, in B frame components
     float vehSunPntBdy[3];  //!<       Current sun pointing vector in body frame

--- a/algorithms/msgPayloadDef/NavAttMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/NavAttMsgF32Payload.h
@@ -11,9 +11,9 @@
 typedef struct {
     double timeTag;         //!< [s]   Current vehicle time-tag associated with measurements*/
     float sigma_BN[3];      //!<       Current spacecraft attitude (MRPs) of body relative to inertial */
-    float omega_BN_B[3];    //!< [r/s] Current spacecraft angular velocity vector of body frame B relative to inertial frame N, in B frame components
+    float omega_BN_B[3];    //!< [r/s] Current spacecraft angular velocity vector of body frame B relative to inertial
+                            //!< frame N, in B frame components
     float vehSunPntBdy[3];  //!<       Current sun pointing vector in body frame
-}NavAttMsgF32Payload;
-
+} NavAttMsgF32Payload;
 
 #endif

--- a/algorithms/msgPayloadDef/NavTransMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/NavTransMsgF32Payload.h
@@ -9,9 +9,9 @@
 
 /*! @brief Structure used to define the output definition for translatoin guidance*/
 typedef struct {
-    float timeTag;        //!< [s]   Current vehicle time-tag associated with measurements*/
-    float r_BN_N[3];      //!< [m]   Current inertial spacecraft position vector in inertial frame N components
-    float v_BN_N[3];      //!< [m/s] Current inertial velocity of the spacecraft in inertial frame N components
+    double timeTag;       //!< [s]   Current vehicle time-tag associated with measurements*/
+    double r_BN_N[3];     //!< [m]   Current inertial spacecraft position vector in inertial frame N components
+    double v_BN_N[3];     //!< [m/s] Current inertial velocity of the spacecraft in inertial frame N components
     float vehAccumDV[3];  //!< [m/s] Total accumulated delta-velocity for s/c
 } NavTransMsgF32Payload;
 

--- a/algorithms/navAggregate/_tests/test_navAggregate.py
+++ b/algorithms/navAggregate/_tests/test_navAggregate.py
@@ -11,16 +11,16 @@ import pytest
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
-bskName = 'Basilisk'
-splitPath = path.split(bskName)
+xmeraName = 'xmera'
+splitPath = path.split(xmeraName)
 
 
 # Import all of the modules that we are going to be called in this simulation
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport
-from Basilisk.fp32 import navAggregateF32
-from Basilisk.utilities import macros
-from Basilisk.architecture import messaging
+from xmera.utilities import SimulationBaseClass
+from xmera.utilities import unitTestSupport
+from xmera.fp32 import navAggregateF32
+from xmera.utilities import macros
+from xmera.architecture import messaging
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
 # @pytest.mark.skipif(conditionstring)

--- a/algorithms/navAggregate/navAggregate.rst
+++ b/algorithms/navAggregate/navAggregate.rst
@@ -49,7 +49,7 @@ The outline to set up the navAggregate module in Python is as follows:
 
 #. Import the module::
 
-    from Basilisk.fswAlgorithms import navAggregate
+    from xmera.fswAlgorithms import navAggregate
 
 #. Create an instantiation::
 

--- a/algorithms/navAggregate/navAggregateAlgorithm.cpp
+++ b/algorithms/navAggregate/navAggregateAlgorithm.cpp
@@ -10,16 +10,15 @@
 #include <stdio.h>
 
 /**
- * @brief Copy a 3x1 float vector.
+ * @brief Copy a 3x1 vector.
  * @param v The vector to be copied.
  * @param result The vector copy.
  */
-static void v3Copy(float v[3], float result[3]) {
-    size_t dim = 3;
-    size_t i;
-    for (i = 0; i < dim; i++) {
-        result[i] = v[i];
-    }
+template <typename ScalarT>
+static void v3Copy(ScalarT const v[3], ScalarT result[3]) {
+    result[0] = v[0];
+    result[1] = v[1];
+    result[2] = v[2];
 }
 
 /*! This method takes the navigation message snippets created by the various

--- a/algorithms/rateControl/_tests/test_rateControl.py
+++ b/algorithms/rateControl/_tests/test_rateControl.py
@@ -5,10 +5,10 @@
 import numpy as np
 import pytest
 
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.fp32 import rateControlF32
-from Basilisk.utilities import macros
-from Basilisk.architecture import messaging
+from xmera.utilities import SimulationBaseClass
+from xmera.fp32 import rateControlF32
+from xmera.utilities import macros
+from xmera.architecture import messaging
 
 @pytest.mark.parametrize("setExtTorque", [False, True])
 

--- a/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
+++ b/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
@@ -7,15 +7,15 @@ import os
 
 import numpy as np
 import pytest
-from Basilisk.architecture import messaging
-from Basilisk.fp32 import stepperMotorControllerF32
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import macros
+from xmera.architecture import messaging
+from xmera.fp32 import stepperMotorControllerF32
+from xmera.utilities import SimulationBaseClass
+from xmera.utilities import macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
-bskName = 'Basilisk'
-splitPath = path.split(bskName)
+xmeraName = 'xmera'
+splitPath = path.split(xmeraName)
 
 # the inputs are rounded to single precision such that the module and python use the same precision for the inputs.
 # Otherwise, the ceiling/floor function with a division input may result in a difference of 1,

--- a/algorithms/sunSearch/_tests/test_sunSearch.py
+++ b/algorithms/sunSearch/_tests/test_sunSearch.py
@@ -13,11 +13,11 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
 
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.fp32 import sunSearchF32
-from Basilisk.utilities import macros
-from Basilisk.architecture import messaging
-from Basilisk.architecture import sim_model
+from xmera.utilities import SimulationBaseClass
+from xmera.fp32 import sunSearchF32
+from xmera.utilities import macros
+from xmera.architecture import messaging
+from xmera.architecture import sim_model
 
 
 def computeKinematicProperties(theta_R, T_R, u_M, I, omega_M):

--- a/algorithms/sunlineEphem/_tests/test_sunlineEphem.py
+++ b/algorithms/sunlineEphem/_tests/test_sunlineEphem.py
@@ -4,10 +4,10 @@
 
 import numpy as np
 
-from Basilisk.architecture import messaging
-from Basilisk.fp32 import sunlineEphemF32
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import macros
+from xmera.architecture import messaging
+from xmera.fp32 import sunlineEphemF32
+from xmera.utilities import SimulationBaseClass
+from xmera.utilities import macros
 
 def test_sunlineEphem():
     unitTaskName = "unitTask"               # arbitrary name (don't change)


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-1841
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
The ephemeridesRecenter module is updated to use floats instead of doubles. The module is also refactored where needed.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
All tests pass.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
The doubles of translational states will be converted at a later point.