### PR TITLE
Add file exclusions for clang-tidy analysis

### DIFF
--- a/.github/clang-tidy-exclude.txt
+++ b/.github/clang-tidy-exclude.txt
@@ -1,0 +1,33 @@
+# List of repository-relative paths to skip during the static-analysis clang-tidy run.
+# Lines starting with '#' or blank lines are ignored. One literal path per line.
+
+algorithms/attTrackingError/attTrackingError.h
+algorithms/attTrackingError/attTrackingError.cpp
+algorithms/celestialTwoBodyPoint/celestialTwoBodyPoint.h
+algorithms/celestialTwoBodyPoint/celestialTwoBodyPoint.cpp
+algorithms/ephemNavConverter/ephemNavConverter.h
+algorithms/ephemNavConverter/ephemNavConverter.cpp
+algorithms/ephemeridesRecenter/ephemeridesRecenter.h
+algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
+algorithms/inertial3D/inertial3D.h
+algorithms/inertial3D/inertial3D.cpp
+algorithms/mrpSteering/mrpSteering.h
+algorithms/mrpSteering/mrpSteering.cpp
+algorithms/navAggregate/navAggregate.h
+algorithms/navAggregate/navAggregate.cpp
+algorithms/oeStateEphem/oeStateEphem.h
+algorithms/oeStateEphem/oeStateEphem.cpp
+algorithms/rateControl/rateControl.h
+algorithms/rateControl/rateControl.cpp
+algorithms/rateServoFullNonlinear/rateServoFullNonlinear.h
+algorithms/rateServoFullNonlinear/rateServoFullNonlinear.cpp
+algorithms/rwMotorVoltage/rwMotorVoltage.h
+algorithms/rwMotorVoltage/rwMotorVoltage.cpp
+algorithms/rwNullSpace/rwNullSpace.h
+algorithms/rwNullSpace/rwNullSpace.cpp
+algorithms/stepperMotorController/stepperMotorController.h
+algorithms/stepperMotorController/stepperMotorController.cpp
+algorithms/sunSearch/sunSearch.h
+algorithms/sunSearch/sunSearch.cpp
+algorithms/sunlineEphem/sunlineEphem.h
+algorithms/sunlineEphem/sunlineEphem.cpp

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -267,17 +267,48 @@ jobs:
             changed["${canon}"]=1
           done
 
+          # Load exclusion list (repository-relative paths, no globs)
+          exclude_file="${git_root}/.github/clang-tidy-exclude.txt"
+          exclude_paths=()
+          if [[ -f "$exclude_file" ]]; then
+            echo "Loading clang-tidy exclusions from ${exclude_file}:"
+            while IFS= read -r line; do
+              [[ -z "$line" || "$line" =~ ^# ]] && continue
+              path="$(realpath -m "${git_root}/${line}")"
+              exclude_paths+=("$path")
+            done < "$exclude_file"
+            if [ "${#exclude_paths[@]}" -gt 0 ]; then
+              printf '  - %s\n' "${exclude_paths[@]}"
+            else
+              echo "  (exclusion file is empty)"
+            fi
+          else
+            echo "No exclusion file found at ${exclude_file}; analyzing all changed files."
+          fi
+
           # Gather algorithm + architecture sources that are tracked and skip *.cxx
           files=()
+          excluded_files=()
           while IFS= read -r path; do
             [[ -z "$path" ]] && continue
             canon="$(realpath -m "$path")"
             if [[ -n "${tracked[$canon]:-}" && -n "${changed[$canon]:-}" ]]; then
+              for excluded in "${exclude_paths[@]}"; do
+                if [[ "$canon" == "$excluded" ]]; then
+                  excluded_files+=("$path")
+                  continue 2
+                fi
+              done
               files+=("$path")
             fi
           done < <(jq -r '.[].file' xmera/build/compile_commands.json \
             | grep -E '(^|/)(algorithms|architecture)/' \
             | grep -vE '\.cxx$' || true)
+
+          if [ "${#excluded_files[@]}" -gt 0 ]; then
+            echo "Skipping files listed in the clang-tidy exclusion file:"
+            printf '  - %s\n' "${excluded_files[@]}"
+          fi
 
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No tracked source files (algorithms/architecture) to analyze after filtering generated outputs."


### PR DESCRIPTION
* **Tickets addressed:** emagnc-1973
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR adds the ability to exclude files from the clang-tidy static analysis CI workflow. The exclusion process is simple; a `clang-tidy-exclude.txt` file is added and contains one file path per line to exclude. It is expected that only Xmera module files will be added to the exclusions because the remainder should be subjected to fsw analysis.

## Verification
Tested in CI with a test branch PRd against this banch.

## Documentation
None

## Future work
None
