### PR TITLE
Feature/fixes mrp pd

### DIFF
--- a/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
+++ b/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
@@ -28,38 +28,6 @@ inline Eigen::Vector3f referenceUpdate(const MrpPDAlgorithm& alg, const InputGui
     return Lr;
 }
 
-inline void testMrpPDSetup() {
-    MrpPDAlgorithm alg{};
-
-    // --- Test expected exceptions ---
-
-    // Negative feedback gains
-    EXPECT_THROW(alg.setProportionalGainK(-0.1), fs::invalid_argument);
-    EXPECT_THROW(alg.setDerivativeGainP(-0.1), fs::invalid_argument);
-
-    Eigen::Matrix3f badInertia{};
-    badInertia << 1, 0, 0, 0, 1, 0, 0, 0, 0;
-    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fs::invalid_argument);
-    badInertia << 1, 0, 0, 0, 1, 0, 0, 1, 1;
-    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fs::invalid_argument);
-    badInertia << 3, 0, 0, 0, 1, 0, 0, 0, 1;
-    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fs::invalid_argument);
-
-    float K = 100;
-    float P = 10;
-    Eigen::Vector3f torque = Eigen::Vector3f(1., 2, 3);
-    alg.setProportionalGainK(K);
-    alg.setDerivativeGainP(P);
-    alg.setKnownTorquePntB_B(torque);
-
-    // Check setters and getters
-    EXPECT_NEAR(alg.getProportionalGainK(), K, 1e-6);
-    EXPECT_NEAR(alg.getDerivativeGainP(), P, 1e-6);
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(alg.getKnownTorquePntB_B()[i], torque[i], 1e-6);
-    }
-}
-
 inline void regressionTestMrpPD(float K,
                                 float P,
                                 std::vector<float> torque,
@@ -82,8 +50,8 @@ inline void regressionTestMrpPD(float K,
     inputs.domega_RN_B = Eigen::Map<Eigen::Vector3f>(domega_RN_B.data());
 
     // Reference
-    Eigen::Vector3f outputTorque{};
-    Eigen::Vector3f referenceTorque{};
+    Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
+    Eigen::Vector3f referenceTorque = Eigen::Vector3f::Zero();
     EXPECT_NO_THROW(outputTorque = alg.update(inputs));
     EXPECT_NO_THROW(referenceTorque = referenceUpdate(alg, inputs));
 
@@ -93,60 +61,6 @@ inline void regressionTestMrpPD(float K,
 
         // Finiteness
         EXPECT_TRUE(std::isfinite(outputTorque[i]));
-    }
-}
-
-inline void propertyTestMrpPD() {
-    // --- Test module with targeted inputs to ensure individual terms are properly implemented ---
-    MrpPDAlgorithm alg{};
-    alg.setProportionalGainK(10);
-    alg.setDerivativeGainP(200);
-
-    Eigen::Vector3f torque = Eigen::Vector3f::Zero();
-    InputGuidanceData inputs{};
-
-    // All inputs are zeros except external torque should return external torque
-    torque << 1, 2, 3;
-    alg.setKnownTorquePntB_B(torque);
-    Eigen::Vector3f outputTorque{};
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], -torque[i], 1e-6);
-    }
-
-    // If input rates and accelerations are null, the torque is the input mrp scaled by proportional gain
-    torque << 0, 0, 0;
-    alg.setKnownTorquePntB_B(torque);
-    inputs.sigma_BR << 0.5, 0.2, 0.1;
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], -alg.getProportionalGainK() * inputs.sigma_BR[i], 1e-6);
-    }
-
-    // If input rates and accelerations are null, with Identity inertia matrix, the torque is the domega term
-    inputs.sigma_BR << 0, 0, 0;
-    inputs.domega_RN_B << 0.5, 0.2, 0.1;
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], inputs.domega_RN_B[i], 1e-6);
-    }
-
-    // If all but omega_BR_B null, the torque is omega_BR_B scaled by derivative gain
-    inputs.domega_RN_B << 0, 0, 0;
-    inputs.omega_BR_B << -0.3, 0.1, -0.8;
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], -alg.getDerivativeGainP() * inputs.omega_BR_B[i], 1e-6);
-    }
-
-    // If everything is zero except omega_BR_B and omega_RN_B, the torque is the cross product of their sum
-    alg.setDerivativeGainP(0);
-    inputs.omega_BR_B << 0.0, 0.9, -0.2;
-    inputs.omega_RN_B << 1.2, 0, 0;
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
-    Eigen::Vector3f omega_BN_B = inputs.omega_BR_B + inputs.omega_RN_B;
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], inputs.omega_RN_B.cross(omega_BN_B)[i], 1e-6);
     }
 }
 

--- a/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
+++ b/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
@@ -76,10 +76,10 @@ inline void regressionTestMrpPD(float K,
     alg.setKnownTorquePntB_B(Eigen::Map<Eigen::Vector3f>(torque.data()));
 
     InputGuidanceData inputs{};
-    inputs.sigma_BR(sigma_BR.data());
-    inputs.omega_BR_B(omega_BR_B.data());
-    inputs.omega_RN_B(omega_RN_B.data());
-    inputs.domega_RN_B(domega_RN_B.data());
+    inputs.sigma_BR = Eigen::Map<Eigen::Vector3f>(sigma_BR.data());
+    inputs.omega_BR_B = Eigen::Map<Eigen::Vector3f>(omega_BR_B.data());
+    inputs.omega_RN_B = Eigen::Map<Eigen::Vector3f>(omega_RN_B.data());
+    inputs.domega_RN_B = Eigen::Map<Eigen::Vector3f>(domega_RN_B.data());
 
     // Reference
     Eigen::Vector3f outputTorque{};

--- a/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
+++ b/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
@@ -14,16 +14,12 @@
 #include <vector>
 
 // Reference computation for update
-inline Eigen::Vector3f referenceUpdate(const MrpPDAlgorithm& alg, const InputGuidanceData& msg) {
-    const Eigen::Vector3f sigma_BR = msg.sigma_BR;
-    const Eigen::Vector3f omega_BR_B = msg.omega_BR_B;
-    const Eigen::Vector3f omega_RN_B = msg.omega_RN_B;
-    const Eigen::Vector3f domega_RN_B = msg.domega_RN_B;
-    const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
-
+inline Eigen::Vector3f referenceUpdate(const MrpPDAlgorithm& alg,
+                                       const Eigen::Vector3f& sigma_BR,
+                                       const Eigen::Vector3f& omega_BR_B,
+                                       const Eigen::Vector3f& domega_RN_B) {
     const Eigen::Vector3f Lr = -alg.getProportionalGainK() * sigma_BR - alg.getDerivativeGainP() * omega_BR_B +
-                               alg.getSpacecraftInertia() * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
-                               alg.getKnownTorquePntB_B();
+                               alg.getSpacecraftInertia() * domega_RN_B - alg.getKnownTorquePntB_B();
 
     return Lr;
 }
@@ -33,7 +29,6 @@ inline void regressionTestMrpPD(float K,
                                 std::vector<float> torque,
                                 std::vector<float> sigma_BR,
                                 std::vector<float> omega_BR_B,
-                                std::vector<float> omega_RN_B,
                                 std::vector<float> domega_RN_B) {
     // --- Regression test using expected update algorithm ---
 
@@ -43,17 +38,16 @@ inline void regressionTestMrpPD(float K,
     alg.setDerivativeGainP(P);
     alg.setKnownTorquePntB_B(Eigen::Map<Eigen::Vector3f>(torque.data()));
 
-    InputGuidanceData inputs{};
-    inputs.sigma_BR = Eigen::Map<Eigen::Vector3f>(sigma_BR.data());
-    inputs.omega_BR_B = Eigen::Map<Eigen::Vector3f>(omega_BR_B.data());
-    inputs.omega_RN_B = Eigen::Map<Eigen::Vector3f>(omega_RN_B.data());
-    inputs.domega_RN_B = Eigen::Map<Eigen::Vector3f>(domega_RN_B.data());
-
     // Reference
     Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
     Eigen::Vector3f referenceTorque = Eigen::Vector3f::Zero();
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
-    EXPECT_NO_THROW(referenceTorque = referenceUpdate(alg, inputs));
+    EXPECT_NO_THROW(outputTorque = alg.update(Eigen::Map<Eigen::Vector3f>(sigma_BR.data()),
+                                              Eigen::Map<Eigen::Vector3f>(omega_BR_B.data()),
+                                              Eigen::Map<Eigen::Vector3f>(domega_RN_B.data())));
+    EXPECT_NO_THROW(referenceTorque = referenceUpdate(alg,
+                                                      Eigen::Map<Eigen::Vector3f>(sigma_BR.data()),
+                                                      Eigen::Map<Eigen::Vector3f>(omega_BR_B.data()),
+                                                      Eigen::Map<Eigen::Vector3f>(domega_RN_B.data())));
 
     for (int i = 0; i < 3; ++i) {
         // Reference correctness

--- a/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
+++ b/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
@@ -38,6 +38,14 @@ inline void testMrpPDSetup() {
     EXPECT_THROW(alg.setProportionalGainK(-0.1), fs::invalid_argument);
     EXPECT_THROW(alg.setDerivativeGainP(-0.1), fs::invalid_argument);
 
+    Eigen::Matrix3f badInertia{};
+    badInertia << 1, 0, 0, 0, 1, 0, 0, 0, 0;
+    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fs::invalid_argument);
+    badInertia << 1, 0, 0, 0, 1, 0, 0, 1, 1;
+    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fs::invalid_argument);
+    badInertia << 3, 0, 0, 0, 1, 0, 0, 0, 1;
+    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fs::invalid_argument);
+
     float K = 100;
     float P = 10;
     Eigen::Vector3f torque = Eigen::Vector3f(1., 2, 3);

--- a/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
+++ b/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
@@ -14,11 +14,11 @@
 #include <vector>
 
 // Reference computation for update
-CmdTorqueBodyMsgF32Payload referenceUpdate(const MrpPDAlgorithm& alg, AttGuidMsgF32Payload& msg) {
-    const Eigen::Vector3f sigma_BR = cArrayToEigenVector(msg.sigma_BR);
-    const Eigen::Vector3f omega_BR_B = cArrayToEigenVector(msg.omega_BR_B);
-    const Eigen::Vector3f omega_RN_B = cArrayToEigenVector(msg.omega_RN_B);
-    const Eigen::Vector3f domega_RN_B = cArrayToEigenVector(msg.domega_RN_B);
+inline Eigen::Vector3f referenceUpdate(const MrpPDAlgorithm& alg, const InputGuidanceData& msg) {
+    const Eigen::Vector3f sigma_BR = msg.sigma_BR;
+    const Eigen::Vector3f omega_BR_B = msg.omega_BR_B;
+    const Eigen::Vector3f omega_RN_B = msg.omega_RN_B;
+    const Eigen::Vector3f domega_RN_B = msg.domega_RN_B;
     const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
 
     const Eigen::Vector3f Lr = -alg.getProportionalGainK() * sigma_BR - alg.getDerivativeGainP() * omega_BR_B +
@@ -26,9 +26,7 @@ CmdTorqueBodyMsgF32Payload referenceUpdate(const MrpPDAlgorithm& alg, AttGuidMsg
                                alg.getSpacecraftInertia() * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
                                alg.getKnownTorquePntB_B();
 
-    CmdTorqueBodyMsgF32Payload out{};
-    eigenVectorToCArray(Lr, out.torqueRequestBody);
-    return out;
+    return Lr;
 }
 
 inline void testMrpPDSetup() {
@@ -70,29 +68,24 @@ inline void regressionTestMrpPD(float K,
     alg.setDerivativeGainP(P);
     alg.setKnownTorquePntB_B(Eigen::Map<Eigen::Vector3f>(torque.data()));
 
-    Eigen::Vector3f sigma_BR_input(sigma_BR.data());
-    Eigen::Vector3f omega_BR_B_input(omega_BR_B.data());
-    Eigen::Vector3f omega_RN_B_input(omega_RN_B.data());
-    Eigen::Vector3f domega_RN_B_input(domega_RN_B.data());
-
-    AttGuidMsgF32Payload msg{};
-    eigenVectorToCArray(sigma_BR_input, msg.sigma_BR);
-    eigenVectorToCArray(omega_BR_B_input, msg.omega_BR_B);
-    eigenVectorToCArray(omega_RN_B_input, msg.omega_RN_B);
-    eigenVectorToCArray(domega_RN_B_input, msg.domega_RN_B);
+    InputGuidanceData inputs{};
+    inputs.sigma_BR(sigma_BR.data());
+    inputs.omega_BR_B(omega_BR_B.data());
+    inputs.omega_RN_B(omega_RN_B.data());
+    inputs.domega_RN_B(domega_RN_B.data());
 
     // Reference
-    CmdTorqueBodyMsgF32Payload out{};
-    CmdTorqueBodyMsgF32Payload ref{};
-    EXPECT_NO_THROW(out = alg.update(msg));
-    EXPECT_NO_THROW(ref = referenceUpdate(alg, msg));
+    Eigen::Vector3f outputTorque{};
+    Eigen::Vector3f referenceTorque{};
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    EXPECT_NO_THROW(referenceTorque = referenceUpdate(alg, inputs));
 
     for (int i = 0; i < 3; ++i) {
         // Reference correctness
-        EXPECT_NEAR(out.torqueRequestBody[i], ref.torqueRequestBody[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], referenceTorque[i], 1e-6);
 
         // Finiteness
-        EXPECT_TRUE(std::isfinite(out.torqueRequestBody[i]));
+        EXPECT_TRUE(std::isfinite(outputTorque[i]));
     }
 }
 
@@ -103,66 +96,50 @@ inline void propertyTestMrpPD() {
     alg.setDerivativeGainP(200);
 
     Eigen::Vector3f torque = Eigen::Vector3f::Zero();
-    Eigen::Vector3f sigma_BR = Eigen::Vector3f::Zero();
-    Eigen::Vector3f omega_BR_B = Eigen::Vector3f::Zero();
-    Eigen::Vector3f omega_RN_B = Eigen::Vector3f::Zero();
-    Eigen::Vector3f domega_RN_B = Eigen::Vector3f::Zero();
-
-    AttGuidMsgF32Payload msg{};
-    eigenVectorToCArray(sigma_BR, msg.sigma_BR);
-    eigenVectorToCArray(omega_BR_B, msg.omega_BR_B);
-    eigenVectorToCArray(omega_RN_B, msg.omega_RN_B);
-    eigenVectorToCArray(domega_RN_B, msg.domega_RN_B);
+    InputGuidanceData inputs{};
 
     // All inputs are zeros except external torque should return external torque
     torque << 1, 2, 3;
     alg.setKnownTorquePntB_B(torque);
-    CmdTorqueBodyMsgF32Payload out{};
-    EXPECT_NO_THROW(out = alg.update(msg));
+    Eigen::Vector3f outputTorque{};
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.torqueRequestBody[i], -torque[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], -torque[i], 1e-6);
     }
 
     // If input rates and accelerations are null, the torque is the input mrp scaled by proportional gain
     torque << 0, 0, 0;
     alg.setKnownTorquePntB_B(torque);
-    sigma_BR << 0.5, 0.2, 0.1;
-    eigenVectorToCArray(sigma_BR, msg.sigma_BR);
-    EXPECT_NO_THROW(out = alg.update(msg));
+    inputs.sigma_BR << 0.5, 0.2, 0.1;
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.torqueRequestBody[i], -alg.getProportionalGainK() * sigma_BR[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], -alg.getProportionalGainK() * inputs.sigma_BR[i], 1e-6);
     }
 
     // If input rates and accelerations are null, with Identity inertia matrix, the torque is the domega term
-    sigma_BR << 0, 0, 0;
-    eigenVectorToCArray(sigma_BR, msg.sigma_BR);
-    domega_RN_B << 0.5, 0.2, 0.1;
-    eigenVectorToCArray(domega_RN_B, msg.domega_RN_B);
-    EXPECT_NO_THROW(out = alg.update(msg));
+    inputs.sigma_BR << 0, 0, 0;
+    inputs.domega_RN_B << 0.5, 0.2, 0.1;
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.torqueRequestBody[i], domega_RN_B[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], inputs.domega_RN_B[i], 1e-6);
     }
 
     // If all but omega_BR_B null, the torque is omega_BR_B scaled by derivative gain
-    domega_RN_B << 0, 0, 0;
-    eigenVectorToCArray(domega_RN_B, msg.domega_RN_B);
-    omega_BR_B << -0.3, 0.1, -0.8;
-    eigenVectorToCArray(omega_BR_B, msg.omega_BR_B);
-    EXPECT_NO_THROW(out = alg.update(msg));
+    inputs.domega_RN_B << 0, 0, 0;
+    inputs.omega_BR_B << -0.3, 0.1, -0.8;
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.torqueRequestBody[i], -alg.getDerivativeGainP() * omega_BR_B[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], -alg.getDerivativeGainP() * inputs.omega_BR_B[i], 1e-6);
     }
 
     // If everything is zero except omega_BR_B and omega_RN_B, the torque is twice the cross product of their sum
     alg.setDerivativeGainP(0);
-    omega_BR_B << 0.0, 0.9, -0.2;
-    eigenVectorToCArray(omega_BR_B, msg.omega_BR_B);
-    omega_RN_B << 1.2, 0, 0;
-    eigenVectorToCArray(omega_RN_B, msg.omega_RN_B);
-    EXPECT_NO_THROW(out = alg.update(msg));
-    Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
+    inputs.omega_BR_B << 0.0, 0.9, -0.2;
+    inputs.omega_RN_B << 1.2, 0, 0;
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    Eigen::Vector3f omega_BN_B = inputs.omega_BR_B + inputs.omega_RN_B;
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.torqueRequestBody[i], 2 * omega_RN_B.cross(omega_BN_B)[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], 2 * inputs.omega_RN_B.cross(omega_BN_B)[i], 1e-6);
     }
 }
 

--- a/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
+++ b/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
@@ -22,7 +22,6 @@ inline Eigen::Vector3f referenceUpdate(const MrpPDAlgorithm& alg, const InputGui
     const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
 
     const Eigen::Vector3f Lr = -alg.getProportionalGainK() * sigma_BR - alg.getDerivativeGainP() * omega_BR_B +
-                               omega_RN_B.cross(alg.getSpacecraftInertia() * omega_BN_B) +
                                alg.getSpacecraftInertia() * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
                                alg.getKnownTorquePntB_B();
 
@@ -140,14 +139,14 @@ inline void propertyTestMrpPD() {
         EXPECT_NEAR(outputTorque[i], -alg.getDerivativeGainP() * inputs.omega_BR_B[i], 1e-6);
     }
 
-    // If everything is zero except omega_BR_B and omega_RN_B, the torque is twice the cross product of their sum
+    // If everything is zero except omega_BR_B and omega_RN_B, the torque is the cross product of their sum
     alg.setDerivativeGainP(0);
     inputs.omega_BR_B << 0.0, 0.9, -0.2;
     inputs.omega_RN_B << 1.2, 0, 0;
     EXPECT_NO_THROW(outputTorque = alg.update(inputs));
     Eigen::Vector3f omega_BN_B = inputs.omega_BR_B + inputs.omega_RN_B;
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], 2 * inputs.omega_RN_B.cross(omega_BN_B)[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], inputs.omega_RN_B.cross(omega_BN_B)[i], 1e-6);
     }
 }
 

--- a/algorithms/mrpPD/_tests/test_mrpPD.cpp
+++ b/algorithms/mrpPD/_tests/test_mrpPD.cpp
@@ -11,6 +11,88 @@ TEST(MrpPDTest, RegressionTest) {
                         std::vector<float>{0.08, -0.001, -0.003});
 }
 
-TEST(MrpPDTest, PropertyTest) { propertyTestMrpPD(); }
+TEST(MrpPDTest, PropertyTest) {
+    // --- Test module with targeted inputs to ensure individual terms are properly implemented ---
+    MrpPDAlgorithm alg{};
+    alg.setProportionalGainK(10);
+    alg.setDerivativeGainP(200);
 
-TEST(MrpPDTest, SetupTest) { testMrpPDSetup(); }
+    Eigen::Vector3f torque = Eigen::Vector3f::Zero();
+    InputGuidanceData inputs{};
+
+    // All inputs are zeros except external torque should return external torque
+    torque << 1, 2, 3;
+    alg.setKnownTorquePntB_B(torque);
+    Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(outputTorque[i], -torque[i], 1e-6);
+    }
+
+    // If input rates and accelerations are null, the torque is the input mrp scaled by proportional gain
+    torque << 0, 0, 0;
+    alg.setKnownTorquePntB_B(torque);
+    inputs.sigma_BR << 0.5, 0.2, 0.1;
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(outputTorque[i], -alg.getProportionalGainK() * inputs.sigma_BR[i], 1e-6);
+    }
+
+    // If input rates and accelerations are null, with Identity inertia matrix, the torque is the domega term
+    inputs.sigma_BR << 0, 0, 0;
+    inputs.domega_RN_B << 0.5, 0.2, 0.1;
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(outputTorque[i], inputs.domega_RN_B[i], 1e-6);
+    }
+
+    // If all but omega_BR_B null, the torque is omega_BR_B scaled by derivative gain
+    inputs.domega_RN_B << 0, 0, 0;
+    inputs.omega_BR_B << -0.3, 0.1, -0.8;
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(outputTorque[i], -alg.getDerivativeGainP() * inputs.omega_BR_B[i], 1e-6);
+    }
+
+    // If everything is zero except omega_BR_B and omega_RN_B, the torque is the cross product of their sum
+    alg.setDerivativeGainP(0);
+    inputs.omega_BR_B << 0.0, 0.9, -0.2;
+    inputs.omega_RN_B << 1.2, 0, 0;
+    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    Eigen::Vector3f omega_BN_B = inputs.omega_BR_B + inputs.omega_RN_B;
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(outputTorque[i], inputs.omega_RN_B.cross(omega_BN_B)[i], 1e-6);
+    }
+}
+
+TEST(MrpPDTest, SetupTest) {
+    MrpPDAlgorithm alg{};
+
+    // --- Test expected exceptions ---
+
+    // Negative feedback gains
+    EXPECT_THROW(alg.setProportionalGainK(-0.1), fs::invalid_argument);
+    EXPECT_THROW(alg.setDerivativeGainP(-0.1), fs::invalid_argument);
+
+    Eigen::Matrix3f badInertia{};
+    badInertia << 1, 0, 0, 0, 1, 0, 0, 0, 0;
+    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fs::invalid_argument);
+    badInertia << 1, 0, 0, 0, 1, 0, 0, 1, 1;
+    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fs::invalid_argument);
+    badInertia << 3, 0, 0, 0, 1, 0, 0, 0, 1;
+    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fs::invalid_argument);
+
+    float K = 100;
+    float P = 10;
+    Eigen::Vector3f torque = Eigen::Vector3f(1., 2, 3);
+    alg.setProportionalGainK(K);
+    alg.setDerivativeGainP(P);
+    alg.setKnownTorquePntB_B(torque);
+
+    // Check setters and getters
+    EXPECT_NEAR(alg.getProportionalGainK(), K, 1e-6);
+    EXPECT_NEAR(alg.getDerivativeGainP(), P, 1e-6);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(alg.getKnownTorquePntB_B()[i], torque[i], 1e-6);
+    }
+}

--- a/algorithms/mrpPD/_tests/test_mrpPD.cpp
+++ b/algorithms/mrpPD/_tests/test_mrpPD.cpp
@@ -7,7 +7,6 @@ TEST(MrpPDTest, RegressionTest) {
                         std::vector<float>{0.2, -0.1, -0.4},
                         std::vector<float>{-0.1, -0.4, 0},
                         std::vector<float>{0.009, 0.007, -0.006},
-                        std::vector<float>{-0.0009, -0.00005, -0.0004},
                         std::vector<float>{0.08, -0.001, -0.003});
 }
 
@@ -18,13 +17,13 @@ TEST(MrpPDTest, PropertyTest) {
     alg.setDerivativeGainP(200);
 
     Eigen::Vector3f torque = Eigen::Vector3f::Zero();
-    InputGuidanceData inputs{};
 
     // All inputs are zeros except external torque should return external torque
     torque << 1, 2, 3;
     alg.setKnownTorquePntB_B(torque);
     Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    EXPECT_NO_THROW(outputTorque =
+                        alg.update(Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero()));
     for (int i = 0; i < 3; ++i) {
         EXPECT_NEAR(outputTorque[i], -torque[i], 1e-6);
     }
@@ -32,36 +31,24 @@ TEST(MrpPDTest, PropertyTest) {
     // If input rates and accelerations are null, the torque is the input mrp scaled by proportional gain
     torque << 0, 0, 0;
     alg.setKnownTorquePntB_B(torque);
-    inputs.sigma_BR << 0.5, 0.2, 0.1;
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    Eigen::Vector3f const sigma_BR(0.5, 0.2, 0.1);
+    EXPECT_NO_THROW(outputTorque = alg.update(sigma_BR, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero()));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], -alg.getProportionalGainK() * inputs.sigma_BR[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], -alg.getProportionalGainK() * sigma_BR[i], 1e-6);
     }
 
     // If input rates and accelerations are null, with Identity inertia matrix, the torque is the domega term
-    inputs.sigma_BR << 0, 0, 0;
-    inputs.domega_RN_B << 0.5, 0.2, 0.1;
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    Eigen::Vector3f const domega_RN_B(0.5, 0.2, 0.1);
+    EXPECT_NO_THROW(outputTorque = alg.update(Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), domega_RN_B));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], inputs.domega_RN_B[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], domega_RN_B[i], 1e-6);
     }
 
     // If all but omega_BR_B null, the torque is omega_BR_B scaled by derivative gain
-    inputs.domega_RN_B << 0, 0, 0;
-    inputs.omega_BR_B << -0.3, 0.1, -0.8;
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
+    Eigen::Vector3f const omega_BR_B(-0.3, 0.1, -0.8);
+    EXPECT_NO_THROW(outputTorque = alg.update(Eigen::Vector3f::Zero(), omega_BR_B, Eigen::Vector3f::Zero()));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], -alg.getDerivativeGainP() * inputs.omega_BR_B[i], 1e-6);
-    }
-
-    // If everything is zero except omega_BR_B and omega_RN_B, the torque is the cross product of their sum
-    alg.setDerivativeGainP(0);
-    inputs.omega_BR_B << 0.0, 0.9, -0.2;
-    inputs.omega_RN_B << 1.2, 0, 0;
-    EXPECT_NO_THROW(outputTorque = alg.update(inputs));
-    Eigen::Vector3f omega_BN_B = inputs.omega_BR_B + inputs.omega_RN_B;
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], inputs.omega_RN_B.cross(omega_BN_B)[i], 1e-6);
+        EXPECT_NEAR(outputTorque[i], -alg.getDerivativeGainP() * omega_BR_B[i], 1e-6);
     }
 }
 

--- a/algorithms/mrpPD/_tests/test_mrpPD.py
+++ b/algorithms/mrpPD/_tests/test_mrpPD.py
@@ -87,8 +87,6 @@ def test_mrpPD(show_plots, set_external_torque):
 def compute_true_torque(mrp_pd, guidance_cmd_data, ISCPntB_B, knownTorquePntB_B):
     # Compute hub inertial angular velocity in B-frame components
     omega_BR_B = np.array(guidance_cmd_data.omega_BR_B)
-    omega_RN_B = np.array(guidance_cmd_data.omega_RN_B)
-    omega_BN_B = omega_BR_B + omega_RN_B
 
     K = mrp_pd.K
     P = mrp_pd.P
@@ -96,8 +94,7 @@ def compute_true_torque(mrp_pd, guidance_cmd_data, ISCPntB_B, knownTorquePntB_B)
     domega_RN_B = np.array(guidance_cmd_data.domega_RN_B)
 
     # Compute required attitude control torque
-    Lr = (- K * sigma_BR - P * omega_BR_B + np.cross(omega_RN_B, ISCPntB_B @ omega_BN_B)
-          + ISCPntB_B @ (domega_RN_B - np.cross(omega_BN_B, omega_RN_B)) - knownTorquePntB_B)  # [Nm]
+    Lr = - K * sigma_BR - P * omega_BR_B + ISCPntB_B @ domega_RN_B  - knownTorquePntB_B  # [Nm]
 
     return Lr
 

--- a/algorithms/mrpPD/_tests/test_mrpPD_fuzz.cpp
+++ b/algorithms/mrpPD/_tests/test_mrpPD_fuzz.cpp
@@ -7,5 +7,4 @@ FUZZ_TEST(MrpPDAlgorithmFuzz, regressionTestMrpPD)
                  fuzztest::VectorOf(fuzztest::InRange(-1e6F, 1e6F)).WithSize(3),
                  fuzztest::VectorOf(fuzztest::InRange(-1e6F, 1e6F)).WithSize(3),
                  fuzztest::VectorOf(fuzztest::InRange(-1e6F, 1e6F)).WithSize(3),
-                 fuzztest::VectorOf(fuzztest::InRange(-1e6F, 1e6F)).WithSize(3),
                  fuzztest::VectorOf(fuzztest::InRange(-1e6F, 1e6F)).WithSize(3));

--- a/algorithms/mrpPD/mrpPD.cpp
+++ b/algorithms/mrpPD/mrpPD.cpp
@@ -14,7 +14,9 @@ void MrpPD::reset(uint64_t callTime) {
     }
 
     if (this->vehConfigInMsg.isWritten()) {
-        this->algorithm.setSpacecraftInertia(this->vehConfigInMsg());
+        auto vehicleConfigInMsg = this->vehConfigInMsg();
+        auto inertia = cArrayToEigenMatrix3(vehicleConfigInMsg.ISCPntB_B);
+        this->algorithm.setSpacecraftInertia(inertia);
     }
 }
 

--- a/algorithms/mrpPD/mrpPD.cpp
+++ b/algorithms/mrpPD/mrpPD.cpp
@@ -32,7 +32,6 @@ void MrpPD::updateState(uint64_t callTime) {
         localGuidInMsg = this->guidInMsg();
         inputData.sigma_BR = cArrayToEigenVector(localGuidInMsg.sigma_BR);
         inputData.omega_BR_B = cArrayToEigenVector(localGuidInMsg.omega_BR_B);
-        inputData.omega_RN_B = cArrayToEigenVector(localGuidInMsg.omega_RN_B);
         inputData.domega_RN_B = cArrayToEigenVector(localGuidInMsg.domega_RN_B);
 
         // Call the algorithm update method

--- a/algorithms/mrpPD/mrpPD.cpp
+++ b/algorithms/mrpPD/mrpPD.cpp
@@ -23,13 +23,20 @@ void MrpPD::reset(uint64_t callTime) {
  @param callTime [ns] Time the method is called
 */
 void MrpPD::updateState(uint64_t callTime) {
-    auto localGuidInMsg = AttGuidMsgF32Payload();
+    auto torqueCmdMsgF32Payload = CmdTorqueBodyMsgF32Payload();
     if (this->guidInMsg.isWritten()) {
+        auto localGuidInMsg = AttGuidMsgF32Payload();
+        InputGuidanceData inputData{};
         localGuidInMsg = this->guidInMsg();
-    }
+        inputData.sigma_BR = cArrayToEigenVector(localGuidInMsg.sigma_BR);
+        inputData.omega_BR_B = cArrayToEigenVector(localGuidInMsg.omega_BR_B);
+        inputData.omega_RN_B = cArrayToEigenVector(localGuidInMsg.omega_RN_B);
+        inputData.domega_RN_B = cArrayToEigenVector(localGuidInMsg.domega_RN_B);
 
-    // Call the algorithm update method
-    CmdTorqueBodyMsgF32Payload torqueCmdMsgF32Payload = this->algorithm.update(localGuidInMsg);
+        // Call the algorithm update method
+        const auto torque = this->algorithm.update(inputData);
+        eigenVectorToCArray(torque, torqueCmdMsgF32Payload.torqueRequestBody);
+    }
 
     this->cmdTorqueOutMsg.write(&torqueCmdMsgF32Payload, moduleID, callTime);
 }

--- a/algorithms/mrpPD/mrpPD.cpp
+++ b/algorithms/mrpPD/mrpPD.cpp
@@ -27,15 +27,13 @@ void MrpPD::reset(uint64_t callTime) {
 void MrpPD::updateState(uint64_t callTime) {
     auto torqueCmdMsgF32Payload = CmdTorqueBodyMsgF32Payload();
     if (this->guidInMsg.isWritten()) {
-        auto localGuidInMsg = AttGuidMsgF32Payload();
-        InputGuidanceData inputData{};
-        localGuidInMsg = this->guidInMsg();
-        inputData.sigma_BR = cArrayToEigenVector(localGuidInMsg.sigma_BR);
-        inputData.omega_BR_B = cArrayToEigenVector(localGuidInMsg.omega_BR_B);
-        inputData.domega_RN_B = cArrayToEigenVector(localGuidInMsg.domega_RN_B);
+        auto localGuidInMsg = this->guidInMsg();
+        Eigen::Vector3f const sigma_BR = cArrayToEigenVector(localGuidInMsg.sigma_BR);
+        Eigen::Vector3f const omega_BR_B = cArrayToEigenVector(localGuidInMsg.omega_BR_B);
+        Eigen::Vector3f const domega_RN_B = cArrayToEigenVector(localGuidInMsg.domega_RN_B);
 
         // Call the algorithm update method
-        const auto torque = this->algorithm.update(inputData);
+        const auto torque = this->algorithm.update(sigma_BR, omega_BR_B, domega_RN_B);
         eigenVectorToCArray(torque, torqueCmdMsgF32Payload.torqueRequestBody);
     }
 

--- a/algorithms/mrpPD/mrpPD.h
+++ b/algorithms/mrpPD/mrpPD.h
@@ -2,7 +2,6 @@
 #define XMERAF32_MRP_PD_H
 
 #include <stdint.h>
-#include <stdexcept>
 
 #include <Eigen/Dense>
 

--- a/algorithms/mrpPD/mrpPD.rst
+++ b/algorithms/mrpPD/mrpPD.rst
@@ -31,17 +31,16 @@ Detailed Module Description
 This attitude feedback module using the MRP feedback control related to the control in section 8.4.1 in `Analytical Mechanics of Space Systems <http://dx.doi.org/10.2514/4.105210>`_:
 
 .. math::
-    {\mathbf L}_{r} =  -K \mathbf\sigma - [P] \delta\mathbf\omega   + [I](\dot{\mathbf\omega}_{r} - [\tilde{\mathbf\omega}]\mathbf\omega_{r})
-			+[\tilde{\mathbf \omega}_{r}] ]
-			[I]\mathbf\omega   - \mathbf L
+    {\mathbf L}_{r} =  -K \mathbf\sigma - [P] \delta\mathbf\omega   + [I]\dot{\mathbf\omega}_{r}
+            - \mathbf L
 
 Note that this control solution creates an external control torque which must be produced with a cluster of thrusters.  No reaction wheel information is used here.  Further, the feedback control component is a simple proportional and derivative feedback formulation.  As shown in `Analytical Mechanics of Space Systems <http://dx.doi.org/10.2514/4.105210>`_, this control can asymptotically track a general reference trajectory given by the reference frame :math:`\mathcal R`.
-
+The torque provided does not compute gyroscopic terms.
 
 Module Assumptions and Limitations
 ----------------------------------
 This control assumes the spacecraft is rigid and that the inertia tensor does not vary with time.
-
+The module does not add gyroscopic terms to the output torque.
 
 User Guide
 ----------

--- a/algorithms/mrpPD/mrpPDAlgorithm.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm.cpp
@@ -5,29 +5,20 @@
 /*! Update method for mrpPD control algorithm. This method takes the attitude and rate errors relative to the
  reference frame, as well as the reference frame angular rates and acceleration, and computes the required control
  torque Lr.
- @return void
- @param guidInMsg [-] guidance message input
+ @return Eigen::Vector3f
+ @param inputs [InputGuidanceData] struct containing guidance data required for torque computations
 */
-CmdTorqueBodyMsgF32Payload MrpPDAlgorithm::update(AttGuidMsgF32Payload guidInMsg) const {
+Eigen::Vector3f MrpPDAlgorithm::update(const InputGuidanceData& inputs) const {
     // Compute hub inertial angular velocity in B-frame components
-    const Eigen::Vector3f omega_BR_B = cArrayToEigenVector(guidInMsg.omega_BR_B);
-    const Eigen::Vector3f omega_RN_B = cArrayToEigenVector(guidInMsg.omega_RN_B);
-    const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
-
-    const Eigen::Vector3f sigma_BR = cArrayToEigenVector(guidInMsg.sigma_BR);
-    const Eigen::Vector3f domega_RN_B = cArrayToEigenVector(guidInMsg.domega_RN_B);
+    const Eigen::Vector3f omega_BN_B = inputs.omega_BR_B + inputs.omega_RN_B;
 
     // Compute required attitude control torque vector
-    const Eigen::Vector3f Lr = -this->proportionalGain * sigma_BR - this->feedbackGain * omega_BR_B +
-                               omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
-                               this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
-                               this->knownTorquePntB_B;  // [Nm]
+    const auto Lr = -this->proportionalGain * inputs.sigma_BR - this->feedbackGain * inputs.omega_BR_B +
+                         inputs.omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
+                         this->ISCPntB_B * (inputs.domega_RN_B - omega_BN_B.cross(inputs.omega_RN_B)) -
+                         this->knownTorquePntB_B;  // [Nm]
 
-    // Create the output message
-    auto torqueCmdMsgF32Payload = CmdTorqueBodyMsgF32Payload();
-    eigenVectorToCArray(Lr, torqueCmdMsgF32Payload.torqueRequestBody);
-
-    return torqueCmdMsgF32Payload;
+    return Lr;
 }
 
 /*! This method sets the spacecraft inertia according to the vehicle configuration input message

--- a/algorithms/mrpPD/mrpPDAlgorithm.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm.cpp
@@ -26,6 +26,9 @@ Eigen::Vector3f MrpPDAlgorithm::update(const InputGuidanceData& inputs) const {
  @param inertia Inertia matrix
 */
 void MrpPDAlgorithm::setSpacecraftInertia(const Eigen::Matrix3f& inertia) {
+    if (!inertiaIsValid(inertia)) {
+        FS_THROW_INVALID_ARGUMENT("Matrix inertia did not pass validity checks");
+    }
     this->ISCPntB_B = inertia;
 }
 

--- a/algorithms/mrpPD/mrpPDAlgorithm.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm.cpp
@@ -1,6 +1,6 @@
 #include "mrpPDAlgorithm.h"
-#include "architecture/utilities/eigenSupport.h"
-#include <cmath>
+#include "../freestandingInvalidArgument.h"
+#include "../utilities/validInertiaCheck.h"
 
 /*! Update method for mrpPD control algorithm. This method takes the attitude and rate errors relative to the
  reference frame, as well as the reference frame angular rates and acceleration, and computes the required control

--- a/algorithms/mrpPD/mrpPDAlgorithm.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm.cpp
@@ -23,10 +23,10 @@ Eigen::Vector3f MrpPDAlgorithm::update(const InputGuidanceData& inputs) const {
 
 /*! This method sets the spacecraft inertia according to the vehicle configuration input message
  @return void
- @param vehicleConfigInMsg Vehicle config input
+ @param inertia Inertia matrix
 */
-void MrpPDAlgorithm::setSpacecraftInertia(VehicleConfigMsgF32Payload vehicleConfigInMsg) {
-    this->ISCPntB_B = cArrayToEigenMatrix3(vehicleConfigInMsg.ISCPntB_B);
+void MrpPDAlgorithm::setSpacecraftInertia(const Eigen::Matrix3f& inertia) {
+    this->ISCPntB_B = inertia;
 }
 
 /*! This method gets the spacecraft inertia matrix

--- a/algorithms/mrpPD/mrpPDAlgorithm.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm.cpp
@@ -6,13 +6,16 @@
  reference frame, as well as the reference frame angular rates and acceleration, and computes the required control
  torque Lr.
  @return Eigen::Vector3f
- @param inputs [InputGuidanceData] struct containing guidance data required for torque computations
+ @param sigma_BR Body to reference MRP
+ @param omega_BR_B Body to reference rate
+ @param domega_RN_B Body to reference acceleration
 */
-Eigen::Vector3f MrpPDAlgorithm::update(const InputGuidanceData& inputs) const {
+Eigen::Vector3f MrpPDAlgorithm::update(const Eigen::Vector3f& sigma_BR,
+                                       const Eigen::Vector3f& omega_BR_B,
+                                       const Eigen::Vector3f& domega_RN_B) const {
     // Compute required attitude control torque vector
     const Eigen::Vector3f Lr = -this->proportionalGain * sigma_BR - this->feedbackGain * omega_BR_B +
-                               this->ISCPntB_B * domega_RN_B -
-                               this->knownTorquePntB_B;  // [Nm]
+                               this->ISCPntB_B * domega_RN_B - this->knownTorquePntB_B;  // [Nm]
 
     return Lr;
 }

--- a/algorithms/mrpPD/mrpPDAlgorithm.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm.cpp
@@ -9,14 +9,10 @@
  @param inputs [InputGuidanceData] struct containing guidance data required for torque computations
 */
 Eigen::Vector3f MrpPDAlgorithm::update(const InputGuidanceData& inputs) const {
-    // Compute hub inertial angular velocity in B-frame components
-    const Eigen::Vector3f omega_BN_B = inputs.omega_BR_B + inputs.omega_RN_B;
-
     // Compute required attitude control torque vector
     const auto Lr = -this->proportionalGain * inputs.sigma_BR - this->feedbackGain * inputs.omega_BR_B +
-                         inputs.omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
-                         this->ISCPntB_B * (inputs.domega_RN_B - omega_BN_B.cross(inputs.omega_RN_B)) -
-                         this->knownTorquePntB_B;  // [Nm]
+                               this->ISCPntB_B * inputs.domega_RN_B -
+                               this->knownTorquePntB_B;  // [Nm]
 
     return Lr;
 }

--- a/algorithms/mrpPD/mrpPDAlgorithm.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm.cpp
@@ -10,8 +10,8 @@
 */
 Eigen::Vector3f MrpPDAlgorithm::update(const InputGuidanceData& inputs) const {
     // Compute required attitude control torque vector
-    const auto Lr = -this->proportionalGain * inputs.sigma_BR - this->feedbackGain * inputs.omega_BR_B +
-                               this->ISCPntB_B * inputs.domega_RN_B -
+    const Eigen::Vector3f Lr = -this->proportionalGain * sigma_BR - this->feedbackGain * omega_BR_B +
+                               this->ISCPntB_B * domega_RN_B -
                                this->knownTorquePntB_B;  // [Nm]
 
     return Lr;

--- a/algorithms/mrpPD/mrpPDAlgorithm.h
+++ b/algorithms/mrpPD/mrpPDAlgorithm.h
@@ -6,8 +6,6 @@
 
 #include <Eigen/Dense>
 
-#include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
-
 /*! Struct containing the guidance inputs needed by the algorithm. */
 struct InputGuidanceData {
     Eigen::Vector3f sigma_BR = Eigen::Vector3f::Zero();
@@ -23,7 +21,7 @@ class MrpPDAlgorithm {
     ~MrpPDAlgorithm() = default;
 
     Eigen::Vector3f update(const InputGuidanceData& inputs) const;
-    void setSpacecraftInertia(VehicleConfigMsgF32Payload vehicleConfigInMsg);
+    void setSpacecraftInertia(const Eigen::Matrix3f& inertia);
     Eigen::Matrix3f getSpacecraftInertia() const;
     void setDerivativeGainP(float P);
     float getDerivativeGainP() const;

--- a/algorithms/mrpPD/mrpPDAlgorithm.h
+++ b/algorithms/mrpPD/mrpPDAlgorithm.h
@@ -2,19 +2,10 @@
 #define XMERAF32_MRP_PD_ALGORITHM_H
 
 #include "../freestandingInvalidArgument.h"
-#include "../validInertiaCheck.h"
-
+#include "utilities/validInertiaCheck.h"
 #include <stdint.h>
+#include <Eigen/Core>
 
-#include <Eigen/Dense>
-
-/*! Struct containing the guidance inputs needed by the algorithm. */
-struct InputGuidanceData {
-    Eigen::Vector3f sigma_BR = Eigen::Vector3f::Zero();
-    Eigen::Vector3f omega_BR_B = Eigen::Vector3f::Zero();
-    Eigen::Vector3f omega_RN_B = Eigen::Vector3f::Zero();
-    Eigen::Vector3f domega_RN_B = Eigen::Vector3f::Zero();
-};
 
 /*! @brief MRP PD control algorithm class. */
 class MrpPDAlgorithm {

--- a/algorithms/mrpPD/mrpPDAlgorithm.h
+++ b/algorithms/mrpPD/mrpPDAlgorithm.h
@@ -2,6 +2,8 @@
 #define XMERAF32_MRP_PD_ALGORITHM_H
 
 #include "../freestandingInvalidArgument.h"
+#include "../validInertiaCheck.h"
+
 #include <stdint.h>
 
 #include <Eigen/Dense>

--- a/algorithms/mrpPD/mrpPDAlgorithm.h
+++ b/algorithms/mrpPD/mrpPDAlgorithm.h
@@ -6,9 +6,15 @@
 
 #include <Eigen/Dense>
 
-#include "msgPayloadDef/AttGuidMsgF32Payload.h"
-#include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
 #include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
+
+/*! Struct containing the guidance inputs needed by the algorithm. */
+struct InputGuidanceData {
+    Eigen::Vector3f sigma_BR = Eigen::Vector3f::Zero();
+    Eigen::Vector3f omega_BR_B = Eigen::Vector3f::Zero();
+    Eigen::Vector3f omega_RN_B = Eigen::Vector3f::Zero();
+    Eigen::Vector3f domega_RN_B = Eigen::Vector3f::Zero();
+};
 
 /*! @brief MRP PD control algorithm class. */
 class MrpPDAlgorithm {
@@ -16,7 +22,7 @@ class MrpPDAlgorithm {
     MrpPDAlgorithm() = default;
     ~MrpPDAlgorithm() = default;
 
-    CmdTorqueBodyMsgF32Payload update(AttGuidMsgF32Payload guidInMsg) const;
+    Eigen::Vector3f update(const InputGuidanceData& inputs) const;
     void setSpacecraftInertia(VehicleConfigMsgF32Payload vehicleConfigInMsg);
     Eigen::Matrix3f getSpacecraftInertia() const;
     void setDerivativeGainP(float P);

--- a/algorithms/mrpPD/mrpPDAlgorithm.h
+++ b/algorithms/mrpPD/mrpPDAlgorithm.h
@@ -6,14 +6,15 @@
 #include <stdint.h>
 #include <Eigen/Core>
 
-
 /*! @brief MRP PD control algorithm class. */
 class MrpPDAlgorithm {
    public:
     MrpPDAlgorithm() = default;
     ~MrpPDAlgorithm() = default;
 
-    Eigen::Vector3f update(const InputGuidanceData& inputs) const;
+    Eigen::Vector3f update(const Eigen::Vector3f& sigma_BR,
+                           const Eigen::Vector3f& omega_BR_B,
+                           const Eigen::Vector3f& domega_RN_B) const;
     void setSpacecraftInertia(const Eigen::Matrix3f& inertia);
     Eigen::Matrix3f getSpacecraftInertia() const;
     void setDerivativeGainP(float P);

--- a/algorithms/mrpPD/mrpPDAlgorithm.h
+++ b/algorithms/mrpPD/mrpPDAlgorithm.h
@@ -24,9 +24,10 @@ class MrpPDAlgorithm {
     float getProportionalGainK() const;
 
    private:
-    float proportionalGain{};             //!< [rad/s] Proportional gain applied to MRP errors
-    float feedbackGain{};                 //!< [N*m*s] Rate error feedback gain applied
-    Eigen::Vector3f knownTorquePntB_B{};  //!< [N*m] Known external torque expressed in body frame components
+    float proportionalGain{};  //!< [rad/s] Proportional gain applied to MRP errors
+    float feedbackGain{};      //!< [N*m*s] Rate error feedback gain applied
+    Eigen::Vector3f knownTorquePntB_B =
+        Eigen::Vector3f::Zero();  //!< [N*m] Known external torque expressed in body frame components
     Eigen::Matrix3f ISCPntB_B =
         Eigen::Matrix3f::Identity();  //!< [kg*m^2] Spacecraft inertia about point B expressed in body frame components
 };

--- a/algorithms/utilities/CMakeLists.txt
+++ b/algorithms/utilities/CMakeLists.txt
@@ -9,3 +9,5 @@ target_sources(AlgorithmUtilities INTERFACE
 target_link_libraries(AlgorithmUtilities INTERFACE
   Eigen3::Eigen
 )
+
+add_subdirectory(tests)

--- a/algorithms/utilities/tests/CMakeLists.txt
+++ b/algorithms/utilities/tests/CMakeLists.txt
@@ -1,0 +1,31 @@
+add_executable(test_validateInertia
+  test_validateInertia.cpp
+  utilitiesHelpers.hpp
+)
+
+target_link_libraries(test_validateInertia PRIVATE
+    Eigen3::Eigen
+    GTest::gtest_main
+  )
+
+gtest_discover_tests(test_validateInertia)
+
+if(XMERA_ENABLE_FUZZTESTS)
+  fuzztest_setup_fuzzing_flags()
+
+  add_executable(test_validateInertia_fuzz
+    utilitiesHelpers.hpp
+    test_validateInertia_fuzz.cpp
+  )
+
+  target_link_libraries(test_validateInertia_fuzz PRIVATE
+    Eigen3::Eigen
+    fuzztest::fuzztest
+    fuzztest::fuzztest_gtest_main
+  )
+
+  gtest_discover_tests(test_validateInertia_fuzz
+    PROPERTIES
+      LABELS "fuzz\;fuzz-smoke"
+  )
+endif()

--- a/algorithms/utilities/tests/test_validateInertia.cpp
+++ b/algorithms/utilities/tests/test_validateInertia.cpp
@@ -1,0 +1,13 @@
+#include "../validInertiaCheck.h"
+#include <gtest/gtest.h>
+
+TEST(ValidateInertiaTest, SetupTest) {
+    // --- Test expected exceptions ---
+    Eigen::Matrix3f badInertia = Eigen::Matrix3f::Identity();
+    badInertia << 1, 0, 0, 0, 1, 0, 0, 0, 0;
+    EXPECT_FALSE(inertiaIsValid(badInertia));
+    badInertia << 1, 0, 0, 0, 1, 0, 0, 1, 1;
+    EXPECT_FALSE(inertiaIsValid(badInertia));
+    badInertia << 3, 0, 0, 0, 1, 0, 0, 0, 1;
+    EXPECT_FALSE(inertiaIsValid(badInertia));
+}

--- a/algorithms/utilities/tests/test_validateInertia_fuzz.cpp
+++ b/algorithms/utilities/tests/test_validateInertia_fuzz.cpp
@@ -1,0 +1,9 @@
+#include "utilitiesHelpers.hpp"
+#include <fuzztest/fuzztest.h>
+
+FUZZ_TEST(InertiaFuzz, testInertiaValidity)
+    .WithDomains(fuzztest::InRange(1.0F, 1e6F),
+                 fuzztest::InRange(1.0F, 1e6F),
+                 fuzztest::InRange(1e-6F, 1.0F),
+                 fuzztest::InRange(1e-6F, 1.0F),
+                 fuzztest::InRange(1e-6F, 1.0F));

--- a/algorithms/utilities/tests/utilitiesHelpers.hpp
+++ b/algorithms/utilities/tests/utilitiesHelpers.hpp
@@ -1,0 +1,56 @@
+#include "../validInertiaCheck.h"
+#include <gtest/gtest.h>
+#include <Eigen/Core>
+
+/* Function to generate a cross product operator from a vector */
+inline Eigen::Matrix3f tildeMatrix(const Eigen::Vector3f &vector) {
+    Eigen::Matrix3f tilde;
+    tilde << 0.0F, -vector(2), vector(1), vector(2), 0.0F, -vector(0), -vector(1), vector(0), 0.0F;
+    return tilde;
+}
+
+/* Function to generate a dcm from an mrp */
+inline Eigen::Matrix3f mrpToDcm(const Eigen::Vector3f &mrp) {
+    const Eigen::Matrix3f t = tildeMatrix(mrp);
+    const float denom = (1.0 + mrp.dot(mrp));
+    const Eigen::Matrix3f dcm = (8.0 * t * t - 4.0 * (1.0 - mrp.dot(mrp)) * t) / (denom * denom);
+
+    return dcm + Eigen::Matrix3f::Identity();
+}
+
+/* Function to generate a general inertia matrix */
+inline Eigen::Matrix3f GenerateValidInertiaMatrix(float const ev1,
+                                                  float const ev2,
+                                                  float const sigma1,
+                                                  float const sigma2,
+                                                  float const sigma3) {
+    /* Sort the first two eigenvalues so ev_min <= ev_max */
+    const float ev_min = std::min(ev1, ev2);
+    const float ev_max = std::max(ev1, ev2);
+    const float ev3_min = (ev_max - ev_min > 1e-5f) ? ev_max - ev_min + 1e-5f : 1e-5f;
+    const float ev3_max = ev_max + ev_min - 1e-5f;
+
+    const float ev3 = ev3_min + (0.5 * (ev3_max - ev3_min));
+    const std::array<float, 3> eigenvalues = {ev_min, ev3, ev_max};
+
+    /* Create a rotation matrix with provided mrp */
+    Eigen::Vector3f mrp(sigma1, sigma2, sigma3);
+    if (mrp.squaredNorm() > 1) {
+        mrp = -mrp / mrp.squaredNorm();
+    }
+    Eigen::Matrix3f R = mrpToDcm(mrp);
+
+    /* Create diagonal matrix D with eigenvalues */
+    Eigen::Matrix3f D;
+    D << eigenvalues[0], 0, 0, 0, eigenvalues[1], 0, 0, 0, eigenvalues[2];
+
+    /* Return rotated diagonal matrix */
+    return R.transpose() * D * R;
+}
+
+/* Test validity against generated inertia matrix */
+inline void testInertiaValidity(float eigen1, float eigen2, float sigma1, float sigma2, float sigma3) {
+    const Eigen::Matrix3f inertia = GenerateValidInertiaMatrix(eigen1, eigen2, sigma1, sigma2, sigma3);
+
+    EXPECT_TRUE(inertiaIsValid(inertia));
+}

--- a/algorithms/utilities/validInertiaCheck.h
+++ b/algorithms/utilities/validInertiaCheck.h
@@ -1,0 +1,32 @@
+#ifndef FP32_XMERA_FSW_ALGORITHMS_VALID_INERTIA_H
+#define FP32_XMERA_FSW_ALGORITHMS_VALID_INERTIA_H
+
+#include <Eigen/Eigenvalues>
+
+constexpr float tolerance = 1e-6;
+
+inline bool inertiaIsValid(const Eigen::Matrix3f& inertia) {
+    /* Check for matrix symmetry */
+    if (!inertia.isApprox(inertia.transpose())) {
+        return false;
+    }
+
+    /* Check that all eigen values are positive */
+    const Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> eigenSolver(inertia);
+    if (eigenSolver.info() != Eigen::Success) {
+        return false;
+    }
+
+    Eigen::Vector3f eigenvalues = eigenSolver.eigenvalues();
+    for (auto eigenvalue : eigenvalues) {
+        if (eigenvalue <= tolerance) {
+            return false;
+        }
+    }
+
+    /* Check that principal inertia values are consistent */
+    return !(eigenvalues[0] + eigenvalues[1] < eigenvalues[2] || eigenvalues[1] + eigenvalues[2] < eigenvalues[0] ||
+             eigenvalues[0] + eigenvalues[2] < eigenvalues[1]);
+}
+
+#endif  // FP32_XMERA_FSW_ALGORITHMS_VALID_INERTIA_H


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2001
* **Review:** By commit  
* **Merge strategy:** Merge (no squash) 

## Description
Fixes for the mrp PD module
The first commit is the largest change: the input and output for the algorithm are no longer messages but Eigen Vectors.
The 2nd through the 5th commits change the inertia setting to also be done with eigen instead of messages, as well as to check if it is valid. This includes adding a header file with the inertia checks
Then some unused includes are removed
Finally gyroscopic terms are removed and the documentation is updated.

## Verification
Tests pass after the logical modifications according to the updates

## Documentation
Updated

## Future work
None
