### PR TITLE
Update navAggregate C-shim with VandV changes

### DIFF
--- a/algorithms/navAggregate/navAggregateAlgorithm_c.cpp
+++ b/algorithms/navAggregate/navAggregateAlgorithm_c.cpp
@@ -1,6 +1,13 @@
+/* MIT License
+ *
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
+ */
+
 #include "navAggregateAlgorithm_c.h"
 #include "navAggregateAlgorithm.h"
 
+#include <Eigen/Core>
 #include <array>
 
 uint32_t NavAggregateAlgorithm_getMaxAggNavMsg(void) { return MAX_AGG_NAV_MSG; }
@@ -13,19 +20,41 @@ void NavAggregateAlgorithm_destroy(NavAggregateAlgorithm* self) {
     delete reinterpret_cast<::NavAggregateAlgorithm*>(self);
 }
 
-AggregateOutput NavAggregateAlgorithm_update(NavAggregateAlgorithm* self,
-                                             const InputNavAttData* attInputs,
-                                             const InputNavTransData* transInputs) {
-    // Convert C arrays to std::array for C++ algorithm call
-    std::array<InputNavAttData, MAX_AGG_NAV_MSG> attArray;
-    std::array<InputNavTransData, MAX_AGG_NAV_MSG> transArray;
+AggregateOutput_c NavAggregateAlgorithm_update(NavAggregateAlgorithm* self,
+                                               const NavAttMsgF32Payload* attMsgsPayloads,
+                                               const NavTransMsgF32Payload* transMsgsPayloads) {
+    /* Convert C payload arrays to Eigen-based internal types */
+    std::array<InputNavAttData, MAX_AGG_NAV_MSG> attArray{};
+    std::array<InputNavTransData, MAX_AGG_NAV_MSG> transArray{};
 
     for (uint32_t i = 0; i < MAX_AGG_NAV_MSG; ++i) {
-        attArray[i] = attInputs[i];
-        transArray[i] = transInputs[i];
+        attArray[i].timeTag = attMsgsPayloads[i].timeTag;
+        attArray[i].sigma_BN = Eigen::Map<const Eigen::Vector3f>(attMsgsPayloads[i].sigma_BN);
+        attArray[i].omega_BN_B = Eigen::Map<const Eigen::Vector3f>(attMsgsPayloads[i].omega_BN_B);
+        attArray[i].vehSunPntBdy = Eigen::Map<const Eigen::Vector3f>(attMsgsPayloads[i].vehSunPntBdy);
+
+        transArray[i].timeTag = transMsgsPayloads[i].timeTag;
+        transArray[i].r_BN_N = Eigen::Map<const Eigen::Vector3d>(transMsgsPayloads[i].r_BN_N);
+        transArray[i].v_BN_N = Eigen::Map<const Eigen::Vector3d>(transMsgsPayloads[i].v_BN_N);
+        transArray[i].vehAccumDV = Eigen::Map<const Eigen::Vector3f>(transMsgsPayloads[i].vehAccumDV);
     }
 
-    return reinterpret_cast<::NavAggregateAlgorithm*>(self)->update(attArray, transArray);
+    AggregateOutput result = reinterpret_cast<::NavAggregateAlgorithm*>(self)->update(attArray, transArray);
+
+    /* Convert Eigen-based output back to C-compatible POD types */
+    AggregateOutput_c out{};
+
+    out.navAttOut.timeTag = result.navAttOut.timeTag;
+    Eigen::Map<Eigen::Vector3f>(out.navAttOut.sigma_BN) = result.navAttOut.sigma_BN;
+    Eigen::Map<Eigen::Vector3f>(out.navAttOut.omega_BN_B) = result.navAttOut.omega_BN_B;
+    Eigen::Map<Eigen::Vector3f>(out.navAttOut.vehSunPntBdy) = result.navAttOut.vehSunPntBdy;
+
+    out.navTransOut.timeTag = result.navTransOut.timeTag;
+    Eigen::Map<Eigen::Vector3d>(out.navTransOut.r_BN_N) = result.navTransOut.r_BN_N;
+    Eigen::Map<Eigen::Vector3d>(out.navTransOut.v_BN_N) = result.navTransOut.v_BN_N;
+    Eigen::Map<Eigen::Vector3f>(out.navTransOut.vehAccumDV) = result.navTransOut.vehAccumDV;
+
+    return out;
 }
 
 void NavAggregateAlgorithm_setAttTimeIdx(NavAggregateAlgorithm* self, uint32_t idx) {

--- a/algorithms/navAggregate/navAggregateAlgorithm_c.h
+++ b/algorithms/navAggregate/navAggregateAlgorithm_c.h
@@ -1,10 +1,15 @@
+/* MIT License
+ *
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics,
+ University of Colorado at Boulder
+ */
+
 #ifndef F32XIMERA_NAVAGGREGATEALGORITHM_C_H
 #define F32XIMERA_NAVAGGREGATEALGORITHM_C_H
 
-#include "navAggregateOutput.h"
+#include "msgPayloadDef/NavAttMsgF32Payload.h"
+#include "msgPayloadDef/NavTransMsgF32Payload.h"
 #include <stdint.h>
-
-#define MAX_AGG_NAV_MSG 10
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,6 +19,15 @@ extern "C" {
  * @brief Opaque handle to the C++ NavAggregateAlgorithm instance.
  */
 typedef struct NavAggregateAlgorithm NavAggregateAlgorithm;
+
+/**
+ * @brief C-compatible aggregate output containing attitude and translational
+ *        navigation results.
+ */
+typedef struct {
+    NavAttMsgF32Payload navAttOut;     /*!< attitude navigation output */
+    NavTransMsgF32Payload navTransOut; /*!< translation navigation output */
+} AggregateOutput_c;
 
 /**
  * @brief Get the maximum aggregate navigation message count.
@@ -35,14 +49,14 @@ void NavAggregateAlgorithm_destroy(NavAggregateAlgorithm* self);
 
 /**
  * @brief Run the update step.
- * @param self       Pointer to the instance.
- * @param attInputs  Pointer to array of attitude navigation inputs.
- * @param transInputs Pointer to array of translational navigation inputs.
- * @return AggregateOutput The computed output.
+ * @param self               Pointer to the instance.
+ * @param attMsgsPayloads    Pointer to array of attitude navigation message payloads.
+ * @param transMsgsPayloads  Pointer to array of translational navigation message payloads.
+ * @return AggregateOutput_c The computed output messages.
  */
-AggregateOutput NavAggregateAlgorithm_update(NavAggregateAlgorithm* self,
-                                             const InputNavAttData* attInputs,
-                                             const InputNavTransData* transInputs);
+AggregateOutput_c NavAggregateAlgorithm_update(NavAggregateAlgorithm* self,
+                                               const NavAttMsgF32Payload* attMsgsPayloads,
+                                               const NavTransMsgF32Payload* transMsgsPayloads);
 
 /**
  * @brief Set the attitude time index.


### PR DESCRIPTION
* **Tickets addressed:**
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
This PR updates the navAggregate C-shim to include updates from the navAggregate VandV:
- Uses AggregateOutput_c (POD) as the return type instead of AggregateOutput
- Converts NavAttMsgF32Payload[] -> InputNavAttData (via Eigen::Map) before calling update()
- Converts the Eigen-based AggregateOutput result back to POD AggregateOutput_c
- Removed the duplicated MAX_AGG_NAV_MSG define

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't
add or update any tests justify this choice. -->

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and
completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
