### PR TITLE
Add ctest fuzz smoke preset

### DIFF
--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -201,15 +201,6 @@ jobs:
           CMAKE_MAKE_PROGRAM: /usr/bin/ninja
           VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
-      - name: Cache vcpkg build artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ github.workspace }}/b/vcpkg/installed
-            ${{ github.workspace }}/b/vcpkg/packages
-            ${{ github.workspace }}/b/vcpkg/buildtrees
-          key: vcpkg-${{ runner.os }}-${{ hashFiles('xmera/src/vcpkg.json', 'xmera/src/vcpkg-configuration.json') }}
-
       - name: Add NuGet sources for vcpkg binary cache (read-only)
         env:
           VCPKG_EXE: ${{ github.workspace }}/b/vcpkg/vcpkg
@@ -233,9 +224,9 @@ jobs:
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${USERNAME}" \
-            -Password "${{ secrets.GITHUB_TOKEN }}"
+            -Password "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN_READ_ONLY }}"
 
-          "${NUGET_CMD[@]}" setapikey "${{ secrets.GITHUB_TOKEN }}" -Source "${FEED_URL}"
+          "${NUGET_CMD[@]}" setapikey "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN_READ_ONLY }}" -Source "${FEED_URL}"
 
       - name: Create virtual environment
         run: |

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -276,6 +276,12 @@ jobs:
           cmake --install build --prefix $(pwd)/dist
           python -m pip install -e .
 
+      - name: Run CTest (C/C++ tests)
+        working-directory: xmera/build
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/junit"
+          ctest --output-on-failure --output-junit "${GITHUB_WORKSPACE}/junit/ctest-${{ matrix.os }}-py${{ matrix.python-version }}.xml"
+
       - name: Run fp32-fsw-xmera tests
         run: |
           source .venv/bin/activate
@@ -339,6 +345,15 @@ jobs:
         with:
           name: pytest-${{ matrix.os }}-py${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
+          retention-days: 7
+
+      - name: Upload CTest results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: junit/ctest-${{ matrix.os }}-py${{ matrix.python-version }}.xml
+          if-no-files-found: warn
           retention-days: 7
 
       - name: Show ccache stats

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -188,15 +188,6 @@ jobs:
           CMAKE_MAKE_PROGRAM: /usr/bin/ninja
           VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
-      - name: Cache vcpkg build artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ github.workspace }}/b/vcpkg/installed
-            ${{ github.workspace }}/b/vcpkg/packages
-            ${{ github.workspace }}/b/vcpkg/buildtrees
-          key: vcpkg-${{ runner.os }}-${{ hashFiles('xmera/src/vcpkg.json', 'xmera/src/vcpkg-configuration.json') }}
-
       - name: Add NuGet sources for vcpkg binary cache (portable)
         env:
           VCPKG_EXE: ${{ github.workspace }}/b/vcpkg/vcpkg

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -265,7 +265,13 @@ jobs:
           cmake --install build --prefix $(pwd)/dist
           python -m pip install -e .
 
-      - name: Run fp32-fsw-xmera tests
+      - name: Run CTest (C/C++ tests)
+        working-directory: xmera/build
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/junit"
+          ctest --output-on-failure --output-junit "${GITHUB_WORKSPACE}/junit/ctest-${{ matrix.os }}-py${{ matrix.python-version }}.xml"
+
+      - name: Run Python Tests
         run: |
           source .venv/bin/activate
           mkdir -p junit coverage
@@ -328,6 +334,15 @@ jobs:
         with:
           name: pytest-${{ matrix.os }}-py${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
+          retention-days: 7
+
+      - name: Upload CTest results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: junit/ctest-${{ matrix.os }}-py${{ matrix.python-version }}.xml
+          if-no-files-found: warn
           retention-days: 7
 
       - name: Show ccache stats

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -239,7 +239,7 @@ jobs:
         run: |
           ln -s "${GITHUB_WORKSPACE}" .
           args=(
-            --preset ci-test
+            --preset fuzz-smoke-test
             "-DXMERA_MODULE_ROOTS=${GITHUB_WORKSPACE}/xmera/src/fswAlgorithms/;${GITHUB_WORKSPACE}/xmera/src/simulation/;${GITHUB_WORKSPACE}/xmera/src/moduleTemplates/;${GITHUB_WORKSPACE}/xmera/src/fp32-fsw-xmera/algorithms"
             "-DXMERA_ENABLE_GROUPS=simulation;fswAlgorithms;moduleTemplates;fp32"
           )

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -170,15 +170,6 @@ jobs:
           CMAKE_MAKE_PROGRAM: /usr/bin/ninja
           VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
-      - name: Cache vcpkg build artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ github.workspace }}/b/vcpkg/installed
-            ${{ github.workspace }}/b/vcpkg/packages
-            ${{ github.workspace }}/b/vcpkg/buildtrees
-          key: vcpkg-${{ runner.os }}-${{ hashFiles('xmera/src/vcpkg.json', 'xmera/src/vcpkg-configuration.json') }}
-
       - name: Add NuGet sources for vcpkg binary cache (read-only)
         env:
           VCPKG_EXE: ${{ github.workspace }}/b/vcpkg/vcpkg


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR adds a Ctest step to both build and test workflows. The first commit removes a redundant vcpkg caching step (now that we cache via the nuget repository in github). The second commit changes the CMake build preset to use `fuzz-smoke-test` so that all ctests are built and run.

## Verification
CI runs successfully and the test additions are identified as having run in the CI logs/outputs.

## Documentation
None

## Future work
None
