### PR TITLE
Add clang-tidy static analysis workflow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+Checks: >
+  bugprone-*
+  ,clang-analyzer-*
+  ,clang-diagnostic-*
+  ,cppcoreguidelines-*
+  ,cert-dcl21-cpp
+  ,cert-dcl58-cpp
+  ,cert-err34-c
+  ,cert-err52-cpp
+  ,cert-err60-cpp
+  ,cert-flp30-c
+  ,cert-msc50-cpp
+  ,cert-msc51-cpp
+  ,cert-str34-c
+  ,google-default-arguments
+  ,google-explicit-constructor
+  ,google-runtime-operator
+  ,hicpp-*
+  ,misc-*
+  ,mpi-buffer-deref
+  ,mpi-type-mismatch
+  ,modernize-*
+  ,openmp-use-default-none
+  ,performance-*
+  ,portability-simd-intrinsics
+  ,readability-*
+  ,-cppcoreguidelines-avoid-non-const-global-variables
+
+WarningsAsErrors: '*'
+CheckOptions:
+  - key: modernize-use-auto.MinTypeNameLength
+    value: '5'
+  - key: cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllCapsName
+    value: '1'
+  - key: readability-function-size.StatementThreshold
+    value: '200'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -273,11 +273,6 @@ jobs:
           cmake --install build --prefix $(pwd)/dist
           python -m pip install -e .
 
-      - name: Install fp32-fsw-xmera (editable, if package)
-        run: |
-          source .venv/bin/activate
-          if [[ -f pyproject.toml || -f setup.py ]]; then python -m pip install -e .; fi
-
       - name: Run fp32-fsw-xmera tests
         run: |
           source .venv/bin/activate

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -77,58 +77,6 @@ jobs:
           repository: lasp/basilisk
           path: xmera
 
-      - name: Add Release overlay preset for Xmera base
-        working-directory: xmera/src
-        run: |
-          python <<'PY'
-          import json
-          from pathlib import Path
-
-          preset_name = "base"
-          overlay_name = "base-release"
-
-          src_path = Path("CMakePresets.json")
-          if not src_path.exists():
-            raise SystemExit("CMakePresets.json not found in xmera/src")
-
-          with src_path.open("r", encoding="utf-8") as fh:
-            data = json.load(fh)
-
-          names = {p["name"] for p in data.get("configurePresets", [])}
-          if preset_name not in names:
-            raise SystemExit(f"Preset '{preset_name}' not present in CMakePresets.json")
-
-          user_path = Path("CMakeUserPresets.json")
-          if user_path.exists():
-            with user_path.open("r", encoding="utf-8") as fh:
-              user_data = json.load(fh)
-          else:
-            user_data = {"version": data.get("version", 5)}
-
-          user_cfg = user_data.setdefault("configurePresets", [])
-          user_cfg = [p for p in user_cfg if p.get("name") != overlay_name]
-          user_cfg.append({
-              "name": overlay_name,
-              "inherits": preset_name,
-              "cacheVariables": {
-                  "CMAKE_BUILD_TYPE": "Release"
-              }
-          })
-          user_data["configurePresets"] = user_cfg
-
-          user_build = user_data.setdefault("buildPresets", [])
-          user_build = [p for p in user_build if p.get("name") != overlay_name]
-          user_build.append({
-              "name": overlay_name,
-              "configurePreset": overlay_name
-          })
-          user_data["buildPresets"] = user_build
-
-          with user_path.open("w", encoding="utf-8") as fh:
-            json.dump(user_data, fh, indent=2)
-            fh.write("\n")
-          PY
-
       - name: Set up Python ${{ matrix.python-version }}
         id: setup-py
         uses: actions/setup-python@v5
@@ -299,7 +247,7 @@ jobs:
         run: |
           ln -s "${GITHUB_WORKSPACE}" .
           args=(
-            --preset base-release
+            --preset ci-test
             "-DXMERA_MODULE_ROOTS=${GITHUB_WORKSPACE}/xmera/src/fswAlgorithms/;${GITHUB_WORKSPACE}/xmera/src/simulation/;${GITHUB_WORKSPACE}/xmera/src/moduleTemplates/;${GITHUB_WORKSPACE}/xmera/src/fp32-fsw-xmera/algorithms"
             "-DXMERA_ENABLE_GROUPS=simulation;fswAlgorithms;moduleTemplates;fp32"
           )

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,305 @@
+name: "Static Analysis"
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+env:
+  USERNAME: ${{ github.repository_owner }}
+  FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
+  VCPKG_FEATURE_FLAGS: "manifests,registries,binarycaching"
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_PARALLEL_LEVEL: 4
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout fp32-fsw-xmera
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed algorithms/architecture files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            algorithms/**
+            architecture/**
+
+      - name: Checkout Xmera core
+        uses: actions/checkout@v4
+        with:
+          repository: lasp/basilisk
+          path: xmera
+
+      - name: Set up Python
+        id: setup-py
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            xmera/**/requirements.txt
+            xmera/**/pyproject.toml
+            **/requirements.txt
+            **/pyproject.toml
+            **/requirements*.txt
+
+      - name: Pin Python interpreter
+        run: |
+          PY="$(python -c 'import sys; print(sys.executable)')"
+          echo "PYTHON_EXE=$PY" >> "$GITHUB_ENV"
+          echo "Pinned Python: $PY"
+          "$PY" -V
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ninja-build build-essential \
+            pkg-config autoconf automake libtool \
+            zip unzip \
+            bison swig \
+            libdrm-dev \
+            libx11-dev libxkbcommon-x11-dev libx11-xcb-dev \
+            libxft-dev libxext-dev libgles2-mesa-dev \
+            libxi-dev libxtst-dev libxrandr-dev libltdl-dev \
+            libgtk2.0-dev \
+            python3-setuptools python3-jinja2 python3-tk \
+            mono-complete \
+            ccache \
+            gcc-13 g++-13 \
+            clang clang-tidy jq
+          ccache --version
+          ninja --version
+          clang --version
+          clang-tidy --version
+
+      - name: Select GCC 13
+        run: |
+          echo "CC=gcc-13"  >> "$GITHUB_ENV"
+          echo "CXX=g++-13" >> "$GITHUB_ENV"
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache"   >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+          gcc-13 -dumpfullversion
+          g++-13 -dumpfullversion
+
+      - name: Normalize Ninja
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y ninja-build
+          echo "/usr/bin" >> "$GITHUB_PATH"
+          echo "CMAKE_GENERATOR=Ninja"              >> "$GITHUB_ENV"
+          echo "CMAKE_MAKE_PROGRAM=/usr/bin/ninja"  >> "$GITHUB_ENV"
+          echo "NINJA_STATUS=[%f/%t %o/sec] "       >> "$GITHUB_ENV"
+          command -v ninja
+          ninja --version
+
+      - name: Toolchain sanity check
+        run: |
+          echo "RUNNER_OS=${RUNNER_OS}"
+          echo "CC=${CC:-(default)}"
+          echo "CXX=${CXX:-(default)}"
+          echo "CMAKE_GENERATOR=${CMAKE_GENERATOR:-(default)}"
+          echo "CMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM:-(default)}"
+          echo "PYTHON_EXE=${PYTHON_EXE:-(unset)}"
+          which python && python -V
+          "$PYTHON_EXE" -V
+          which gcc-13  && gcc-13 -dumpfullversion || true
+          which g++-13  && g++-13 -dumpfullversion || true
+          which ninja   && ninja --version   || true
+
+      - name: Setup CMake 3.28.3
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.28.3"
+
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: ${{ github.workspace }}/b/vcpkg
+          vcpkgJsonGlob: "xmera/src/vcpkg.json"
+          vcpkgConfigurationJsonGlob: "xmera/src/vcpkg-configuration.json"
+        env:
+          VCPKG_KEEP_ENV_VARS: CC;CXX;CMAKE_GENERATOR;CMAKE_MAKE_PROGRAM;NINJA_STATUS
+          VCPKG_MAX_CONCURRENCY: "1"
+          CMAKE_GENERATOR: Ninja
+          CMAKE_MAKE_PROGRAM: /usr/bin/ninja
+          VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
+      - name: Cache vcpkg build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/b/vcpkg/installed
+            ${{ github.workspace }}/b/vcpkg/packages
+            ${{ github.workspace }}/b/vcpkg/buildtrees
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('xmera/src/vcpkg.json', 'xmera/src/vcpkg-configuration.json') }}
+
+      - name: Add NuGet sources for vcpkg binary cache
+        env:
+          VCPKG_EXE: ${{ github.workspace }}/b/vcpkg/vcpkg
+        run: |
+          set -euo pipefail
+
+          NUGET="$("${VCPKG_EXE}" fetch nuget | awk 'NF{last=$0} END{print last}')"
+
+          declare -a NUGET_CMD=()
+
+          if [[ "$NUGET" == *.exe ]]; then
+            NUGET_CMD=(mono "$NUGET")
+          else
+            NUGET_CMD=("$NUGET")
+          fi
+
+          printf 'Using NuGet CLI: %q\n' "${NUGET_CMD[@]}"
+
+          "${NUGET_CMD[@]}" sources add \
+            -Source "${FEED_URL}" \
+            -StorePasswordInClearText \
+            -Name GitHubPackages \
+            -UserName "${USERNAME}" \
+            -Password "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}"
+
+          "${NUGET_CMD[@]}" setapikey "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}" -Source "${FEED_URL}"
+
+      - name: Create virtual environment
+        run: |
+          "$PYTHON_EXE" -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -V
+          pip -V
+
+      - name: Install Python deps
+        run: |
+          if [[ -f "$GITHUB_WORKSPACE/xmera/requirements.txt" ]]; then
+            ./.venv/bin/python -m pip install -r "$GITHUB_WORKSPACE/xmera/requirements.txt"
+          fi
+          ./.venv/bin/python -m pip install --upgrade gcovr
+          ./.venv/bin/python -m pip list
+
+      - name: Configure Xmera (with external modules)
+        working-directory: xmera/src
+        env:
+          VCPKG_BINARY_SOURCES: "clear;nuget,${{ env.FEED_URL }},readwrite"
+        run: |
+          ln -s "${GITHUB_WORKSPACE}" .
+          args=(
+            --preset ci-test
+            "-DXMERA_MODULE_ROOTS=${GITHUB_WORKSPACE}/xmera/src/fp32-fsw-xmera/algorithms"
+            "-DXMERA_ENABLE_GROUPS=fp32"
+            "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+          )
+          cmake "${args[@]}"
+
+      - name: Build Xmera + modules
+        working-directory: xmera/src
+        run: cmake --build ../build --parallel
+
+      - name: Run clang-tidy
+        run: |
+          mkdir -p reports
+          echo "CLANG_TIDY_STATUS=0" >> "$GITHUB_ENV"
+          if [ ! -f xmera/build/compile_commands.json ]; then
+            echo "compile_commands.json not found. Ensure CMAKE_EXPORT_COMPILE_COMMANDS is enabled."
+            : > reports/clang-tidy.log
+            exit 0
+          fi
+
+          # Build the list of changed algorithm/architecture files (split on whitespace/newlines)
+          changed_rel_paths=(${{ steps.changed-files.outputs.all_changed_files }})
+
+          if [ "${#changed_rel_paths[@]}" -eq 0 ]; then
+            echo "No algorithms/architecture files changed in this PR; skipping clang-tidy."
+            : > reports/clang-tidy.log
+            exit 0
+          fi
+
+          echo "Changed files to analyze:"
+          printf '  - %s\n' "${changed_rel_paths[@]}"
+
+          # Cache tracked repo files using canonical paths to avoid symlink issues
+          git_root="$(git rev-parse --show-toplevel)"
+          declare -A tracked=()
+          while IFS= read -r rel_path; do
+            canon="$(realpath -m "${git_root}/${rel_path}")"
+            tracked["${canon}"]=1
+          done < <(git ls-files)
+
+          # Cache changed files with canonical paths
+          declare -A changed=()
+          for rel_path in "${changed_rel_paths[@]}"; do
+            [[ -z "$rel_path" ]] && continue
+            canon="$(realpath -m "${git_root}/${rel_path}")"
+            changed["${canon}"]=1
+          done
+
+          # Gather algorithm + architecture sources that are tracked and skip *.cxx
+          files=()
+          while IFS= read -r path; do
+            [[ -z "$path" ]] && continue
+            canon="$(realpath -m "$path")"
+            if [[ -n "${tracked[$canon]:-}" && -n "${changed[$canon]:-}" ]]; then
+              files+=("$path")
+            fi
+          done < <(jq -r '.[].file' xmera/build/compile_commands.json \
+            | grep -E '(^|/)(algorithms|architecture)/' \
+            | grep -vE '\.cxx$' || true)
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No tracked source files (algorithms/architecture) to analyze after filtering generated outputs."
+            : > reports/clang-tidy.log
+          else
+            echo "Analyzing ${#files[@]} tracked files in algorithms/ + architecture/ (excluding generated .cxx)."
+            set +e
+            run-clang-tidy -p xmera/build -j"$(nproc)" "${files[@]}" 2>&1 | tee reports/clang-tidy.log
+            clang_tidy_status="${PIPESTATUS[0]}"
+            set -e
+            echo "CLANG_TIDY_STATUS=${clang_tidy_status}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+
+      - name: Annotate clang-tidy results
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat reports/clang-tidy.log | reviewdog \
+            -efm="%f:%l:%c: %t%*[^:]: %m" \
+            -efm="%f:%l:%c: %m" \
+            -name="clang-tidy" \
+            -reporter=github-pr-check \
+            -filter-mode=diff_context \
+            -level=warning \
+            -fail-on-error=true
+
+      - name: Fail when clang-tidy reports issues
+        if: env.CLANG_TIDY_STATUS != '0'
+        run: |
+          echo "clang-tidy reported issues (status=${CLANG_TIDY_STATUS}); failing job."
+          exit 1
+
+      - name: Upload clang-tidy artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-log
+          path: reports/clang-tidy.log
+          if-no-files-found: error


### PR DESCRIPTION
* **Tickets addressed:** emagnc-1913
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR add a new github workflow file `static-analysis.yml` which runs the clang-tidy tool on PR changes and reports the results as annotations on commit diff in the PR view. The clang-tidy errors are treated as CI check failures and will prevent the PR from being accepted.

## Verification
The CI workflow has been run against a set of dummy changes (see the last commit in this PR with message [drop]).

## Documentation
NA

## Future work
Future work will increase the variety of analysis and analyzers.
