### PR TITLE
Add C shims for ephemNavConverter, navAggregate, and sunlineEphem

### DIFF
--- a/algorithms/ephemNavConverter/ephemNavConverterAlgorithm_c.cpp
+++ b/algorithms/ephemNavConverter/ephemNavConverterAlgorithm_c.cpp
@@ -1,0 +1,16 @@
+#include "ephemNavConverterAlgorithm_c.h"
+#include "ephemNavConverterAlgorithm.h"
+
+EphemNavConverterAlgorithm* EphemNavConverterAlgorithm_create(void) {
+    return reinterpret_cast<EphemNavConverterAlgorithm*>(new ::EphemNavConverterAlgorithm());
+}
+
+void EphemNavConverterAlgorithm_destroy(EphemNavConverterAlgorithm* self) {
+    delete reinterpret_cast<::EphemNavConverterAlgorithm*>(self);
+}
+
+NavTransMsgF32Payload EphemNavConverterAlgorithm_update(EphemNavConverterAlgorithm* self,
+                                                        uint64_t callTime,
+                                                        const EphemerisMsgF32Payload* ephemerisInMsg) {
+    return reinterpret_cast<::EphemNavConverterAlgorithm*>(self)->update(callTime, *ephemerisInMsg);
+}

--- a/algorithms/ephemNavConverter/ephemNavConverterAlgorithm_c.h
+++ b/algorithms/ephemNavConverter/ephemNavConverterAlgorithm_c.h
@@ -1,0 +1,44 @@
+#ifndef F32XIMERA_EPHEMNAVCONVERTERALGORITHM_C_H
+#define F32XIMERA_EPHEMNAVCONVERTERALGORITHM_C_H
+
+#include "msgPayloadDef/EphemerisMsgF32Payload.h"
+#include "msgPayloadDef/NavTransMsgF32Payload.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Opaque handle to the C++ EphemNavConverterAlgorithm instance.
+ */
+typedef struct EphemNavConverterAlgorithm EphemNavConverterAlgorithm;
+
+/**
+ * @brief Construct a new EphemNavConverterAlgorithm instance.
+ * @return Pointer to a new EphemNavConverterAlgorithm (must be destroyed).
+ */
+EphemNavConverterAlgorithm* EphemNavConverterAlgorithm_create(void);
+
+/**
+ * @brief Destroy a previously created EphemNavConverterAlgorithm.
+ * @param self Pointer to the instance to destroy.
+ */
+void EphemNavConverterAlgorithm_destroy(EphemNavConverterAlgorithm* self);
+
+/**
+ * @brief Run the update step.
+ * @param self           Pointer to the instance.
+ * @param callTime       Time stamp for update.
+ * @param ephemerisInMsg Pointer to ephemeris message payload.
+ * @return NavTransMsgF32Payload  The computed navigation translation message.
+ */
+NavTransMsgF32Payload EphemNavConverterAlgorithm_update(EphemNavConverterAlgorithm* self,
+                                                        uint64_t callTime,
+                                                        const EphemerisMsgF32Payload* ephemerisInMsg);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // F32XIMERA_EPHEMNAVCONVERTERALGORITHM_C_H

--- a/algorithms/navAggregate/navAggregateAlgorithm.h
+++ b/algorithms/navAggregate/navAggregateAlgorithm.h
@@ -13,14 +13,9 @@
 
 #include "msgPayloadDef/NavAttMsgF32Payload.h"
 #include "msgPayloadDef/NavTransMsgF32Payload.h"
+#include "navAggregateOutput.h"
 
 #define MAX_AGG_NAV_MSG 10
-
-/*! structure containing the attitude and translational navigation out messages */
-typedef struct {
-    NavAttMsgF32Payload navAttOut;     /*!< attitude navigation out message payload */
-    NavTransMsgF32Payload navTransOut; /*!< translation navigation out message payload */
-} AggregateOutput;
 
 class NavAggregateAlgorithm {
    public:

--- a/algorithms/navAggregate/navAggregateAlgorithm_c.cpp
+++ b/algorithms/navAggregate/navAggregateAlgorithm_c.cpp
@@ -1,0 +1,109 @@
+#include "navAggregateAlgorithm_c.h"
+#include "navAggregateAlgorithm.h"
+
+#include <array>
+
+uint32_t NavAggregateAlgorithm_getMaxAggNavMsg(void) { return MAX_AGG_NAV_MSG; }
+
+NavAggregateAlgorithm* NavAggregateAlgorithm_create(void) {
+    return reinterpret_cast<NavAggregateAlgorithm*>(new ::NavAggregateAlgorithm());
+}
+
+void NavAggregateAlgorithm_destroy(NavAggregateAlgorithm* self) {
+    delete reinterpret_cast<::NavAggregateAlgorithm*>(self);
+}
+
+AggregateOutput NavAggregateAlgorithm_update(NavAggregateAlgorithm* self,
+                                             const NavAttMsgF32Payload* attMsgsPayloads,
+                                             const NavTransMsgF32Payload* transMsgsPayloads) {
+    // Convert C arrays to std::array for C++ algorithm call
+    std::array<NavAttMsgF32Payload, MAX_AGG_NAV_MSG> attArray;
+    std::array<NavTransMsgF32Payload, MAX_AGG_NAV_MSG> transArray;
+
+    for (uint32_t i = 0; i < MAX_AGG_NAV_MSG; ++i) {
+        attArray[i] = attMsgsPayloads[i];
+        transArray[i] = transMsgsPayloads[i];
+    }
+
+    return reinterpret_cast<::NavAggregateAlgorithm*>(self)->update(attArray, transArray);
+}
+
+void NavAggregateAlgorithm_setAttTimeIdx(NavAggregateAlgorithm* self, uint32_t idx) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setAttTimeIdx(idx);
+}
+
+uint32_t NavAggregateAlgorithm_getAttTimeIdx(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getAttTimeIdx();
+}
+
+void NavAggregateAlgorithm_setTransTimeIdx(NavAggregateAlgorithm* self, uint32_t idx) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setTransTimeIdx(idx);
+}
+
+uint32_t NavAggregateAlgorithm_getTransTimeIdx(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getTransTimeIdx();
+}
+
+void NavAggregateAlgorithm_setAttIdx(NavAggregateAlgorithm* self, uint32_t idx) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setAttIdx(idx);
+}
+
+uint32_t NavAggregateAlgorithm_getAttIdx(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getAttIdx();
+}
+
+void NavAggregateAlgorithm_setRateIdx(NavAggregateAlgorithm* self, uint32_t idx) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setRateIdx(idx);
+}
+
+uint32_t NavAggregateAlgorithm_getRateIdx(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getRateIdx();
+}
+
+void NavAggregateAlgorithm_setPosIdx(NavAggregateAlgorithm* self, uint32_t idx) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setPosIdx(idx);
+}
+
+uint32_t NavAggregateAlgorithm_getPosIdx(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getPosIdx();
+}
+
+void NavAggregateAlgorithm_setVelIdx(NavAggregateAlgorithm* self, uint32_t idx) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setVelIdx(idx);
+}
+
+uint32_t NavAggregateAlgorithm_getVelIdx(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getVelIdx();
+}
+
+void NavAggregateAlgorithm_setDvIdx(NavAggregateAlgorithm* self, uint32_t idx) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setDvIdx(idx);
+}
+
+uint32_t NavAggregateAlgorithm_getDvIdx(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getDvIdx();
+}
+
+void NavAggregateAlgorithm_setSunIdx(NavAggregateAlgorithm* self, uint32_t idx) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setSunIdx(idx);
+}
+
+uint32_t NavAggregateAlgorithm_getSunIdx(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getSunIdx();
+}
+
+void NavAggregateAlgorithm_setAttMsgCount(NavAggregateAlgorithm* self, uint32_t msgCount) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setAttMsgCount(msgCount);
+}
+
+uint32_t NavAggregateAlgorithm_getAttMsgCount(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getAttMsgCount();
+}
+
+void NavAggregateAlgorithm_setTransMsgCount(NavAggregateAlgorithm* self, uint32_t msgCount) {
+    reinterpret_cast<::NavAggregateAlgorithm*>(self)->setTransMsgCount(msgCount);
+}
+
+uint32_t NavAggregateAlgorithm_getTransMsgCount(const NavAggregateAlgorithm* self) {
+    return reinterpret_cast<const ::NavAggregateAlgorithm*>(self)->getTransMsgCount();
+}

--- a/algorithms/navAggregate/navAggregateAlgorithm_c.h
+++ b/algorithms/navAggregate/navAggregateAlgorithm_c.h
@@ -1,0 +1,191 @@
+#ifndef F32XIMERA_NAVAGGREGATEALGORITHM_C_H
+#define F32XIMERA_NAVAGGREGATEALGORITHM_C_H
+
+#include "navAggregateOutput.h"
+#include <stdint.h>
+
+#define MAX_AGG_NAV_MSG 10
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Opaque handle to the C++ NavAggregateAlgorithm instance.
+ */
+typedef struct NavAggregateAlgorithm NavAggregateAlgorithm;
+
+/**
+ * @brief Get the maximum aggregate navigation message count.
+ * @return The maximum message count (MAX_AGG_NAV_MSG).
+ */
+uint32_t NavAggregateAlgorithm_getMaxAggNavMsg(void);
+
+/**
+ * @brief Construct a new NavAggregateAlgorithm instance.
+ * @return Pointer to a new NavAggregateAlgorithm (must be destroyed).
+ */
+NavAggregateAlgorithm* NavAggregateAlgorithm_create(void);
+
+/**
+ * @brief Destroy a previously created NavAggregateAlgorithm.
+ * @param self Pointer to the instance to destroy.
+ */
+void NavAggregateAlgorithm_destroy(NavAggregateAlgorithm* self);
+
+/**
+ * @brief Run the update step.
+ * @param self               Pointer to the instance.
+ * @param attMsgsPayloads    Pointer to array of attitude navigation message payloads.
+ * @param transMsgsPayloads  Pointer to array of translational navigation message payloads.
+ * @return AggregateOutput   The computed output messages.
+ */
+AggregateOutput NavAggregateAlgorithm_update(NavAggregateAlgorithm* self,
+                                             const NavAttMsgF32Payload* attMsgsPayloads,
+                                             const NavTransMsgF32Payload* transMsgsPayloads);
+
+/**
+ * @brief Set the attitude time index.
+ * @param self Pointer to the instance.
+ * @param idx  The new attitude time index to set.
+ */
+void NavAggregateAlgorithm_setAttTimeIdx(NavAggregateAlgorithm* self, uint32_t idx);
+
+/**
+ * @brief Get the current attitude time index.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current attitude time index.
+ */
+uint32_t NavAggregateAlgorithm_getAttTimeIdx(const NavAggregateAlgorithm* self);
+
+/**
+ * @brief Set the translation time index.
+ * @param self Pointer to the instance.
+ * @param idx  The new translation time index to set.
+ */
+void NavAggregateAlgorithm_setTransTimeIdx(NavAggregateAlgorithm* self, uint32_t idx);
+
+/**
+ * @brief Get the current translation time index.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current translation time index.
+ */
+uint32_t NavAggregateAlgorithm_getTransTimeIdx(const NavAggregateAlgorithm* self);
+
+/**
+ * @brief Set the attitude index.
+ * @param self Pointer to the instance.
+ * @param idx  The new attitude index to set.
+ */
+void NavAggregateAlgorithm_setAttIdx(NavAggregateAlgorithm* self, uint32_t idx);
+
+/**
+ * @brief Get the current attitude index.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current attitude index.
+ */
+uint32_t NavAggregateAlgorithm_getAttIdx(const NavAggregateAlgorithm* self);
+
+/**
+ * @brief Set the rate index.
+ * @param self Pointer to the instance.
+ * @param idx  The new rate index to set.
+ */
+void NavAggregateAlgorithm_setRateIdx(NavAggregateAlgorithm* self, uint32_t idx);
+
+/**
+ * @brief Get the current rate index.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current rate index.
+ */
+uint32_t NavAggregateAlgorithm_getRateIdx(const NavAggregateAlgorithm* self);
+
+/**
+ * @brief Set the position index.
+ * @param self Pointer to the instance.
+ * @param idx  The new position index to set.
+ */
+void NavAggregateAlgorithm_setPosIdx(NavAggregateAlgorithm* self, uint32_t idx);
+
+/**
+ * @brief Get the current position index.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current position index.
+ */
+uint32_t NavAggregateAlgorithm_getPosIdx(const NavAggregateAlgorithm* self);
+
+/**
+ * @brief Set the velocity index.
+ * @param self Pointer to the instance.
+ * @param idx  The new velocity index to set.
+ */
+void NavAggregateAlgorithm_setVelIdx(NavAggregateAlgorithm* self, uint32_t idx);
+
+/**
+ * @brief Get the current velocity index.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current velocity index.
+ */
+uint32_t NavAggregateAlgorithm_getVelIdx(const NavAggregateAlgorithm* self);
+
+/**
+ * @brief Set the accumulated DV index.
+ * @param self Pointer to the instance.
+ * @param idx  The new accumulated DV index to set.
+ */
+void NavAggregateAlgorithm_setDvIdx(NavAggregateAlgorithm* self, uint32_t idx);
+
+/**
+ * @brief Get the current accumulated DV index.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current accumulated DV index.
+ */
+uint32_t NavAggregateAlgorithm_getDvIdx(const NavAggregateAlgorithm* self);
+
+/**
+ * @brief Set the sun index.
+ * @param self Pointer to the instance.
+ * @param idx  The new sun index to set.
+ */
+void NavAggregateAlgorithm_setSunIdx(NavAggregateAlgorithm* self, uint32_t idx);
+
+/**
+ * @brief Get the current sun index.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current sun index.
+ */
+uint32_t NavAggregateAlgorithm_getSunIdx(const NavAggregateAlgorithm* self);
+
+/**
+ * @brief Set the attitude message count.
+ * @param self     Pointer to the instance.
+ * @param msgCount The new attitude message count to set.
+ */
+void NavAggregateAlgorithm_setAttMsgCount(NavAggregateAlgorithm* self, uint32_t msgCount);
+
+/**
+ * @brief Get the current attitude message count.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current attitude message count.
+ */
+uint32_t NavAggregateAlgorithm_getAttMsgCount(const NavAggregateAlgorithm* self);
+
+/**
+ * @brief Set the translational message count.
+ * @param self     Pointer to the instance.
+ * @param msgCount The new translational message count to set.
+ */
+void NavAggregateAlgorithm_setTransMsgCount(NavAggregateAlgorithm* self, uint32_t msgCount);
+
+/**
+ * @brief Get the current translational message count.
+ * @param self Pointer to the instance.
+ * @return uint32_t  The current translational message count.
+ */
+uint32_t NavAggregateAlgorithm_getTransMsgCount(const NavAggregateAlgorithm* self);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // F32XIMERA_NAVAGGREGATEALGORITHM_C_H

--- a/algorithms/navAggregate/navAggregateOutput.h
+++ b/algorithms/navAggregate/navAggregateOutput.h
@@ -1,0 +1,21 @@
+#ifndef F32XIMERA_NAV_AGGREGATE_OUTPUT_H
+#define F32XIMERA_NAV_AGGREGATE_OUTPUT_H
+
+#include "msgPayloadDef/NavAttMsgF32Payload.h"
+#include "msgPayloadDef/NavTransMsgF32Payload.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! structure containing the attitude and translational navigation out messages */
+typedef struct {
+    NavAttMsgF32Payload navAttOut;     /*!< attitude navigation out message payload */
+    NavTransMsgF32Payload navTransOut; /*!< translation navigation out message payload */
+} AggregateOutput;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // F32XIMERA_NAV_AGGREGATE_OUTPUT_H

--- a/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.cpp
+++ b/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.cpp
@@ -1,0 +1,17 @@
+#include "sunlineEphemAlgorithm_c.h"
+#include "sunlineEphemAlgorithm.h"
+
+SunlineEphemAlgorithm* SunlineEphemAlgorithm_create(void) {
+    return reinterpret_cast<SunlineEphemAlgorithm*>(new ::SunlineEphemAlgorithm());
+}
+
+void SunlineEphemAlgorithm_destroy(SunlineEphemAlgorithm* self) {
+    delete reinterpret_cast<::SunlineEphemAlgorithm*>(self);
+}
+
+NavAttMsgF32Payload SunlineEphemAlgorithm_updateState(const SunlineEphemAlgorithm* self,
+                                                      const EphemerisMsgF32Payload* sunPos,
+                                                      const NavTransMsgF32Payload* scPos,
+                                                      const NavAttMsgF32Payload* scAtt) {
+    return reinterpret_cast<const ::SunlineEphemAlgorithm*>(self)->updateState(*sunPos, *scPos, *scAtt);
+}

--- a/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.h
+++ b/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.h
@@ -1,0 +1,47 @@
+#ifndef F32XIMERA_SUNLINEEPHEMALGORITHM_C_H
+#define F32XIMERA_SUNLINEEPHEMALGORITHM_C_H
+
+#include "msgPayloadDef/EphemerisMsgF32Payload.h"
+#include "msgPayloadDef/NavAttMsgF32Payload.h"
+#include "msgPayloadDef/NavTransMsgF32Payload.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Opaque handle to the C++ SunlineEphemAlgorithm instance.
+ */
+typedef struct SunlineEphemAlgorithm SunlineEphemAlgorithm;
+
+/**
+ * @brief Construct a new SunlineEphemAlgorithm instance.
+ * @return Pointer to a new SunlineEphemAlgorithm (must be destroyed).
+ */
+SunlineEphemAlgorithm* SunlineEphemAlgorithm_create(void);
+
+/**
+ * @brief Destroy a previously created SunlineEphemAlgorithm.
+ * @param self Pointer to the instance to destroy.
+ */
+void SunlineEphemAlgorithm_destroy(SunlineEphemAlgorithm* self);
+
+/**
+ * @brief Compute ephemeris-based sunline heading in body frame.
+ * @param self   Pointer to the instance.
+ * @param sunPos Pointer to sun ephemeris message payload.
+ * @param scPos  Pointer to spacecraft position message payload.
+ * @param scAtt  Pointer to spacecraft attitude message payload.
+ * @return NavAttMsgF32Payload  Navigation message containing sunline direction in body frame.
+ */
+NavAttMsgF32Payload SunlineEphemAlgorithm_updateState(const SunlineEphemAlgorithm* self,
+                                                      const EphemerisMsgF32Payload* sunPos,
+                                                      const NavTransMsgF32Payload* scPos,
+                                                      const NavAttMsgF32Payload* scAtt);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // F32XIMERA_SUNLINEEPHEMALGORITHM_C_H


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR adds C shims to the algorithms ephemNavConverter, navAggregate, and sunlineEphem. This is a copy of the PR from @dinkelk 

## Verification
CI runs successfully and compiled for risc-v target

## Documentation
NA

## Future work
None
