### PR TITLE
Add message defines

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout Xmera core
         uses: actions/checkout@v4
         with:
-          repository: lasp/basilisk
+          repository: lasp/xmera
           path: xmera
 
       - name: Set up Python
@@ -193,9 +193,9 @@ jobs:
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${USERNAME}" \
-            -Password "${{ github.token }}"
+            -Password "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN_READ_ONLY }}"
 
-          "${NUGET_CMD[@]}" setapikey "${{ github.token }}" -Source "${FEED_URL}"
+          "${NUGET_CMD[@]}" setapikey "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN_READ_ONLY }}" -Source "${FEED_URL}"
 
       - name: Create virtual environment
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,20 +114,21 @@ set_target_properties(gncAlgorithms PROPERTIES
 add_subdirectory("architecture/utilities")
 target_link_libraries(gncAlgorithms PUBLIC utilities)
 
-# 8) Generate Ada bindings (always, for both Linux and RISC-V)
-set(BINDINGS_DIR "${PROJECT_BINARY_DIR}/bindings")
-file(MAKE_DIRECTORY "${BINDINGS_DIR}")
+if(GENERATE_ADA_BINDINGS)
+  # 8) Generate Ada bindings (always, for both Linux and RISC-V)
+  set(BINDINGS_DIR "${PROJECT_BINARY_DIR}/bindings")
+  file(MAKE_DIRECTORY "${BINDINGS_DIR}")
 
-set(ada_specs "")
-foreach(module_name IN LISTS algorithms)
-  generate_ada_spec(${module_name} ada_specs)
-endforeach()
+  set(ada_specs "")
+  foreach(module_name IN LISTS algorithms)
+    generate_ada_spec(${module_name} ada_specs)
+  endforeach()
 
-add_custom_target(generate_ada_bindings ALL
-  DEPENDS ${ada_specs}
-)
-
-add_dependencies(gncAlgorithms generate_ada_bindings)
+  add_custom_target(generate_ada_bindings ALL
+    DEPENDS ${ada_specs}
+  )
+  add_dependencies(gncAlgorithms generate_ada_bindings)
+endif()
 
 # 9) Usage summary:
 # Native Linux (Debug):

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,21 @@ if(NOT IS_DIRECTORY "${EIGEN3_DIR}/Eigen")
   message(FATAL_ERROR "Eigen not found under ${EIGEN3_DIR}")
 endif()
 
-set(algorithms "attTrackingError")
+# "rateServoFullNonlinear" "rwMotorVoltage" "stepperMotorController"
+set(algorithms
+    "attTrackingError"
+    "celestialTwoBodyPoint"
+    "ephemeridesRecenter"
+    "ephemNavConverter"
+    "inertial3D"
+    "mrpSteering"
+    "navAggregate"
+    "oeStateEphem"
+    "rateControl"
+    "rwNullSpace"
+    "sunlineEphem"
+    "sunSearch"
+)
 foreach(algorithm_name IN LISTS algorithms)
   add_algorithm(${algorithm_name})
 endforeach()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,8 @@
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "EIGEN3_DIR": "../eigen"
+        "EIGEN3_DIR": "../eigen",
+        "GENERATE_ADA_BINDINGS": "OFF"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# Repository Name
+# Adamant-Xmera Flight Software Algorithms
 This repository contains the GNC FSW algorithms.
 
 ## Getting Started
 This repository has two primary usages and therefore two build paths:
-1. To compile the FSW algorithms as modules for the Ximera simulation tool.
-2. To compile the FSW algorithms for the GNC target platform.
+1. To compile the FSW algorithms as modules for the Xmera simulation tool.
+2. To compile the FSW algorithms as a single library for use within the Adamant system.
 
-The build Ximera build path is controlled by the Ximera build system. It expects the directory structure:
+The build Xmera build path is controlled by the Xmera build system. It has the directory structure:
 - algorithms/
-  - msgPayloadDef/
+  - CMakeLists.txt
   - alg1/
+    - CMakeLists.txt
     - module.i
     - module.h
     - module.cpp
   - alg2/
     - etc.
 
-The flight software build path is controlled by the CMake build system and associated cmake files in this repository.
-This build path is described below.
+The flight software build path is controlled by the CMake build system.
 
 ### Dependencies:
-- Eigen for freestanding C++ (it's assumed that the repo is at ../ relative to this repo)
+- Eigen for freestanding C++ (it's assumed that the Eigen repo is at ../ relative to this repo)
 
 ### Required Tooling:
 - GCC 13.3.1 or higher
@@ -49,23 +49,40 @@ sudo update-alternatives --config g++
 3. Test GCC with `gcc --version` - this command should output information about the installed GCC compiler, including
 its version number.
 
-### Using Build.sh
-```
-build.sh — drives builds via CMakePresets.json
+### Using CMake Presets
+
+This repository is driven by CMake presets in `CMakePresets.json`. Build directories are created under `build/<preset>`.
 
 Examples:
-  ./build.sh --list
-  ./build.sh linux-gcc-debug/release
-  ./build.sh macos-gcc-debug/release
-  ./build.sh riscv32-gcc-debug/release (this option only works on Linux with installed cross compiler)
-  ./build.sh --configure linux-gcc-debug --build linux-gcc-debug --fresh
-  ./build.sh macos-gcc-debug --archive lib/libgncAlgorithms.a
-
-Notes:
-- Uses your CMakePresets.json configure/build presets.
-- --fresh uses CMake's native reconfigure (CMake >= 3.24).
-- The script chooses a sensible default preset if none is provided.
 ```
+# List configure/build presets
+cmake --list-presets=configure
+cmake --list-presets=build
+
+# Configure + build debug on Linux
+cmake --preset linux-gcc-debug
+cmake --build --preset linux-gcc-debug
+
+# Configure + build release on macOS
+cmake --preset macos-gcc-release
+cmake --build --preset macos-gcc-release
+
+# RISC-V cross build (Linux only with the cross toolchain installed)
+cmake --preset riscv32-gcc-debug
+cmake --build --preset riscv32-gcc-debug
+
+# Clean rebuild using CMake's native reconfigure (CMake >= 3.24)
+cmake --preset linux-gcc-debug --fresh
+cmake --build --preset linux-gcc-debug
+
+# Build a specific target
+cmake --build --preset linux-gcc-debug --target gncAlgorithms
+
+# Build with extra parallelism
+cmake --build --preset linux-gcc-debug -- -j8
+```
+
+Note: `build_a.sh` and `build_all.sh` are legacy and not required when using CMake presets directly.
 
 One can add a user-defined preset to CMakeUserPresets.json which is not added to the repository.
 E.g.

--- a/algorithms/attTrackingError/attTrackingErrorAlgorithm_c.cpp
+++ b/algorithms/attTrackingError/attTrackingErrorAlgorithm_c.cpp
@@ -21,10 +21,9 @@ void AttTrackingErrorAlgorithm_reset(AttTrackingErrorAlgorithm* self, uint64_t c
 }
 
 AttGuidMsgF32Payload AttTrackingErrorAlgorithm_update(AttTrackingErrorAlgorithm* self,
-                                                      uint64_t callTime,
                                                       AttRefMsgF32Payload* attRefInMsg,
                                                       NavAttMsgF32Payload* attNavInMsg) {
-    return reinterpret_cast<::AttTrackingErrorAlgorithm*>(self)->update(callTime, *attRefInMsg, *attNavInMsg);
+    return reinterpret_cast<::AttTrackingErrorAlgorithm*>(self)->update(*attRefInMsg, *attNavInMsg);
 }
 
 void AttTrackingErrorAlgorithm_setSigma_R0R(AttTrackingErrorAlgorithm* self, Vector3f_c sigma_R0R) {

--- a/algorithms/attTrackingError/attTrackingErrorAlgorithm_c.h
+++ b/algorithms/attTrackingError/attTrackingErrorAlgorithm_c.h
@@ -6,10 +6,10 @@
 #ifndef F32XIMERA_ATTTRACKINGERRORALGORITHM_C_H
 #define F32XIMERA_ATTTRACKINGERRORALGORITHM_C_H
 
-#include <stdint.h>
 #include "msgPayloadDef/AttGuidMsgF32Payload.h"
 #include "msgPayloadDef/AttRefMsgF32Payload.h"
 #include "msgPayloadDef/NavAttMsgF32Payload.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,30 +44,24 @@ void AttTrackingErrorAlgorithm_destroy(AttTrackingErrorAlgorithm* self);
  * @param self     Pointer to the instance.
  * @param callTime Time stamp for reset.
  */
-void AttTrackingErrorAlgorithm_reset(AttTrackingErrorAlgorithm* self,
-                                     uint64_t callTime);
-
+void AttTrackingErrorAlgorithm_reset(AttTrackingErrorAlgorithm* self, uint64_t callTime);
 /**
  * @brief Run the update step.
  * @param self         Pointer to the instance.
- * @param callTime     Time stamp for update.
  * @param attRefInMsg  Pointer to reference-frame message payload.
  * @param attNavInMsg  Pointer to navigation attitude message payload.
  * @return AttGuidMsgPayload  The computed guidance message.
  */
-AttGuidMsgF32Payload
-AttTrackingErrorAlgorithm_update(AttTrackingErrorAlgorithm* self,
-                                 uint64_t callTime,
-                                 AttRefMsgF32Payload* attRefInMsg,
-                                 NavAttMsgF32Payload* attNavInMsg);
+AttGuidMsgF32Payload AttTrackingErrorAlgorithm_update(AttTrackingErrorAlgorithm* self,
+                                                      AttRefMsgF32Payload* attRefInMsg,
+                                                      NavAttMsgF32Payload* attNavInMsg);
 
 /**
  * @brief Set the σ_R0R three-vector.
  * @param self      Pointer to the instance.
  * @param sigma_R0R 3-vector in flattened POD format.
  */
-void AttTrackingErrorAlgorithm_setSigma_R0R(AttTrackingErrorAlgorithm* self,
-                                            Vector3f_c sigma_R0R);
+void AttTrackingErrorAlgorithm_setSigma_R0R(AttTrackingErrorAlgorithm* self, Vector3f_c sigma_R0R);
 
 /**
  * @brief Get the current σ_R0R three-vector.

--- a/algorithms/celestialTwoBodyPoint/CMakeLists.txt
+++ b/algorithms/celestialTwoBodyPoint/CMakeLists.txt
@@ -10,8 +10,12 @@ target_sources("${module}" PRIVATE
   celestialTwoBodyPointAlgorithm.cpp
 )
 
-target_include_directories("${module}" PUBLIC "..")
+target_include_directories("${module}" PUBLIC
+  ".."
+  "../.."
+)
 
 target_link_libraries("${module}" PRIVATE
   ArchitectureUtilities
+  AlgorithmUtilities
 )

--- a/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
+++ b/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
@@ -38,7 +38,10 @@ AttRefMsgF32Payload CelestialTwoBodyPointAlgorithm::update(EphemerisMsgF32Payloa
                   Eigen::Map<const Eigen::Vector3d>(transNavIn.r_BN_N);
         v_P2B_N = Eigen::Map<const Eigen::Vector3d>(secCelBodyIn.v_BdyZero_N) -
                   Eigen::Map<const Eigen::Vector3d>(transNavIn.v_BN_N);
-        const float dotProduct = R_P2B_N.normalized().dot(R_P1B_N.normalized());
+
+        Eigen::Vector3f const R_P2B_N_hat = R_P2B_N.normalized().cast<float>();
+        Eigen::Vector3f const R_P1B_N_hat = R_P1B_N.normalized().cast<float>();
+        const float dotProduct = R_P2B_N_hat.dot(R_P1B_N_hat);
         platAngDiff = safeAcosf(dotProduct);
     }
 

--- a/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
+++ b/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
@@ -6,11 +6,9 @@
 
 #include "celestialTwoBodyPointAlgorithm.h"
 #include "../freestandingInvalidArgument.h"
+#include "../utilities/safeMathFloat.h"
 #include "architecture/utilities/eigenSupport.h"
 #include "architecture/utilities/rigidBodyKinematics.hpp"
-#include <architecture/utilities/safeMath.h>
-
-#include <math.h>
 
 void CelestialTwoBodyPointAlgorithm::reset(const bool secCelBodyIsLinked) {
     this->secCelBodyIsLinked = secCelBodyIsLinked;
@@ -41,7 +39,7 @@ AttRefMsgF32Payload CelestialTwoBodyPointAlgorithm::update(EphemerisMsgF32Payloa
         v_P2B_N = Eigen::Map<const Eigen::Vector3d>(secCelBodyIn.v_BdyZero_N) -
                   Eigen::Map<const Eigen::Vector3d>(transNavIn.v_BN_N);
         const float dotProduct = R_P2B_N.normalized().dot(R_P1B_N.normalized());
-        platAngDiff = safeAcos(dotProduct);
+        platAngDiff = safeAcosf(dotProduct);
     }
 
     /*! - Cross the P1 states to get R_P2, v_p2 and a_P2 */

--- a/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
+++ b/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
@@ -46,8 +46,8 @@ AttRefMsgF32Payload CelestialTwoBodyPointAlgorithm::update(EphemerisMsgF32Payloa
     }
 
     /*! - Cross the P1 states to get R_P2, v_p2 and a_P2 */
-    if (!this->secCelBodyIsLinked || fabs(platAngDiff) < this->singularityThresh ||
-        fabs(platAngDiff) > M_PI - this->singularityThresh) {
+    if (!this->secCelBodyIsLinked || fabsf(platAngDiff) < this->singularityThresh ||
+        fabsf(platAngDiff) > M_PI - this->singularityThresh) {
         R_P2B_N = R_P1B_N.cross(v_P1B_N);
         v_P2B_N = Eigen::Vector3d::Zero();
     }

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenter.cpp
@@ -5,7 +5,15 @@
  */
 
 #include "ephemeridesRecenter.h"
+
+#include <algorithm>
 #include <stdexcept>
+
+static BodyName stringToBodyName(const std::string& bodyName) {
+    BodyName newBodyName{};
+    std::ranges::copy(bodyName.begin(), bodyName.end(), newBodyName.data());
+    return newBodyName;
+}
 
 /*! @brief This method resets the module.
  @return void
@@ -32,8 +40,9 @@ void EphemeridesRecenter::updateState(const uint64_t callTime) {
     std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> bodyPayloads{};
     for (auto i = 0; i < this->ephemeridesNumber; ++i) {
         BodyEphemerisPayload newBodyPayload{};
-        newBodyPayload.bodySpiceName = this->ephemerides[i].bodySpiceName;
-        newBodyPayload.originalCentralBodyName = this->ephemerides[i].originalCentralBodyName;
+        newBodyPayload.bodySpiceName = stringToBodyName(this->ephemerides.at(i).bodySpiceName);
+        newBodyPayload.originalCentralBodyName = stringToBodyName(this->ephemerides.at(i).originalCentralBodyName);
+
         newBodyPayload.inputEphemerisPayload = this->ephemerides[i].inputEphemerisMsg();
         bodyPayloads[i] = newBodyPayload;
     }
@@ -57,32 +66,34 @@ void EphemeridesRecenter::addBodyEphemerisToRecenter(const BodyEphemeris& epheme
     this->recenteredEphemerisOutputMsgs.push_back(new Message<EphemerisMsgF32Payload>);
     this->ephemerides[this->ephemeridesNumber] = ephemerisBody;
     this->ephemeridesNumber += 1;
-    this->algorithm.addBodyEphemerisToRecenter(ephemerisBody.bodySpiceName);
+    this->algorithm.addBodyEphemerisToRecenter(stringToBodyName(ephemerisBody.bodySpiceName));
 }
 
 /*! @brief Set a new celestial body center by name
  @return void
  @param bodyName std::string : the new zero base
  */
-void EphemeridesRecenter::setNewZeroBase(const std::string& bodyName) { this->algorithm.setNewZeroBaseName(bodyName); }
+void EphemeridesRecenter::setNewZeroBase(const std::string& bodyName) {
+    this->algorithm.setNewZeroBaseName(stringToBodyName(bodyName));
+}
 
 /*! @brief Get the new celestial body center by name
  @return std::string : the new zero base
  */
-std::string EphemeridesRecenter::getNewZeroBase() const { return this->algorithm.getNewZeroBase(); }
+std::string EphemeridesRecenter::getNewZeroBase() const { return {this->algorithm.getNewZeroBase().data()}; }
 
 /*! @brief Set the previous common zero base of all the celestial bodies entered
  @param bodyName std::string : the new zero base
  */
 void EphemeridesRecenter::setPreviousCommonZeroBase(const std::string& bodyName) {
-    this->algorithm.setPreviousCommonZeroBase(bodyName);
+    this->algorithm.setPreviousCommonZeroBase(stringToBodyName(bodyName));
 }
 
 /*! @brief Get the previous common zero base of all the celestial bodies entered
  @return std::string : the new zero base
  */
 std::string EphemeridesRecenter::getPreviousCommonZeroBase() const {
-    return this->algorithm.getPreviousCommonZeroBase();
+    return {this->algorithm.getPreviousCommonZeroBase().data()};
 }
 
 /*! @brief Get the number of bodies that were entered into the module
@@ -95,21 +106,25 @@ size_t EphemeridesRecenter::getNumberOfBodies() const { return this->algorithm.g
  @return size_t : whether or not the index was found
  */
 size_t EphemeridesRecenter::getBodyIndexFromName(const std::string& celestialBodyName) const {
-    return this->algorithm.getBodyIndexFromName(celestialBodyName);
+    return this->algorithm.getBodyIndexFromName(stringToBodyName(celestialBodyName));
 }
 
 /*! @brief Get all the names of the bodies entered
  @return std::array<std::string, MAX_NUM_CHANGE_BODIES> : an array of names
  */
 std::array<std::string, MAX_NUM_CHANGE_BODIES> EphemeridesRecenter::getAllNames() const {
-    return this->algorithm.getAllNames();
+    auto bodyNames = this->algorithm.getAllNames();
+    std::array<std::string, MAX_NUM_CHANGE_BODIES> bodyNamesAsStrings{};
+    for (size_t i = 0; i < MAX_NUM_CHANGE_BODIES; ++i) {
+        bodyNamesAsStrings.at(i) = std::string(bodyNames.at(i).data());
+    }
+    return bodyNamesAsStrings;
 }
 
 /*! @brief Clear all the bodies from the current list
  */
 void EphemeridesRecenter::clearAllBodies() {
-    BodyEphemeris emptyBody{};
-    std::fill(this->ephemerides.begin(), this->ephemerides.end(), emptyBody);
+    std::ranges::fill(this->ephemerides, BodyEphemeris{});
     this->ephemeridesNumber = 0;
     this->algorithm.clearAllBodies();
 }

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
@@ -8,27 +8,8 @@
 #include "../freestandingInvalidArgument.h"
 #include <algorithm>
 
-/*! @brief Subtract two C-array vectors
- @param v1 double[3] : vector 1
- @param v2 double[3] : vector 2
- @param result double[3] : subtracted vectors
- */
-static void vectorSubtraction(const double v1[3], const double v2[3], double result[3]) {
-    for (int i = 0; i < 3; ++i) {
-        result[i] = v1[i] - v2[i];
-    }
-}
-
-/*! @brief Add two C-array vectors
- @param v1 double[3] : vector 1
- @param v2 double[3] : vector 2
- @param result double[3] : added vectors
- */
-static void vectorAddition(const double v1[3], const double v2[3], double result[3]) {
-    for (int i = 0; i < 3; ++i) {
-        result[i] = v1[i] + v2[i];
-    }
-}
+#include "fp32-fsw-xmera/architecture/utilities/eigenSupport.h"
+#include <Eigen/Core>
 
 void EphemeridesRecenterAlgorithm::reset() {
     this->newCentralIndex = this->findNewZeroBaseIndex(this->newCentralBodyName);
@@ -48,12 +29,15 @@ std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgor
      * the list) first re-center the moon around the common central body so that every body is relative to the common
      * center*/
     if (newCentralBody.originalCentralBodyName != this->previousCentralBodyName) {
-        auto moonCentralBodyIndex = this->getBodyIndexFromName(newCentralBody.originalCentralBodyName);
+        const auto moonCentralBodyIndex = this->getBodyIndexFromName(newCentralBody.originalCentralBodyName);
         auto moonCentralBodyInput = this->celestialBodies[moonCentralBodyIndex].inputEphemerisPayload;
-        vectorAddition(
-            newCentralBodyPayload.r_BdyZero_N, moonCentralBodyInput.r_BdyZero_N, newCentralBodyPayload.r_BdyZero_N);
-        vectorAddition(
-            newCentralBodyPayload.v_BdyZero_N, moonCentralBodyInput.v_BdyZero_N, newCentralBodyPayload.v_BdyZero_N);
+        Eigen::Vector3d const relativePosition = cArrayToEigenVector3(newCentralBodyPayload.r_BdyZero_N) +
+                                                 cArrayToEigenVector3(moonCentralBodyInput.r_BdyZero_N);
+        eigenVectorToCArray(relativePosition, newCentralBodyPayload.r_BdyZero_N);
+
+        Eigen::Vector3d const relativeVelocity = cArrayToEigenVector3(newCentralBodyPayload.v_BdyZero_N) +
+                                                 cArrayToEigenVector3(moonCentralBodyInput.v_BdyZero_N);
+        eigenVectorToCArray(relativeVelocity, newCentralBodyPayload.v_BdyZero_N);
     }
 
     std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> recenteredBodies{};
@@ -64,22 +48,29 @@ std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgor
             EphemerisMsgF32Payload newEphemerisToRecenterPayload = newBodies[i].inputEphemerisPayload;
             if (this->celestialBodies[i].originalCentralBodyName != newCentralBody.bodySpiceName &&
                 this->celestialBodies[i].originalCentralBodyName == this->previousCentralBodyName) {
-                vectorSubtraction(newEphemerisToRecenterPayload.r_BdyZero_N,
-                                  newCentralBodyPayload.r_BdyZero_N,
-                                  newEphemerisToRecenterPayload.r_BdyZero_N);
-                vectorSubtraction(newEphemerisToRecenterPayload.v_BdyZero_N,
-                                  newCentralBodyPayload.v_BdyZero_N,
-                                  newEphemerisToRecenterPayload.v_BdyZero_N);
+                Eigen::Vector3d const relativePosition =
+                    cArrayToEigenVector3(newEphemerisToRecenterPayload.r_BdyZero_N) -
+                    cArrayToEigenVector3(newCentralBodyPayload.r_BdyZero_N);
+                eigenVectorToCArray(relativePosition, newEphemerisToRecenterPayload.r_BdyZero_N);
+
+                Eigen::Vector3d const relativeVelocity =
+                    cArrayToEigenVector3(newEphemerisToRecenterPayload.v_BdyZero_N) -
+                    cArrayToEigenVector3(newCentralBodyPayload.v_BdyZero_N);
+                eigenVectorToCArray(relativeVelocity, newEphemerisToRecenterPayload.v_BdyZero_N);
 
                 if (auto [moonIndex, moonFound] = this->findMoonOfBody(this->celestialBodies[i]);
-                    moonFound &&  this->celestialBodies[i].bodySpiceName != this->previousCentralBodyName) {
+                    moonFound && this->celestialBodies[i].bodySpiceName != this->previousCentralBodyName) {
                     EphemerisMsgF32Payload moonOfBodyPayload = this->celestialBodies[moonIndex].inputEphemerisPayload;
-                    vectorAddition(newEphemerisToRecenterPayload.r_BdyZero_N,
-                                   moonOfBodyPayload.r_BdyZero_N,
-                                   moonOfBodyPayload.r_BdyZero_N);
-                    vectorAddition(newEphemerisToRecenterPayload.v_BdyZero_N,
-                                   moonOfBodyPayload.v_BdyZero_N,
-                                   moonOfBodyPayload.v_BdyZero_N);
+
+                    Eigen::Vector3d const moonRelativePosition =
+                        cArrayToEigenVector3(newEphemerisToRecenterPayload.r_BdyZero_N) +
+                        cArrayToEigenVector3(moonOfBodyPayload.r_BdyZero_N);
+                    eigenVectorToCArray(moonRelativePosition, moonOfBodyPayload.r_BdyZero_N);
+
+                    Eigen::Vector3d const moonRelativeVelocity =
+                        cArrayToEigenVector3(newEphemerisToRecenterPayload.v_BdyZero_N) +
+                        cArrayToEigenVector3(moonOfBodyPayload.v_BdyZero_N);
+                    eigenVectorToCArray(moonRelativeVelocity, moonOfBodyPayload.v_BdyZero_N);
 
                     recenteredBodies[moonIndex].bodySpiceName = this->celestialBodies[moonIndex].bodySpiceName;
                     recenteredBodies[moonIndex].isMoon = true;

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
@@ -119,7 +119,7 @@ bool EphemeridesRecenterAlgorithm::findMoonOfBody(const BodyEphemerisPayload& ce
  @param celestialBodyName std::string : celestial body name
  @return size_t : index
  */
-size_t EphemeridesRecenterAlgorithm::getBodyIndexFromName(const std::string& celestialBodyName) const {
+size_t EphemeridesRecenterAlgorithm::getBodyIndexFromName(const BodyName& celestialBodyName) const {
     if (this->celestialBodyCount == 0) {
         FS_THROW_INVALID_ARGUMENT("Requesting a body index but the current celestial body count is 0");
     }
@@ -134,32 +134,29 @@ size_t EphemeridesRecenterAlgorithm::getBodyIndexFromName(const std::string& cel
 /*! @brief Set the new zero base body type by name
  @param bodyName std::string : the new zero base
  */
-void EphemeridesRecenterAlgorithm::setNewZeroBaseName(const std::string& bodyName) {
-    this->newCentralBodyName = bodyName;
-}
+void EphemeridesRecenterAlgorithm::setNewZeroBaseName(const BodyName& bodyName) { this->newCentralBodyName = bodyName; }
 
 /*! @brief Find the new zero base body type by name
- @param bodyName std::string : the new zero base
+ @param bodyName BodyName : the new zero base
  */
-size_t EphemeridesRecenterAlgorithm::findNewZeroBaseIndex(const std::string& bodyName) {
-    if (auto indexOfNewZeroBase = std::find(this->bodyNames.begin(), this->bodyNames.end(), bodyName);
-        indexOfNewZeroBase == this->bodyNames.end()) {
+size_t EphemeridesRecenterAlgorithm::findNewZeroBaseIndex(const BodyName& bodyName) {
+    auto* indexOfNewZeroBase = std::ranges::find(this->bodyNames, bodyName);
+    if (indexOfNewZeroBase == this->bodyNames.end()) {
         FS_THROW_INVALID_ARGUMENT("New zero base body was not in the list of existing bodies");
-    } else {
-        return std::distance(this->bodyNames.begin(), indexOfNewZeroBase);
     }
+    return std::distance(this->bodyNames.begin(), indexOfNewZeroBase);
 }
 
 /*! @brief Get the new celestial body center by name
- @return std::string : the new zero base
+ @return BodyName : the new zero base
  */
-std::string EphemeridesRecenterAlgorithm::getNewZeroBase() const { return this->newCentralBodyName; }
+BodyName EphemeridesRecenterAlgorithm::getNewZeroBase() const { return this->newCentralBodyName; }
 
 /*! @brief Set the previous common zero base of all the celestial bodies entered
- @param bodyName std::string : the new zero base
+ @param bodyName BodyName : the new zero base
  */
-void EphemeridesRecenterAlgorithm::setPreviousCommonZeroBase(const std::string& bodyName) {
-    if (auto indexOfPreviousZeroBase = std::find(this->bodyNames.begin(), this->bodyNames.end(), bodyName);
+void EphemeridesRecenterAlgorithm::setPreviousCommonZeroBase(const BodyName& bodyName) {
+    if (const auto* indexOfPreviousZeroBase = std::ranges::find(this->bodyNames, bodyName);
         indexOfPreviousZeroBase == this->bodyNames.end()) {
         FS_THROW_INVALID_ARGUMENT("Previous zero base body was not in the list of existing bodies");
     }
@@ -168,9 +165,9 @@ void EphemeridesRecenterAlgorithm::setPreviousCommonZeroBase(const std::string& 
 }
 
 /*! @brief Get the previous common zero base of all the celestial bodies entered
- @return std::string : the new zero base
+ @return BodyName : the new zero base
  */
-std::string EphemeridesRecenterAlgorithm::getPreviousCommonZeroBase() const { return this->previousCentralBodyName; }
+BodyName EphemeridesRecenterAlgorithm::getPreviousCommonZeroBase() const { return this->previousCentralBodyName; }
 
 /*! @brief Get the number of bodies that were entered into the module
  @return size_t : the number of bodies
@@ -178,13 +175,13 @@ std::string EphemeridesRecenterAlgorithm::getPreviousCommonZeroBase() const { re
 size_t EphemeridesRecenterAlgorithm::getNumberOfBodies() const { return this->celestialBodyCount; }
 
 /*! @brief Get all the names of the bodies entered
- @return std::array<std::string, MAX_NUM_CHANGE_BODIES> : an array of names
+ @return std::array<BodyName, MAX_NUM_CHANGE_BODIES> : an array of names
  */
-std::array<std::string, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgorithm::getAllNames() const {
+std::array<BodyName, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgorithm::getAllNames() const {
     if (this->celestialBodyCount == 0) {
         FS_THROW_INVALID_ARGUMENT("Requesting all body names but the current celestial body count is 0");
     }
-    std::array<std::string, MAX_NUM_CHANGE_BODIES> names{};
+    std::array<BodyName, MAX_NUM_CHANGE_BODIES> names{};
     for (size_t i = 0; i < this->celestialBodyCount; ++i) {
         if (!this->bodyNames[i].empty()) {
             names[i] = this->bodyNames[i];
@@ -194,14 +191,13 @@ std::array<std::string, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgorithm::get
 }
 
 /*! @brief Add celestial body by name
- @param bodyName std::string : the body name to add
+ @param bodyName BodyName : the body name to add
  */
-void EphemeridesRecenterAlgorithm::addBodyEphemerisToRecenter(const std::string& bodyName) {
+void EphemeridesRecenterAlgorithm::addBodyEphemerisToRecenter(const BodyName& bodyName) {
     if (this->celestialBodyCount + 1 > MAX_NUM_CHANGE_BODIES) {
         FS_THROW_INVALID_ARGUMENT("Adding one body too many to the list");
     }
-    if (auto indexInList = std::find(this->bodyNames.begin(), this->bodyNames.end(), bodyName);
-        indexInList != this->bodyNames.end()) {
+    if (const auto* indexInList = std::ranges::find(this->bodyNames, bodyName); indexInList != this->bodyNames.end()) {
         FS_THROW_INVALID_ARGUMENT("Body already added to list");
     }
     this->bodyNames[this->celestialBodyCount] = bodyName;
@@ -211,9 +207,7 @@ void EphemeridesRecenterAlgorithm::addBodyEphemerisToRecenter(const std::string&
 /*! @brief Clear all the bodies from the current list
  */
 void EphemeridesRecenterAlgorithm::clearAllBodies() {
-    BodyEphemerisPayload emptyBody{};
-    const std::string emptyString{};
-    std::fill(this->celestialBodies.begin(), this->celestialBodies.end(), emptyBody);
-    std::fill(this->bodyNames.begin(), this->bodyNames.end(), emptyString);
+    this->celestialBodies.fill(BodyEphemerisPayload{});
+    this->bodyNames.fill(BodyName{});
     this->celestialBodyCount = 0;
 }

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.cpp
@@ -71,8 +71,8 @@ std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgor
                                   newCentralBodyPayload.v_BdyZero_N,
                                   newEphemerisToRecenterPayload.v_BdyZero_N);
 
-                if (size_t moonIndex{}; this->findMoonOfBody(this->celestialBodies[i], &moonIndex) &&
-                                        this->celestialBodies[i].bodySpiceName != this->previousCentralBodyName) {
+                if (auto [moonIndex, moonFound] = this->findMoonOfBody(this->celestialBodies[i]);
+                    moonFound &&  this->celestialBodies[i].bodySpiceName != this->previousCentralBodyName) {
                     EphemerisMsgF32Payload moonOfBodyPayload = this->celestialBodies[moonIndex].inputEphemerisPayload;
                     vectorAddition(newEphemerisToRecenterPayload.r_BdyZero_N,
                                    moonOfBodyPayload.r_BdyZero_N,
@@ -97,22 +97,22 @@ std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> EphemeridesRecenterAlgor
     return recenteredBodies;
 }
 
-/*! @brief Find the moon index of a given body
- @param celestialBody std::string : celestial body name
- @param index size_t* : index
- @return bool : whether the index was found
+/*! @brief Find the moon index of a given body name
+ @param celestialBody - celestial body name
+ @return foundIndex - whether the moon name is found and the index to the body
  */
-bool EphemeridesRecenterAlgorithm::findMoonOfBody(const BodyEphemerisPayload& celestialBody, size_t* index) const {
+MoonIndexFound EphemeridesRecenterAlgorithm::findMoonOfBody(const BodyEphemerisPayload& celestialBody) const {
+    MoonIndexFound foundIndex{};
     if (this->celestialBodyCount == 0) {
         FS_THROW_INVALID_ARGUMENT("Requesting a body index but the current celestial body count is 0");
     }
     for (size_t i = 0; i < this->celestialBodyCount; ++i) {
         if (this->celestialBodies[i].originalCentralBodyName == celestialBody.bodySpiceName) {
-            *index = i;
-            return true;
+            foundIndex.index = i;
+            foundIndex.found = true;
         }
     }
-    return false;
+    return foundIndex;
 }
 
 /*! @brief Get the index of a body

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -9,18 +9,18 @@
 
 #include "msgPayloadDef/EphemerisMsgF32Payload.h"
 #include <array>
-#include <string>
 
 inline constexpr int MAX_NUM_CHANGE_BODIES = 20;
 
+using BodyName = std::array<char, 256>;
 /**
  * @brief Container for input/output ephemeris messages used in recentering.
  */
 class BodyEphemerisPayload {
    public:
-    std::string bodySpiceName;            //!< SPICE name of the body
-    std::string originalCentralBodyName;  //!< Original reference body for ephemeris data
-    bool isMoon{false};                   //!< Body is moon of another body in the list
+    BodyName bodySpiceName;            //!< SPICE name of the body
+    BodyName originalCentralBodyName;  //!< Original reference body for ephemeris data
+    bool isMoon{false};                //!< Body is moon of another body in the list
     EphemerisMsgF32Payload inputEphemerisPayload{EphemerisMsgF32Payload{}};  //!< Input ephemeris message
     EphemerisMsgF32Payload outputEphemerisPayload{
         EphemerisMsgF32Payload{}};  //!< Output ephemeris message after recentering
@@ -37,27 +37,27 @@ class EphemeridesRecenterAlgorithm {
     void reset();
     std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> updateState(
         const std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES>& newBody);
-    size_t getBodyIndexFromName(const std::string& celestialBodyName) const;
-    void setNewZeroBaseName(const std::string& bodyName);
-    size_t findNewZeroBaseIndex(const std::string& bodyName);
-    std::string getNewZeroBase() const;
-    void setPreviousCommonZeroBase(const std::string& bodyName);
-    std::string getPreviousCommonZeroBase() const;
+    size_t getBodyIndexFromName(const BodyName& celestialBodyName) const;
+    void setNewZeroBaseName(const BodyName& bodyName);
+    size_t findNewZeroBaseIndex(const BodyName& bodyName);
+    BodyName getNewZeroBase() const;
+    void setPreviousCommonZeroBase(const BodyName& bodyName);
+    BodyName getPreviousCommonZeroBase() const;
     size_t getNumberOfBodies() const;
-    std::array<std::string, MAX_NUM_CHANGE_BODIES> getAllNames() const;
-    void addBodyEphemerisToRecenter(const std::string& bodyName);
+    std::array<BodyName, MAX_NUM_CHANGE_BODIES> getAllNames() const;
+    void addBodyEphemerisToRecenter(const BodyName& bodyName);
     void clearAllBodies();
 
    private:
     bool findMoonOfBody(const BodyEphemerisPayload& celestialBody, size_t* index) const;
 
-    std::string newCentralBodyName{};
-    std::array<std::string, MAX_NUM_CHANGE_BODIES> bodyNames{};
+    BodyName newCentralBodyName{};
+    std::array<BodyName, MAX_NUM_CHANGE_BODIES> bodyNames{};
     size_t celestialBodyCount{};  //!< Number of primary bodies
     size_t newCentralIndex{};
     std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> celestialBodies{};  //!< All celestial bodies involved
     BodyEphemerisPayload previousCentralBody{};                                 //!< Previous reference body
-    std::string previousCentralBodyName{};
+    BodyName previousCentralBodyName{};
 };
 
 #endif

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -9,10 +9,17 @@
 
 #include "msgPayloadDef/EphemerisMsgF32Payload.h"
 #include <array>
+#include <cstddef>
 
 inline constexpr int MAX_NUM_CHANGE_BODIES = 20;
 
 using BodyName = std::array<char, 256>;
+
+struct MoonIndexFound {
+    size_t index;
+    bool found;
+};
+
 /**
  * @brief Container for input/output ephemeris messages used in recentering.
  */
@@ -49,7 +56,7 @@ class EphemeridesRecenterAlgorithm {
     void clearAllBodies();
 
    private:
-    bool findMoonOfBody(const BodyEphemerisPayload& celestialBody, size_t* index) const;
+    MoonIndexFound findMoonOfBody(const BodyEphemerisPayload& celestialBody) const;
 
     BodyName newCentralBodyName{};
     std::array<BodyName, MAX_NUM_CHANGE_BODIES> bodyNames{};

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm.h
@@ -43,7 +43,7 @@ class EphemeridesRecenterAlgorithm {
    public:
     void reset();
     std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> updateState(
-        const std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES>& newBody);
+        const std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES>& newBodies);
     size_t getBodyIndexFromName(const BodyName& celestialBodyName) const;
     void setNewZeroBaseName(const BodyName& bodyName);
     size_t findNewZeroBaseIndex(const BodyName& bodyName);

--- a/algorithms/mrpSteering/mrpSteeringAlgorithm.cpp
+++ b/algorithms/mrpSteering/mrpSteeringAlgorithm.cpp
@@ -8,7 +8,6 @@
 #include "../freestandingInvalidArgument.h"
 #include "architecture/utilities/eigenSupport.h"
 #include "architecture/utilities/rigidBodyKinematics.hpp"
-#include <math.h>
 #include <Eigen/Core>
 #include <numbers>
 

--- a/algorithms/msgPayloadDef/RWArrayConfigMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/RWArrayConfigMsgF32Payload.h
@@ -7,7 +7,7 @@
 #ifndef RW_CONFIG_MESSAGE_F32_H
 #define RW_CONFIG_MESSAGE_F32_H
 
-#include "architecture/msgPayloadDef/definitions.h"
+#include "definitions.h"
 #include <stdint.h>
 
 /*! @brief RW array configuration FSW msg */

--- a/algorithms/msgPayloadDef/RWConstellationMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/RWConstellationMsgF32Payload.h
@@ -8,7 +8,7 @@
 #define RW_CONSTELLATION_MESSAGE_F32_H
 
 #include "RWConfigElementMsgF32Payload.h"
-#include <architecture/msgPayloadDef/definitions.h>
+#include "definitions.h"
 
 /*! @brief Message used to define an array of RW FSW configurations  */
 typedef struct {

--- a/algorithms/msgPayloadDef/RWSpeedMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/RWSpeedMsgF32Payload.h
@@ -7,7 +7,7 @@
 #ifndef RW_SPEED_MESSAGE_F32_H
 #define RW_SPEED_MESSAGE_F32_H
 
-#include "architecture/msgPayloadDef/definitions.h"
+#include "definitions.h"
 
 /*! @brief Structure used to define the output definition for reaction wheel speeds*/
 typedef struct {

--- a/algorithms/msgPayloadDef/RwMotorTorqueMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/RwMotorTorqueMsgF32Payload.h
@@ -7,7 +7,7 @@
 #ifndef RW_MOTOR_TORQUE_MESSAGE_F32_H
 #define RW_MOTOR_TORQUE_MESSAGE_F32_H
 
-#include "architecture/msgPayloadDef/definitions.h"
+#include "definitions.h"
 
 /*! @brief Structure used to define the message format of the motor torque */
 typedef struct {

--- a/algorithms/msgPayloadDef/RwMotorVoltageMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/RwMotorVoltageMsgF32Payload.h
@@ -7,7 +7,7 @@
 #ifndef RW_MOTOR_VOLTAGE_MESSAGE_F32_H
 #define RW_MOTOR_VOLTAGE_MESSAGE_F32_H
 
-#include "architecture/msgPayloadDef/definitions.h"
+#include "definitions.h"
 
 /*! @brief Structure used to define the message format of the motor voltage input  */
 typedef struct {

--- a/algorithms/msgPayloadDef/definitions.h
+++ b/algorithms/msgPayloadDef/definitions.h
@@ -1,0 +1,8 @@
+#ifndef MSG_DEFINITIONS_H
+#define MSG_DEFINITIONS_H
+
+#define MAX_NUM_CSS_SENSORS 32
+#define MAX_EFF_CNT 36
+#define RW_EFF_CNT 36
+
+#endif  // MSG_DEFINITIONS_H

--- a/algorithms/sunSearch/sunSearchAlgorithm.cpp
+++ b/algorithms/sunSearch/sunSearchAlgorithm.cpp
@@ -5,11 +5,11 @@
 */
 
 #include "sunSearchAlgorithm.h"
+
 #include "architecture/utilities/eigenSupport.h"
 #include "architecture/utilities/macroDefinitions.h"
+#include "freestandingInvalidArgument.h"
 #include <math.h>
-
-#include "../freestandingInvalidArgument.h"
 
 /*! This method is used to reset the module.
  @return void

--- a/algorithms/sunSearch/sunSearchAlgorithm.cpp
+++ b/algorithms/sunSearch/sunSearchAlgorithm.cpp
@@ -9,7 +9,6 @@
 #include "architecture/utilities/eigenSupport.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include "freestandingInvalidArgument.h"
-#include <math.h>
 
 /*! This method is used to reset the module.
  @return void
@@ -84,7 +83,7 @@ void SunSearchAlgorithm::computeKinematicProperties(const uint32_t index) {
     /*! If angular acceleration exceeds limit, decrease acceleration and increase slew time */
     if (alpha > maxAcc) {
         alpha = maxAcc;
-        totalTime = 2 * sqrt(SP->slewAngle / alpha);
+        totalTime = 2 * sqrtf(SP->slewAngle / alpha);
         thrustTime = totalTime / 2;
         omegaMax = alpha * thrustTime;
     }

--- a/algorithms/utilities/CMakeLists.txt
+++ b/algorithms/utilities/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(AlgorithmUtilities INTERFACE)
 target_sources(AlgorithmUtilities INTERFACE
   ephemerisUtilities.cpp
   orbitalMotion.cpp
+  safeMathFloat.c
 )
 
 target_link_libraries(AlgorithmUtilities INTERFACE

--- a/algorithms/utilities/safeMathFloat.c
+++ b/algorithms/utilities/safeMathFloat.c
@@ -1,0 +1,30 @@
+#include "safeMathFloat.h"
+
+#include <math.h>
+
+float safeAcosf(const float x) {
+    if (x < -1.0F) {
+        return acosf(-1.0F);
+    }
+    if (x > 1.0F) {
+        return acosf(1.0F);
+    }
+    return acosf(x);
+}
+
+float safeAsinf(const float x) {
+    if (x < -1.0F) {
+        return asinf(-1.0F);
+    }
+    if (x > 1.0F) {
+        return asinf(1.0F);
+    }
+    return asinf(x);
+}
+
+float safeSqrtf(const float x) {
+    if (x < 0.0F) {
+        return 0.0F;
+    }
+    return sqrtf(x);
+}

--- a/algorithms/utilities/safeMathFloat.h
+++ b/algorithms/utilities/safeMathFloat.h
@@ -1,0 +1,14 @@
+#ifndef SAFE_MATH_FLOAT_H_
+#define SAFE_MATH_FLOAT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+float safeAcosf(float x);
+float safeAsinf(float x);
+float safeSqrtf(float x);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/architecture/utilities/eigenSupport.h
+++ b/architecture/utilities/eigenSupport.h
@@ -1,32 +1,13 @@
-/*
- ISC License
+#ifndef EIGEN_SUPPORT
+#define EIGEN_SUPPORT
 
- Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
-
- Permission to use, copy, modify, and/or distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
-
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
- */
-
-#ifndef EIGENSUPPORT
-#define EIGENSUPPORT
-
-#include "eigenMRP.h"
+#include <architecture/utilities/eigenMRP.h>
 
 #include <Eigen/Core>
 #include <exception>
 
 template <class Derived>
-constexpr bool is_row_major_v = (Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0;
+inline constexpr bool is_row_major_v = (Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0;
 
 template <class Derived>
 inline constexpr bool is_fixed_v =
@@ -44,24 +25,24 @@ inline constexpr bool is_fixed_v =
  * @param inMat Matrix to copy from.
  * @param out Destination array that receives the flattened entries.
  */
-template <class Derived, std::size_t Size>
-void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Size]) {
+template <class Derived, std::size_t size>
+void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[size]) {
     static_assert(Derived::RowsAtCompileTime != Eigen::Dynamic && Derived::ColsAtCompileTime != Eigen::Dynamic,
                   "Input must be a fixed-size Eigen type.");
 
-    using Scalar = typename Derived::Scalar;
+    using Scalar = Derived::Scalar;
     constexpr int Rows = Derived::RowsAtCompileTime;
     constexpr int Cols = Derived::ColsAtCompileTime;
 
-    static_assert(static_cast<std::size_t>(Rows) * static_cast<std::size_t>(Cols) == Size,
+    static_assert(static_cast<std::size_t>(Rows) * static_cast<std::size_t>(Cols) == size,
                   "Output array size must equal rows*cols of input.");
 
     if constexpr ((Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0) {
         Eigen::Matrix<Scalar, Rows, Cols, Eigen::RowMajor> tmp = inMat;
-        std::memcpy(out, tmp.data(), Size * sizeof(Scalar));
+        std::copy(tmp.data(), tmp.data() + tmp.size(), out);
     } else {
         Eigen::Matrix<Scalar, Cols, Rows> tmpT = inMat.transpose();
-        std::memcpy(out, tmpT.data(), Size * sizeof(Scalar));
+        std::copy(tmpT.data(), tmpT.data() + tmpT.size(), out);
     }
 }
 
@@ -77,19 +58,18 @@ void eigenMatrixToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Deriv
  * @param inMat Matrix to copy from.
  * @param out Destination array that must hold at least `inMat.size()` values.
  */
-template <class Derived, std::size_t Size>
-void eigenMatrixXToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Size]) {
-    using Scalar = typename Derived::Scalar;
+template <class Derived, std::size_t size>
+void eigenMatrixXToCArray(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[size]) {
+    using Scalar = Derived::Scalar;
 
     // Runtime capacity check against compile-time size
-    if (static_cast<std::size_t>(inMat.size()) > Size) {
+    if (static_cast<std::size_t>(inMat.size()) > size) {
         std::terminate();
     }
 
     // Make a contiguous row-major buffer regardless of input layout
     Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
-    const auto count = static_cast<std::size_t>(inMat.size());
-    std::memcpy(out, rm.data(), count * sizeof(Scalar));
+    std::copy(rm.data(), rm.data() + rm.size(), out);
 }
 
 /**
@@ -110,7 +90,7 @@ void eigenMatrixToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Der
     static_assert(Derived::RowsAtCompileTime != Eigen::Dynamic && Derived::ColsAtCompileTime != Eigen::Dynamic,
                   "Input must be a fixed-size Eigen type.");
 
-    using Scalar = typename Derived::Scalar;
+    using Scalar = Derived::Scalar;
     constexpr int R = Derived::RowsAtCompileTime;
     constexpr int C = Derived::ColsAtCompileTime;
 
@@ -119,10 +99,10 @@ void eigenMatrixToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Der
 
     if constexpr ((Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0) {
         Eigen::Matrix<Scalar, R, C, Eigen::RowMajor> tmp = inMat;
-        std::memcpy(out, tmp.data(), N * M * sizeof(Scalar));
+        std::copy(tmp.data(), tmp.data() + tmp.size(), &out[0][0]);
     } else {
         Eigen::Matrix<Scalar, C, R> tmpT = inMat.transpose();
-        std::memcpy(out, tmpT.data(), N * M * sizeof(Scalar));
+        std::copy(tmpT.data(), tmpT.data() + tmpT.size(), &out[0][0]);
     }
 }
 
@@ -139,17 +119,17 @@ void eigenMatrixToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Der
  * @param inMat Matrix to copy from.
  * @param out Destination 2-D array `out[Rows][Cols]`.
  */
-template <class Derived, std::size_t Rows, std::size_t Cols>
-void eigenMatrixXToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[Rows][Cols]) {
-    using Scalar = typename Derived::Scalar;
+template <class Derived, std::size_t rows, std::size_t cols>
+void eigenMatrixXToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename Derived::Scalar (&out)[rows][cols]) {
+    using Scalar = Derived::Scalar;
 
     // Enforce shape at runtime (safer for 2-D indexing)
-    if (inMat.rows() != static_cast<int>(Rows) || inMat.cols() != static_cast<int>(Cols)) {
+    if (inMat.rows() != static_cast<int>(rows) || inMat.cols() != static_cast<int>(cols)) {
         std::terminate();
     }
 
     Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
-    std::memcpy(&out[0][0], rm.data(), Rows * Cols * sizeof(Scalar));
+    std::copy(rm.data(), rm.data() + rm.size(), &out[0][0]);
 }
 
 /**
@@ -167,35 +147,36 @@ void eigenMatrixXToCArray2D(const Eigen::MatrixBase<Derived>& inMat, typename De
  * @param offset Starting index in `out` for the first element.
  * @param stride Number of indices to skip between elements (default 1).
  */
-template <class Derived, std::size_t Size>
+template <class Derived, std::size_t size>
 void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
-                              typename Derived::Scalar (&out)[Size],
+                              typename Derived::Scalar (&out)[size],
                               std::size_t offset,
-                              const std::size_t stride = 1) {
-    using Scalar = typename Derived::Scalar;
+                              const std::size_t stride = 1U) {
+    using Scalar = Derived::Scalar;
 
     const auto count = static_cast<std::size_t>(inMat.size());
-    if (count == 0) return;
+    if (count == 0U) {
+        return;
+    }
 
-    if (stride == 0 && count > 1) {
+    if (stride == 0U && count > 1U) {
         std::terminate();
     }
 
     // Capacity check: last index must be < N
-    const std::size_t last_index = offset + (count - 1) * stride;
-    if (last_index >= Size) {
+    if (const std::size_t last_index = offset + ((count - 1U) * stride); last_index >= size) {
         std::terminate();
     }
 
     // Make a contiguous row-major buffer regardless of input layout
     Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rm = inMat.derived();
 
-    if (stride == 1) {
-        std::memcpy(out + offset, rm.data(), count * sizeof(Scalar));
+    if (stride == 1U) {
+        std::copy(rm.data(), rm.data() + rm.size(), out + offset);
     } else {
         const Scalar* src = rm.data();
         std::size_t idx = offset;
-        for (std::size_t i = 0; i < count; ++i) {
+        for (std::size_t i = 0U; i < count; ++i) {
             out[idx] = src[i];
             idx += stride;
         }
@@ -212,7 +193,7 @@ void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
  */
 template <typename ScalarT, int size>
 void eigenVectorToCArray(const Eigen::Vector<ScalarT, size>& inVec, ScalarT* outArray) {
-    memcpy(outArray, inVec.data(), size * sizeof(ScalarT));
+    std::copy(inVec.data(), inVec.data() + size, outArray);
 }
 
 /**
@@ -225,10 +206,8 @@ void eigenVectorToCArray(const Eigen::Vector<ScalarT, size>& inVec, ScalarT* out
  * @return Eigen matrix populated with the values from `inArray`.
  */
 template <typename ScalarT, int rows, int cols>
-Eigen::Matrix<ScalarT, rows, cols> cArrayAsEigenMatrix(ScalarT* inArray) {
-    Eigen::Matrix<ScalarT, rows, cols> outMat;
-    outMat = Eigen::Map<Eigen::Matrix<ScalarT, rows, cols>>(inArray, outMat.rows(), outMat.cols());
-    return outMat;
+Eigen::Matrix<ScalarT, rows, cols> cArrayToEigenMatrix(ScalarT* inArray) {
+    return Eigen::Map<Eigen::Matrix<ScalarT, rows, cols>>(inArray);
 }
 
 /**
@@ -241,9 +220,8 @@ Eigen::Matrix<ScalarT, rows, cols> cArrayAsEigenMatrix(ScalarT* inArray) {
  * @return Eigen dynamic matrix containing the mapped values.
  */
 template <typename ScalarT>
-Eigen::MatrixX<ScalarT> cArrayAsEigenMatrixX(ScalarT* inArray, int nRows, int nCols) {
-    Eigen::MatrixX<ScalarT> outMat;
-    outMat.resize(nRows, nCols);
+Eigen::MatrixX<ScalarT> cArrayToEigenMatrixX(ScalarT* inArray, int nRows, int nCols) {
+    Eigen::MatrixX<ScalarT> outMat(nRows, nCols);
     outMat = Eigen::Map<Eigen::MatrixX<ScalarT>>(inArray, outMat.rows(), outMat.cols());
     return outMat;
 }
@@ -256,8 +234,8 @@ Eigen::MatrixX<ScalarT> cArrayAsEigenMatrixX(ScalarT* inArray, int nRows, int nC
  * @param inArray Reference to the C array holding the coefficients.
  * @return Eigen vector whose contents match the input array.
  */
-template <typename ScalarT, std::size_t size>
-Eigen::Vector<ScalarT, size> cArrayAsEigenVector(ScalarT (&inArray)[size]) {
+template <typename ScalarT, int size>
+Eigen::Vector<ScalarT, size> cArrayToEigenVector(ScalarT (&inArray)[size]) {
     return Eigen::Map<Eigen::Vector<ScalarT, size>>(inArray);
 }
 
@@ -269,7 +247,7 @@ Eigen::Vector<ScalarT, size> cArrayAsEigenVector(ScalarT (&inArray)[size]) {
  * @return Eigen::Vector3 populated from the input data.
  */
 template <typename ScalarT>
-Eigen::Vector3<ScalarT> cArrayAsEigenVector3(ScalarT* inArray) {
+Eigen::Vector3<ScalarT> cArrayToEigenVector3(ScalarT* inArray) {
     return Eigen::Map<Eigen::Vector3<ScalarT>>(inArray);
 }
 
@@ -281,7 +259,7 @@ Eigen::Vector3<ScalarT> cArrayAsEigenVector3(ScalarT* inArray) {
  * @return Eigen::MRP constructed from the input.
  */
 template <typename ScalarT>
-Eigen::MRP<ScalarT> cArrayAsEigenMrp(ScalarT* inArray) {
+Eigen::MRP<ScalarT> cArrayToEigenMrp(ScalarT* inArray) {
     Eigen::MRP<ScalarT> sigma_Eigen;
     sigma_Eigen = Eigen::Map<Eigen::Vector<ScalarT, 3>>(inArray);
 
@@ -296,7 +274,7 @@ Eigen::MRP<ScalarT> cArrayAsEigenMrp(ScalarT* inArray) {
  * @return Eigen::Matrix3 with the copied values.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> cArrayAsEigenMatrix3(ScalarT* inArray) {
+Eigen::Matrix3<ScalarT> cArrayToEigenMatrix3(ScalarT* inArray) {
     return Eigen::Map<Eigen::Matrix3<ScalarT>>(inArray, 3, 3).transpose();
 }
 
@@ -308,14 +286,8 @@ Eigen::Matrix3<ScalarT> cArrayAsEigenMatrix3(ScalarT* inArray) {
  * @return Eigen::Matrix3 containing the same entries.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> c2DArrayAsEigenMatrix3(ScalarT in2DArray[3][3]) {
-    Eigen::Matrix3<ScalarT> outMat;
-    for (int i = 0; i < 3; i++) {
-        for (int j = 0; j < 3; j++) {
-            outMat(i, j) = in2DArray[i][j];
-        }
-    }
-
+Eigen::Matrix3<ScalarT> c2DArrayToEigenMatrix3(ScalarT in2DArray[3][3]) {
+    Eigen::Matrix3<ScalarT> outMat = Eigen::Map<const Eigen::Matrix<ScalarT, 3, 3, Eigen::RowMajor>>(&in2DArray[0][0]);
     return outMat;
 }
 
@@ -327,14 +299,8 @@ Eigen::Matrix3<ScalarT> c2DArrayAsEigenMatrix3(ScalarT in2DArray[3][3]) {
  * @return Eigen::Vector3 containing the MRP coefficients.
  */
 template <typename ScalarT>
-Eigen::Vector3<ScalarT> eigenMrpToVector3(const Eigen::MRP<ScalarT> mrp) {
-    Eigen::Vector3<ScalarT> vec3;
-
-    vec3[0] = mrp.x();
-    vec3[1] = mrp.y();
-    vec3[2] = mrp.z();
-
-    return vec3;
+Eigen::Vector3<ScalarT> eigenMrpToVector3(const Eigen::MRP<ScalarT>& mrp) {
+    return Eigen::Vector3<ScalarT>(mrp.x(), mrp.y(), mrp.z());
 }
 
 /**
@@ -345,15 +311,11 @@ Eigen::Vector3<ScalarT> eigenMrpToVector3(const Eigen::MRP<ScalarT> mrp) {
  * @return Eigen::Matrix3 representing the rotation.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> eigenM1(const ScalarT angle) {
-    Eigen::Matrix3<ScalarT> mOut = Eigen::Matrix3<ScalarT>::Identity();
+Eigen::Matrix3<ScalarT> eigenM1(ScalarT angle) {
+    const ScalarT c = std::cos(angle);
+    const ScalarT s = std::sin(angle);
 
-    mOut(1, 1) = std::cos(angle);
-    mOut(1, 2) = std::sin(angle);
-    mOut(2, 1) = -std::sin(angle);
-    mOut(2, 2) = std::cos(angle);
-
-    return mOut;
+    return Eigen::Matrix3<ScalarT>{{ScalarT{1}, ScalarT{0}, ScalarT{0}}, {ScalarT{0}, c, s}, {ScalarT{0}, -s, c}};
 }
 
 /**
@@ -364,15 +326,11 @@ Eigen::Matrix3<ScalarT> eigenM1(const ScalarT angle) {
  * @return Eigen::Matrix3 representing the rotation.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> eigenM2(const ScalarT angle) {
-    Eigen::Matrix3<ScalarT> mOut = Eigen::Matrix3<ScalarT>::Identity();
+Eigen::Matrix3<ScalarT> eigenM2(ScalarT angle) {
+    const ScalarT c = std::cos(angle);
+    const ScalarT s = std::sin(angle);
 
-    mOut(0, 0) = std::cos(angle);
-    mOut(0, 2) = -std::sin(angle);
-    mOut(2, 0) = std::sin(angle);
-    mOut(2, 2) = std::cos(angle);
-
-    return mOut;
+    return Eigen::Matrix3<ScalarT>{{c, ScalarT{0}, -s}, {ScalarT{0}, ScalarT{1}, ScalarT{0}}, {s, ScalarT{0}, c}};
 }
 
 /**
@@ -383,15 +341,11 @@ Eigen::Matrix3<ScalarT> eigenM2(const ScalarT angle) {
  * @return Eigen::Matrix3 representing the rotation.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> eigenM3(const ScalarT angle) {
-    Eigen::Matrix3<ScalarT> mOut = Eigen::Matrix3<ScalarT>::Identity();
+Eigen::Matrix3<ScalarT> eigenM3(ScalarT angle) {
+    const ScalarT c = std::cos(angle);
+    const ScalarT s = std::sin(angle);
 
-    mOut(0, 0) = std::cos(angle);
-    mOut(0, 1) = std::sin(angle);
-    mOut(1, 0) = -std::sin(angle);
-    mOut(1, 1) = std::cos(angle);
-
-    return mOut;
+    return Eigen::Matrix3<ScalarT>{{c, s, ScalarT{0}}, {-s, c, ScalarT{0}}, {ScalarT{0}, ScalarT{0}, ScalarT{1}}};
 }
 
 /**
@@ -403,18 +357,13 @@ Eigen::Matrix3<ScalarT> eigenM3(const ScalarT angle) {
  */
 template <typename Derived>
 Eigen::Matrix3<typename Eigen::MatrixBase<Derived>::Scalar> eigenTilde(const Eigen::MatrixBase<Derived>& vec) {
-    using Scalar = typename Eigen::MatrixBase<Derived>::Scalar;
+    using Scalar = Eigen::MatrixBase<Derived>::Scalar;
 
-    Eigen::Matrix3<Scalar> mOut = Eigen::Matrix3<Scalar>::Zero();
+    const Scalar vx = vec(0);
+    const Scalar vy = vec(1);
+    const Scalar vz = vec(2);
 
-    mOut(0, 1) = -vec(2);
-    mOut(1, 0) = vec(2);
-    mOut(0, 2) = vec(1);
-    mOut(2, 0) = -vec(1);
-    mOut(1, 2) = -vec(0);
-    mOut(2, 1) = vec(0);
-
-    return mOut;
+    return Eigen::Matrix3<Scalar>{{Scalar{0}, -vz, vy}, {vz, Scalar{0}, -vx}, {-vy, vx, Scalar{0}}};
 }
 
-#endif  // EIGENSUPPORT
+#endif  // EIGEN_SUPPORT

--- a/architecture/utilities/macroDefinitions.h
+++ b/architecture/utilities/macroDefinitions.h
@@ -1,0 +1,11 @@
+#ifndef SIM_FSW_MACROS_H
+#define SIM_FSW_MACROS_H
+
+#define NANO2SEC 1e-9
+#define SEC2NANO 1e9
+#define RECAST6X6 (double (*)[6])
+#define RECAST3X3 (double (*)[3])
+#define RECAST2x2 (double (*)[2])
+#define SEC2HOUR 1. / 3600.
+
+#endif


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This Add a number of changes that support the independent (non Xmera) build of the algorithms. These changes in order of commit are:
- Gating generation of Ada bindings with a Cmake option so that they are optional during build.
- Added (temporarily) some Xmera #defines for use until new time types arrive.
- Remove vcpkg caching step because we now do it with a nuget repository
- CTest runs are added to coverage reporting (prior, only Pytest triggered test were included)
- A set of message #defines were adding so that message types are fully independent of Xmera
- Added float version of safeMath.h/c
- The following 7 commits see to fixing build errors and integrating the newly added includes of safeMath and #defines 
- The final commit adds all (bar 3) algorithms to be built. The excluded 3 require work that is well outside the scope of this PR and noted in the Future Work

## Verification
These algorithms successfully compile and Ada bindings are generated. Also, the modules still build and pass tests when included as part of a Xmera build.

## Documentation
None.

## Future work
The Xmera dependency for the algorithm build be provided via CMake FetchContent. This will allow the algorithms to rely  on xmera includes as a dependency and no longer need to copy a version of the file into the xmera project directly. This is particularly useful for message definition dependencies like FSWDeviceAvailability. 
