### PR TITLE
Provide PRs from forks with read-only nuget cache permissions

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,224 @@
+name: "Warm vcpkg cache (develop)"
+
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  actions: read
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+env:
+  USERNAME: ${{ github.repository_owner }}
+  FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
+  VCPKG_FEATURE_FLAGS: "manifests,registries,binarycaching"
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_PARALLEL_LEVEL: 4
+
+jobs:
+  warm-cache:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14]
+    steps:
+      - name: Checkout fp32-fsw-xmera
+        uses: actions/checkout@v4
+
+      - name: Checkout Xmera core
+        uses: actions/checkout@v4
+        with:
+          repository: lasp/basilisk
+          path: xmera
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            xmera/**/requirements.txt
+            xmera/**/pyproject.toml
+            **/requirements.txt
+            **/pyproject.toml
+            **/requirements*.txt
+
+      - name: Pin Python interpreter
+        run: |
+          PY="$(python -c 'import sys; print(sys.executable)')"
+          echo "PYTHON_EXE=$PY" >> "$GITHUB_ENV"
+          echo "Pinned Python: $PY"
+          "$PY" -V
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ninja-build build-essential \
+            pkg-config autoconf automake libtool \
+            zip unzip \
+            bison swig \
+            libdrm-dev \
+            libx11-dev libxkbcommon-x11-dev libx11-xcb-dev \
+            libxft-dev libxext-dev libgles2-mesa-dev \
+            libxi-dev libxtst-dev libxrandr-dev libltdl-dev \
+            libgtk2.0-dev \
+            python3-setuptools python3-jinja2 python3-tk \
+            mono-complete \
+            ccache \
+            gcc-13 g++-13
+          ccache --version
+          ninja --version
+
+      - name: Select GCC 13
+        if: runner.os == 'Linux'
+        run: |
+          echo "CC=gcc-13"  >> "$GITHUB_ENV"
+          echo "CXX=g++-13" >> "$GITHUB_ENV"
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache"   >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+          gcc-13 -dumpfullversion
+          g++-13 -dumpfullversion
+
+      - name: Normalize Ninja
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y ninja-build
+          echo "/usr/bin" >> "$GITHUB_PATH"
+          echo "CMAKE_GENERATOR=Ninja"              >> "$GITHUB_ENV"
+          echo "CMAKE_MAKE_PROGRAM=/usr/bin/ninja"  >> "$GITHUB_ENV"
+          echo "NINJA_STATUS=[%f/%t %o/sec] "       >> "$GITHUB_ENV"
+          command -v ninja
+          ninja --version
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_ANALYTICS: 1
+        run: |
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          brew install ninja swig pkg-config mono ccache
+          which ninja && ninja --version
+          which cmake && cmake --version
+          xcrun --show-sdk-path
+          clang --version
+          clang++ --version
+          ccache --version
+
+      - name: Toolchain sanity check
+        run: |
+          echo "RUNNER_OS=${RUNNER_OS}"
+          echo "CC=${CC:-(default)}"
+          echo "CXX=${CXX:-(default)}"
+          echo "CMAKE_GENERATOR=${CMAKE_GENERATOR:-(default)}"
+          echo "CMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM:-(default)}"
+          echo "PYTHON_EXE=${PYTHON_EXE:-(unset)}"
+          which python && python -V
+          "$PYTHON_EXE" -V
+          which gcc-13  && gcc-13 -dumpfullversion || true
+          which g++-13  && g++-13 -dumpfullversion || true
+          which ninja   && ninja --version   || true
+
+      - name: Setup CMake 3.28.3
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.28.3"
+
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: ${{ github.workspace }}/b/vcpkg
+          vcpkgJsonGlob: "xmera/src/vcpkg.json"
+          vcpkgConfigurationJsonGlob: "xmera/src/vcpkg-configuration.json"
+        env:
+          VCPKG_KEEP_ENV_VARS: CC;CXX;CMAKE_GENERATOR;CMAKE_MAKE_PROGRAM;NINJA_STATUS
+          VCPKG_MAX_CONCURRENCY: "1"
+          CMAKE_GENERATOR: Ninja
+          CMAKE_MAKE_PROGRAM: /usr/bin/ninja
+          VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
+      - name: Cache vcpkg build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/b/vcpkg/installed
+            ${{ github.workspace }}/b/vcpkg/packages
+            ${{ github.workspace }}/b/vcpkg/buildtrees
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('xmera/src/vcpkg.json', 'xmera/src/vcpkg-configuration.json') }}
+
+      - name: Add NuGet sources for vcpkg binary cache (read/write)
+        env:
+          VCPKG_EXE: ${{ github.workspace }}/b/vcpkg/vcpkg
+        run: |
+          set -euo pipefail
+          NUGET="$("${VCPKG_EXE}" fetch nuget | awk 'NF{last=$0} END{print last}')"
+
+          declare -a NUGET_CMD=()   # appease set -u
+
+          if [[ "$NUGET" == *.exe ]]; then
+            NUGET_CMD=(mono "$NUGET")
+          else
+            NUGET_CMD=("$NUGET")
+          fi
+
+          printf 'Using NuGet CLI: %q\n' "${NUGET_CMD[@]}"
+
+          "${NUGET_CMD[@]}" sources add \
+            -Source "${FEED_URL}" \
+            -StorePasswordInClearText \
+            -Name GitHubPackages \
+            -UserName "${USERNAME}" \
+            -Password "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}"
+
+          "${NUGET_CMD[@]}" setapikey "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}" -Source "${FEED_URL}"
+
+      - name: Create virtual environment
+        run: |
+          "$PYTHON_EXE" -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -V
+          pip -V
+
+      - name: Install Python deps (from xmera into fp32-fsw-xmera venv)
+        run: |
+          source .venv/bin/activate
+          if [[ -f "$GITHUB_WORKSPACE/xmera/requirements.txt" ]]; then
+            python -m pip install -r "$GITHUB_WORKSPACE/xmera/requirements.txt"
+          fi
+          python -m pip install --upgrade gcovr
+          python -m pip list
+
+      - name: Configure Xmera (with external modules)
+        working-directory: xmera/src
+        run: |
+          ln -s "${GITHUB_WORKSPACE}" .
+          args=(
+            --preset ci-test
+            "-DXMERA_MODULE_ROOTS=${GITHUB_WORKSPACE}/xmera/src/fswAlgorithms/;${GITHUB_WORKSPACE}/xmera/src/simulation/;${GITHUB_WORKSPACE}/xmera/src/moduleTemplates/;${GITHUB_WORKSPACE}/xmera/src/fp32-fsw-xmera/algorithms"
+            "-DXMERA_ENABLE_GROUPS=simulation;fswAlgorithms;moduleTemplates;fp32"
+          )
+          cmake "${args[@]}"
+
+      - name: Build Xmera + modules (warm cache)
+        working-directory: xmera/src
+        run: cmake --build ../build --parallel
+
+      - name: Show ccache stats
+        if: always()
+        run: ccache --show-stats || true

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -1,0 +1,355 @@
+name: "Pull Request (Forks, NuGet cache read-only)"
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+env:
+  USERNAME: ${{ github.repository_owner }}
+  FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,read"
+  VCPKG_FEATURE_FLAGS: "manifests,registries,binarycaching"
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_PARALLEL_LEVEL: 4
+  CTEST_OUTPUT_ON_FAILURE: 1
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-24.04
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR head (no credentials)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: .pre-commit-config.yaml
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Install clang-format (Linux static binary)
+        run: |
+          sudo wget -qO /usr/local/bin/clang-format https://github.com/cpp-linter/clang-tools-static-binaries/releases/latest/download/clang-format-20_linux-amd64
+          sudo chmod a+x /usr/local/bin/clang-format
+          clang-format --version
+
+      - id: file_changes
+        uses: tj-actions/changed-files@v46
+
+      - name: Run pre-commit (changed files)
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --color always --files ${{ steps.file_changes.outputs.all_changed_files }}
+
+  build-test:
+    name: Build & Test (forks, ${{ matrix.os }} / py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.draft == false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14]
+        python-version: ["3.9", "3.10", "3.11"]
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+      security-events: write
+    steps:
+      - name: Checkout PR head (no credentials)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Checkout Xmera core
+        uses: actions/checkout@v4
+        with:
+          repository: lasp/xmera
+          path: xmera
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        id: setup-py
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            xmera/**/requirements.txt
+            xmera/**/pyproject.toml
+            **/requirements.txt
+            **/pyproject.toml
+            **/requirements*.txt
+
+      - name: Pin matrix Python interpreter
+        run: |
+          PY="$(python -c 'import sys; print(sys.executable)')"
+          echo "PYTHON_EXE=$PY" >> "$GITHUB_ENV"
+          echo "Pinned Python: $PY"
+          "$PY" -V
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ninja-build build-essential \
+            pkg-config autoconf automake libtool \
+            zip unzip \
+            bison swig \
+            libdrm-dev \
+            libx11-dev libxkbcommon-x11-dev libx11-xcb-dev \
+            libxft-dev libxext-dev libgles2-mesa-dev \
+            libxi-dev libxtst-dev libxrandr-dev libltdl-dev \
+            libgtk2.0-dev \
+            python3-setuptools python3-jinja2 python3-tk \
+            mono-complete \
+            ccache \
+            gcc-13 g++-13
+          ccache --version
+          ninja --version
+
+      - name: Select GCC 13 (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          echo "CC=gcc-13"  >> "$GITHUB_ENV"
+          echo "CXX=g++-13" >> "$GITHUB_ENV"
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache"   >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+          gcc-13 -dumpfullversion
+          g++-13 -dumpfullversion
+
+      - name: Normalize Ninja on Linux
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y ninja-build
+          echo "/usr/bin" >> "$GITHUB_PATH"
+          echo "CMAKE_GENERATOR=Ninja"              >> "$GITHUB_ENV"
+          echo "CMAKE_MAKE_PROGRAM=/usr/bin/ninja"  >> "$GITHUB_ENV"
+          echo "NINJA_STATUS=[%f/%t %o/sec] "       >> "$GITHUB_ENV"
+          command -v ninja
+          ninja --version
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_ANALYTICS: 1
+        run: |
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          brew install ninja swig pkg-config mono ccache
+          which ninja && ninja --version
+          which cmake && cmake --version
+          xcrun --show-sdk-path
+          clang --version
+          clang++ --version
+          ccache --version
+
+      - name: Toolchain sanity check
+        run: |
+          echo "RUNNER_OS=${RUNNER_OS}"
+          echo "CC=${CC:-(default)}"
+          echo "CXX=${CXX:-(default)}"
+          echo "CMAKE_GENERATOR=${CMAKE_GENERATOR:-(default)}"
+          echo "CMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM:-(default)}"
+          echo "PYTHON_EXE=${PYTHON_EXE:-(unset)}"
+          which python && python -V
+          "$PYTHON_EXE" -V
+          which gcc-13  && gcc-13 -dumpfullversion || true
+          which g++-13  && g++-13 -dumpfullversion || true
+          which ninja   && ninja --version   || true
+
+      - name: Setup CMake 3.28.3
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.28.3'
+
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: ${{ github.workspace }}/b/vcpkg
+          vcpkgJsonGlob: "xmera/src/vcpkg.json"
+          vcpkgConfigurationJsonGlob: "xmera/src/vcpkg-configuration.json"
+        env:
+          VCPKG_KEEP_ENV_VARS: CC;CXX;CMAKE_GENERATOR;CMAKE_MAKE_PROGRAM;NINJA_STATUS
+          VCPKG_MAX_CONCURRENCY: "1"
+          CMAKE_GENERATOR: Ninja
+          CMAKE_MAKE_PROGRAM: /usr/bin/ninja
+          VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
+      - name: Cache vcpkg build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/b/vcpkg/installed
+            ${{ github.workspace }}/b/vcpkg/packages
+            ${{ github.workspace }}/b/vcpkg/buildtrees
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('xmera/src/vcpkg.json', 'xmera/src/vcpkg-configuration.json') }}
+
+      - name: Add NuGet sources for vcpkg binary cache (read-only)
+        env:
+          VCPKG_EXE: ${{ github.workspace }}/b/vcpkg/vcpkg
+        run: |
+          set -euo pipefail
+          NUGET="$("${VCPKG_EXE}" fetch nuget | awk 'NF{last=$0} END{print last}')"
+
+          declare -a NUGET_CMD=()   # <-- make it exist to appease `set -u`
+
+          if [[ "$NUGET" == *.exe ]]; then
+            NUGET_CMD=(mono "$NUGET")
+          else
+            NUGET_CMD=("$NUGET")
+          fi
+
+          # Print robustly
+          printf 'Using NuGet CLI: %q\n' "${NUGET_CMD[@]}"
+
+          "${NUGET_CMD[@]}" sources add \
+            -Source "${FEED_URL}" \
+            -StorePasswordInClearText \
+            -Name GitHubPackages \
+            -UserName "${USERNAME}" \
+            -Password "${{ secrets.GITHUB_TOKEN }}"
+
+          "${NUGET_CMD[@]}" setapikey "${{ secrets.GITHUB_TOKEN }}" -Source "${FEED_URL}"
+
+      - name: Create virtual environment
+        run: |
+          "$PYTHON_EXE" -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -V
+          pip -V
+
+      - name: Install Python deps (from xmera into fp32-fsw-xmera venv)
+        run: |
+          source .venv/bin/activate
+          if [[ -f "$GITHUB_WORKSPACE/xmera/requirements.txt" ]]; then
+            python -m pip install -r "$GITHUB_WORKSPACE/xmera/requirements.txt"
+          fi
+          python -m pip install --upgrade gcovr
+          python -m pip list
+
+      - name: Configure Xmera (with external modules)
+        working-directory: xmera/src
+        run: |
+          ln -s "${GITHUB_WORKSPACE}" .
+          args=(
+            --preset fuzz-smoke-test
+            "-DXMERA_MODULE_ROOTS=${GITHUB_WORKSPACE}/xmera/src/fswAlgorithms/;${GITHUB_WORKSPACE}/xmera/src/simulation/;${GITHUB_WORKSPACE}/xmera/src/moduleTemplates/;${GITHUB_WORKSPACE}/xmera/src/fp32-fsw-xmera/algorithms"
+            "-DXMERA_ENABLE_GROUPS=simulation;fswAlgorithms;moduleTemplates;fp32"
+          )
+          if [[ "${{ runner.os }}" == "Linux" && "${{ matrix.python-version }}" == "3.11" ]]; then
+            args+=(
+              "-DCMAKE_BUILD_TYPE=Debug"
+              "-DCMAKE_C_FLAGS=--coverage"
+              "-DCMAKE_CXX_FLAGS=--coverage"
+              "-DCMAKE_EXE_LINKER_FLAGS=--coverage"
+              "-DCMAKE_SHARED_LINKER_FLAGS=--coverage"
+            )
+          fi
+          cmake "${args[@]}"
+
+      - name: Build Xmera + modules
+        working-directory: xmera/src
+        run: cmake --build ../build --parallel
+
+      - name: Install Xmera (editable)
+        run: |
+          source .venv/bin/activate
+          cd xmera
+          cmake --install build --prefix $(pwd)/dist
+          python -m pip install -e .
+
+      - name: Run fp32-fsw-xmera tests
+        run: |
+          source .venv/bin/activate
+          mkdir -p junit coverage
+          cd algorithms
+          pytest -n auto \
+            --junitxml="../junit/test-results-${{ matrix.python-version }}.xml"
+          cd ..
+
+      - name: Generate external module coverage (Linux / py3.11 only)
+        if: ${{ runner.os == 'Linux' && matrix.python-version == '3.11' }}
+        run: |
+          source .venv/bin/activate
+          mkdir -p coverage
+          GCOV_BIN="$(command -v gcov-13 || command -v gcov)"
+          echo "Using gcov executable: ${GCOV_BIN}"
+          common_args=(
+            --root "${GITHUB_WORKSPACE}"
+            --filter "${GITHUB_WORKSPACE}/algorithms"
+            --object-directory "${GITHUB_WORKSPACE}/xmera/build"
+            --exclude ".*_tests/.*"
+            --gcov-executable "${GCOV_BIN}"
+            --gcov-ignore-errors no_working_dir_found
+            --gcov-ignore-errors source_not_found
+          )
+          gcovr "${common_args[@]}" \
+            --xml-pretty \
+            --output coverage/external-modules-coverage.xml
+          gcovr "${common_args[@]}" \
+            --html-details \
+            --output coverage/external-modules-coverage.html
+          gcovr "${common_args[@]}" \
+            --txt \
+            --output coverage/external-modules-coverage.txt
+          gcovr "${common_args[@]}" \
+            --json \
+            --output coverage/external-modules-coverage.json
+          {
+            echo '### External Modules Coverage (gcovr)';
+            echo;
+            echo '```text';
+            cat coverage/external-modules-coverage.txt;
+            echo '```';
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage artifacts (Linux / py3.11 only)
+        if: ${{ runner.os == 'Linux' && matrix.python-version == '3.11' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: external-modules-coverage
+          path: |
+            coverage/external-modules-coverage.xml
+            coverage/external-modules-coverage.html
+            coverage/external-modules-coverage.txt
+            coverage/external-modules-coverage.json
+          retention-days: 14
+
+      - name: Upload pytest test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.python-version }}.xml
+          retention-days: 7
+
+      - name: Show ccache stats
+        if: always()
+        run: ccache --show-stats || true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout Xmera core
         uses: actions/checkout@v4
         with:
-          repository: lasp/basilisk
+          repository: lasp/xmera
           path: xmera
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       contents: read
     steps:
@@ -56,7 +57,7 @@ jobs:
   build-test:
     name: Build & Test (${{ matrix.os }} / py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -305,6 +305,8 @@ jobs:
             set -e
             echo "CLANG_TIDY_STATUS=${clang_tidy_status}" >> "$GITHUB_ENV"
           fi
+          # Ensure log exists even if no files were analyzed
+          touch reports/clang-tidy.log
 
       - name: Setup reviewdog
         uses: reviewdog/action-setup@v1

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -236,7 +236,6 @@ jobs:
         run: cmake --build ../build --parallel
 
       - name: Run clang-tidy
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           mkdir -p reports
           echo "CLANG_TIDY_STATUS=0" >> "$GITHUB_ENV"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,7 +14,7 @@ defaults:
 env:
   USERNAME: ${{ github.repository_owner }}
   FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,read"
   VCPKG_FEATURE_FLAGS: "manifests,registries,binarycaching"
   CMAKE_BUILD_PARALLEL_LEVEL: 4
   CTEST_PARALLEL_LEVEL: 4
@@ -176,7 +176,7 @@ jobs:
             ${{ github.workspace }}/b/vcpkg/buildtrees
           key: vcpkg-${{ runner.os }}-${{ hashFiles('xmera/src/vcpkg.json', 'xmera/src/vcpkg-configuration.json') }}
 
-      - name: Add NuGet sources for vcpkg binary cache
+      - name: Add NuGet sources for vcpkg binary cache (read-only)
         env:
           VCPKG_EXE: ${{ github.workspace }}/b/vcpkg/vcpkg
         run: |
@@ -199,9 +199,9 @@ jobs:
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${USERNAME}" \
-            -Password "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}"
+            -Password "${{ github.token }}"
 
-          "${NUGET_CMD[@]}" setapikey "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}" -Source "${FEED_URL}"
+          "${NUGET_CMD[@]}" setapikey "${{ github.token }}" -Source "${FEED_URL}"
 
       - name: Create virtual environment
         run: |
@@ -221,8 +221,6 @@ jobs:
 
       - name: Configure Xmera (with external modules)
         working-directory: xmera/src
-        env:
-          VCPKG_BINARY_SOURCES: "clear;nuget,${{ env.FEED_URL }},readwrite"
         run: |
           ln -s "${GITHUB_WORKSPACE}" .
           args=(


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR adds a second build and test workflow specifically for PRs from forks. This new workflow restricts PRs from forks to having read-only access to the nuget cache (vcpkg). A second `cache-warm.yml` workflow is added which runs after a successful PR merge. This workflow has read and write access to enable it to upload the latest cached ports.

PRs originating from branches in the repository have read and write access such that when a PR completes successfully the compiled vcpkg ports are uploaded to the nuget cache for reuse by later CI runs.

## Verification
These workflows have been tested manually by creating PRs from fork and in-repo branches against the branch of this PR. The correct workflows run/skip for the two different branch sources.

## Documentation
None

## Future work
None
