### PR TITLE
Ignore adding --show_plots option if already exists

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,21 +1,3 @@
-#
-#  ISC License
-#
-#  Copyright (c) 2025, Laboratory for Atmospheric Space Physics, University of Colorado at Boulder
-#
-#  Permission to use, copy, modify, and/or distribute this software for any
-#  purpose with or without fee is hereby granted, provided that the above
-#  copyright notice and this permission notice appear in all copies.
-#
-#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-#
-
 import inspect
 import os
 

--- a/conftest.py
+++ b/conftest.py
@@ -9,8 +9,10 @@ print(path)
 
 
 def pytest_addoption(parser):
-    parser.addoption("--show_plots", action="store_true",
-                     help="test(s) shall display plots")
+    try:
+        parser.addoption("--show_plots", action="store_true", help="test(s) shall display plots")
+    except ValueError as e:
+        print("option --show_plots already added")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
* **Tickets addressed:** maxgnc-2005
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When using this repo as a git submodule, running pytest from the outer repo (can) result in both the outer and fp32 repos trying to add the `--show_plots` options in each of their `conftest.py` files. Trying to add the option a second time results in an error. This PR catches if the `--show_plots` option is being added a second time and ignores the error.


## Verification
This has been manually tested with the fp32 repo included as a git submodule in a second repo. The second repo all declared the --show_plots option and the fp32 redeclaration was caught and ignored.

## Documentation
NA

## Future work
None
