### PR TITLE
Mimu majority vote

### DIFF
--- a/algorithms/mimuMajorityVote/CMakeLists.txt
+++ b/algorithms/mimuMajorityVote/CMakeLists.txt
@@ -14,3 +14,5 @@ target_sources("${module}" PRIVATE
 target_include_directories("${module}" PRIVATE "..")
 
 target_link_libraries("${module}" PRIVATE Eigen3::Eigen)
+
+add_subdirectory(_tests)

--- a/algorithms/mimuMajorityVote/_tests/CMakeLists.txt
+++ b/algorithms/mimuMajorityVote/_tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(test_mimuMajorityVote
+  ../mimuMajorityVoteAlgorithm.cpp
+  mimuMajorityVoteTestHelpers.hpp
+  test_mimuMajorityVote.cpp
+)
+
+target_include_directories(test_mimuMajorityVote PRIVATE "../..")
+target_include_directories(test_mimuMajorityVote PRIVATE "..")
+target_include_directories(test_mimuMajorityVote PRIVATE "${CMAKE_SOURCE_DIR}")
+
+target_link_libraries(test_mimuMajorityVote PRIVATE
+    Eigen3::Eigen
+    GTest::gtest_main
+  )
+
+gtest_discover_tests(test_mimuMajorityVote)

--- a/algorithms/mimuMajorityVote/_tests/CMakeLists.txt
+++ b/algorithms/mimuMajorityVote/_tests/CMakeLists.txt
@@ -14,3 +14,28 @@ target_link_libraries(test_mimuMajorityVote PRIVATE
   )
 
 gtest_discover_tests(test_mimuMajorityVote)
+
+if(XMERA_ENABLE_FUZZTESTS)
+  fuzztest_setup_fuzzing_flags()
+
+  add_executable(test_mimuMajorityVote_fuzz
+    ../mimuMajorityVoteAlgorithm.cpp
+    mimuMajorityVoteTestHelpers.hpp
+    test_mimuMajorityVote_fuzz.cpp
+  )
+
+  target_include_directories(test_mimuMajorityVote_fuzz PRIVATE "../..")
+  target_include_directories(test_mimuMajorityVote_fuzz PRIVATE "..")
+  target_include_directories(test_mimuMajorityVote_fuzz PRIVATE "${CMAKE_SOURCE_DIR}")
+
+  target_link_libraries(test_mimuMajorityVote_fuzz PRIVATE
+    Eigen3::Eigen
+    fuzztest::fuzztest
+    fuzztest::fuzztest_gtest_main
+  )
+
+  gtest_discover_tests(test_mimuMajorityVote_fuzz
+    PROPERTIES
+      LABELS "fuzz\;fuzz-smoke"
+  )
+endif()

--- a/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
+++ b/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
@@ -1,0 +1,83 @@
+#ifndef TEST_MIMU_MAJORITY_VOTE_H
+#define TEST_MIMU_MAJORITY_VOTE_H
+
+#include "../freestandingInvalidArgument.h"
+#include "mimuMajorityVoteAlgorithm.h"
+#include <gtest/gtest.h>
+#include <math.h>
+#include <Eigen/Core>
+#include <vector>
+
+// Reference computation for update
+MimuMajorityVoteOutput referenceUpdate(const MimuMajorityVoteAlgorithm& alg,
+                                       const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs,
+                                       size_t numberOfImus) {
+    float omegaThreshold = alg.getOmegaThreshold();
+
+    // Compute average angular velocity
+    Eigen::Vector3f omegaAverage = Eigen::Vector3f::Zero();
+    for (size_t i = 0U; i < numberOfImus; ++i) {
+        omegaAverage += imuInputs.at(i).angVelBody;
+    }
+    omegaAverage /= static_cast<float>(numberOfImus);
+
+    // Find differences and detect faults
+    bool faultDetected = false;
+    size_t maxDiffIndex = 0U;
+    std::array<float, MAX_IMU_VEH_COUNT> diffMag{};
+    for (size_t i = 0U; i < numberOfImus; ++i) {
+        Eigen::Vector3f diff = imuInputs.at(i).angVelBody - omegaAverage;
+        diffMag.at(i) = diff.norm();
+        if (diffMag.at(i) >= omegaThreshold) {
+            faultDetected = true;
+        }
+        if (diffMag.at(i) > diffMag.at(maxDiffIndex)) {
+            maxDiffIndex = i;
+        }
+    }
+
+    MimuMajorityVoteOutput out{.faultDetected = faultDetected, .mimuIndexFaulted = -1};
+
+    // If fault detected, subtract outlier and recompute average
+    if (faultDetected) {
+        omegaAverage = (3 * omegaAverage - imuInputs.at(maxDiffIndex).angVelBody) / 2;
+        out.mimuIndexFaulted = static_cast<int>(maxDiffIndex);
+    }
+
+    out.avgAngVelBody = omegaAverage;
+    return out;
+}
+
+inline void regressionTestMimuMajorityVote(float omegaThreshold,
+                                            std::vector<float> angVel1,
+                                            std::vector<float> angVel2,
+                                            std::vector<float> angVel3) {
+    MimuMajorityVoteAlgorithm alg{};
+    alg.setOmegaThreshold(omegaThreshold);
+
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    imuInputs.at(0).angVelBody = Eigen::Map<Eigen::Vector3f>(angVel1.data());
+    imuInputs.at(1).angVelBody = Eigen::Map<Eigen::Vector3f>(angVel2.data());
+    imuInputs.at(2).angVelBody = Eigen::Map<Eigen::Vector3f>(angVel3.data());
+    size_t numberOfImus = 3U;
+
+    // Algorithm output
+    MimuMajorityVoteOutput out{};
+    EXPECT_NO_THROW(out = alg.update(imuInputs, numberOfImus));
+
+    // Reference output
+    MimuMajorityVoteOutput ref{};
+    EXPECT_NO_THROW(ref = referenceUpdate(alg, imuInputs, numberOfImus));
+
+    // Compare averaged angular velocity
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.avgAngVelBody[i], ref.avgAngVelBody[i], 1e-6);
+        EXPECT_TRUE(std::isfinite(out.avgAngVelBody[i]));
+    }
+
+    // Compare fault detection
+    EXPECT_EQ(out.faultDetected, ref.faultDetected);
+    EXPECT_EQ(out.mimuIndexFaulted, ref.mimuIndexFaulted);
+}
+
+#endif  // TEST_MIMU_MAJORITY_VOTE_H

--- a/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
+++ b/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
@@ -49,9 +49,10 @@ MimuMajorityVoteOutput referenceUpdate(const MimuMajorityVoteAlgorithm& alg,
 }
 
 inline void regressionTestMimuMajorityVote(float omegaThreshold,
-                                            std::vector<float> angVel1,
-                                            std::vector<float> angVel2,
-                                            std::vector<float> angVel3) {
+                                           const std::vector<float>& angVel1,
+                                           const std::vector<float>& angVel2,
+                                           const std::vector<float>& angVel3) {
+    constexpr size_t kNumImus = 3U;
     MimuMajorityVoteAlgorithm alg{};
     alg.setOmegaThreshold(omegaThreshold);
 

--- a/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
+++ b/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
@@ -8,43 +8,67 @@
 #include <Eigen/Core>
 #include <vector>
 
-// Reference computation for update
+// Reference computation for update — must mirror the production two-stage logic exactly
 MimuMajorityVoteOutput referenceUpdate(const MimuMajorityVoteAlgorithm& alg,
                                        const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs,
                                        size_t numberOfImus) {
-    float omegaThreshold = alg.getOmegaThreshold();
+    float const omegaThreshold = alg.getOmegaThreshold();
 
-    // Compute average angular velocity
+    // Stage 1: Compute average and find differences
     Eigen::Vector3f omegaAverage = Eigen::Vector3f::Zero();
     for (size_t i = 0U; i < numberOfImus; ++i) {
         omegaAverage += imuInputs.at(i).angVelBody;
     }
     omegaAverage /= static_cast<float>(numberOfImus);
 
-    // Find differences and detect faults
-    bool faultDetected = false;
+    MimuMajorityVoteOutput out{};
     size_t maxDiffIndex = 0U;
-    std::array<float, MAX_IMU_VEH_COUNT> diffMag{};
     for (size_t i = 0U; i < numberOfImus; ++i) {
-        Eigen::Vector3f diff = imuInputs.at(i).angVelBody - omegaAverage;
-        diffMag.at(i) = diff.norm();
-        if (diffMag.at(i) >= omegaThreshold) {
-            faultDetected = true;
-        }
-        if (diffMag.at(i) > diffMag.at(maxDiffIndex)) {
+        out.omegaDifferencesMag.at(i) = (imuInputs.at(i).angVelBody - omegaAverage).norm();
+        if (out.omegaDifferencesMag.at(i) > out.omegaDifferencesMag.at(maxDiffIndex)) {
             maxDiffIndex = i;
         }
+        out.validImus.at(i) = true;
     }
 
-    MimuMajorityVoteOutput out{.faultDetected = faultDetected, .mimuIndexFaulted = -1};
-
-    // If fault detected, subtract outlier and recompute average
-    if (faultDetected) {
-        omegaAverage = (3 * omegaAverage - imuInputs.at(maxDiffIndex).angVelBody) / 2;
-        out.mimuIndexFaulted = static_cast<int>(maxDiffIndex);
+    if (out.omegaDifferencesMag.at(maxDiffIndex) < omegaThreshold) {
+        out.avgAngVelBody = omegaAverage;
+        return out;
     }
 
-    out.avgAngVelBody = omegaAverage;
+    // Stage 2: Exclude outlier and recheck remaining
+    out.faultDetected = true;
+    out.validImus.at(maxDiffIndex) = false;
+
+    Eigen::Vector3f remainingAverage = Eigen::Vector3f::Zero();
+    size_t remainingCount = 0U;
+    for (size_t i = 0U; i < numberOfImus; ++i) {
+        if (i != maxDiffIndex) {
+            remainingAverage += imuInputs.at(i).angVelBody;
+            ++remainingCount;
+        }
+    }
+    remainingAverage /= static_cast<float>(remainingCount);
+
+    // Recheck remaining; update to Stage 2 differences
+    bool remainingDisagree = false;
+    for (size_t i = 0U; i < numberOfImus; ++i) {
+        if (i != maxDiffIndex) {
+            float const diff = (imuInputs.at(i).angVelBody - remainingAverage).norm();
+            out.omegaDifferencesMag.at(i) = diff;
+            if (diff >= omegaThreshold) {
+                remainingDisagree = true;
+            }
+        }
+    }
+
+    if (remainingDisagree) {
+        for (size_t j = 0U; j < numberOfImus; ++j) {
+            out.validImus.at(j) = false;
+        }
+    }
+
+    out.avgAngVelBody = remainingAverage;
     return out;
 }
 
@@ -55,20 +79,20 @@ inline void regressionTestMimuMajorityVote(float omegaThreshold,
     constexpr size_t kNumImus = 3U;
     MimuMajorityVoteAlgorithm alg{};
     alg.setOmegaThreshold(omegaThreshold);
+    alg.setNumberOfImus(kNumImus);
 
     std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
-    imuInputs.at(0).angVelBody = Eigen::Map<Eigen::Vector3f>(angVel1.data());
-    imuInputs.at(1).angVelBody = Eigen::Map<Eigen::Vector3f>(angVel2.data());
-    imuInputs.at(2).angVelBody = Eigen::Map<Eigen::Vector3f>(angVel3.data());
-    size_t numberOfImus = 3U;
+    imuInputs.at(0).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel1.data());
+    imuInputs.at(1).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel2.data());
+    imuInputs.at(2).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel3.data());
 
     // Algorithm output
     MimuMajorityVoteOutput out{};
-    EXPECT_NO_THROW(out = alg.update(imuInputs, numberOfImus));
+    EXPECT_NO_THROW(out = alg.update(imuInputs));
 
     // Reference output
     MimuMajorityVoteOutput ref{};
-    EXPECT_NO_THROW(ref = referenceUpdate(alg, imuInputs, numberOfImus));
+    EXPECT_NO_THROW(ref = referenceUpdate(alg, imuInputs, kNumImus));
 
     // Compare averaged angular velocity
     for (int i = 0; i < 3; ++i) {
@@ -78,7 +102,16 @@ inline void regressionTestMimuMajorityVote(float omegaThreshold,
 
     // Compare fault detection
     EXPECT_EQ(out.faultDetected, ref.faultDetected);
-    EXPECT_EQ(out.mimuIndexFaulted, ref.mimuIndexFaulted);
+
+    // Compare validImus
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        EXPECT_EQ(out.validImus.at(i), ref.validImus.at(i));
+    }
+
+    // Compare omegaDifferencesMag
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        EXPECT_NEAR(out.omegaDifferencesMag.at(i), ref.omegaDifferencesMag.at(i), 1e-6);
+    }
 }
 
 #endif  // TEST_MIMU_MAJORITY_VOTE_H

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
@@ -20,6 +20,7 @@ TEST(MimuMajorityVoteTest, PropertyTestNominal) {
     MimuMajorityVoteAlgorithm alg{};
     float threshold = 1.0F;
     alg.setOmegaThreshold(threshold);
+    alg.setNumberOfImus(3U);
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
 
@@ -31,13 +32,15 @@ TEST(MimuMajorityVoteTest, PropertyTestNominal) {
     Eigen::Vector3f expectedAvg =
         (imuInputs.at(0).angVelBody + imuInputs.at(1).angVelBody + imuInputs.at(2).angVelBody) / 3.0F;
 
-    auto out = alg.update(imuInputs, 3U);
+    auto out = alg.update(imuInputs);
 
     for (int i = 0; i < 3; ++i) {
         EXPECT_NEAR(out.avgAngVelBody[i], expectedAvg[i], 1e-6);
     }
     EXPECT_FALSE(out.faultDetected);
-    EXPECT_EQ(out.mimuIndexFaulted, -1);
+    for (size_t i = 0U; i < 3U; ++i) {
+        EXPECT_TRUE(out.validImus.at(i));
+    }
 }
 
 TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
@@ -45,6 +48,7 @@ TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
     MimuMajorityVoteAlgorithm alg{};
     float threshold = 0.05F;
     alg.setOmegaThreshold(threshold);
+    alg.setNumberOfImus(3U);
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
     Eigen::Vector3f outlierRate = baseRate + Eigen::Vector3f(2.0F, 2.0F, 2.0F);
@@ -57,19 +61,21 @@ TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
     // Expected: outlier excluded, average of remaining two
     Eigen::Vector3f expectedAvg = (imuInputs.at(0).angVelBody + imuInputs.at(2).angVelBody) / 2.0F;
 
-    auto out = alg.update(imuInputs, 3U);
+    auto out = alg.update(imuInputs);
 
     for (int i = 0; i < 3; ++i) {
         EXPECT_NEAR(out.avgAngVelBody[i], expectedAvg[i], 1e-6);
     }
     EXPECT_TRUE(out.faultDetected);
-    EXPECT_EQ(out.mimuIndexFaulted, 1);
+    EXPECT_TRUE(out.validImus.at(0));
+    EXPECT_FALSE(out.validImus.at(1));
+    EXPECT_TRUE(out.validImus.at(2));
 }
 
 TEST(MimuMajorityVoteTest, SetupTest) {
     MimuMajorityVoteAlgorithm alg{};
 
-    // --- Test expected exceptions ---
+    // --- Test expected exceptions for omegaThreshold ---
 
     // Zero or negative omegaThreshold
     EXPECT_THROW(alg.setOmegaThreshold(0.0F), fs::invalid_argument);
@@ -79,4 +85,24 @@ TEST(MimuMajorityVoteTest, SetupTest) {
     float threshold = 0.5F;
     EXPECT_NO_THROW(alg.setOmegaThreshold(threshold));
     EXPECT_NEAR(alg.getOmegaThreshold(), threshold, 1e-6);
+
+    // --- Test expected exceptions for numberOfImus ---
+
+    // Too few IMUs
+    EXPECT_THROW(alg.setNumberOfImus(0U), fs::invalid_argument);
+    EXPECT_THROW(alg.setNumberOfImus(2U), fs::invalid_argument);
+
+    // Too many IMUs
+    EXPECT_THROW(alg.setNumberOfImus(static_cast<size_t>(MAX_IMU_VEH_COUNT) + 1U), fs::invalid_argument);
+
+    // Valid counts
+    EXPECT_NO_THROW(alg.setNumberOfImus(3U));
+    EXPECT_EQ(alg.getNumberOfImus(), 3U);
+    EXPECT_NO_THROW(alg.setNumberOfImus(static_cast<size_t>(MAX_IMU_VEH_COUNT)));
+    EXPECT_EQ(alg.getNumberOfImus(), static_cast<size_t>(MAX_IMU_VEH_COUNT));
+
+    // --- Test update() guard when not configured ---
+    MimuMajorityVoteAlgorithm unconfigured{};
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    EXPECT_THROW(unconfigured.update(imuInputs), fs::invalid_argument);
 }

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
@@ -1,0 +1,82 @@
+#include "mimuMajorityVoteTestHelpers.hpp"
+#include <gtest/gtest.h>
+
+TEST(MimuMajorityVoteTest, RegressionTest) {
+    regressionTestMimuMajorityVote(1.0F,
+                                   std::vector<float>{-0.1F, 0.25F, 0.3F},
+                                   std::vector<float>{-0.09F, 0.24F, 0.305F},
+                                   std::vector<float>{-0.105F, 0.26F, 0.295F});
+}
+
+TEST(MimuMajorityVoteTest, RegressionTestOffNominal) {
+    regressionTestMimuMajorityVote(0.05F,
+                                   std::vector<float>{-0.1F, 0.25F, 0.3F},
+                                   std::vector<float>{1.9F, 2.25F, 2.3F},
+                                   std::vector<float>{-0.1F, 0.25F, 0.3F});
+}
+
+TEST(MimuMajorityVoteTest, PropertyTestNominal) {
+    // When all IMUs agree within threshold, output should be simple average with no fault
+    MimuMajorityVoteAlgorithm alg{};
+    float threshold = 1.0F;
+    alg.setOmegaThreshold(threshold);
+
+    Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
+
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    imuInputs.at(0).angVelBody = baseRate;
+    imuInputs.at(1).angVelBody = baseRate + Eigen::Vector3f(0.01F, -0.01F, 0.005F);
+    imuInputs.at(2).angVelBody = baseRate + Eigen::Vector3f(-0.005F, 0.01F, -0.01F);
+
+    Eigen::Vector3f expectedAvg =
+        (imuInputs.at(0).angVelBody + imuInputs.at(1).angVelBody + imuInputs.at(2).angVelBody) / 3.0F;
+
+    auto out = alg.update(imuInputs, 3U);
+
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.avgAngVelBody[i], expectedAvg[i], 1e-6);
+    }
+    EXPECT_FALSE(out.faultDetected);
+    EXPECT_EQ(out.mimuIndexFaulted, -1);
+}
+
+TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
+    // When one IMU is far off, it should be detected as faulted and excluded from average
+    MimuMajorityVoteAlgorithm alg{};
+    float threshold = 0.05F;
+    alg.setOmegaThreshold(threshold);
+
+    Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
+    Eigen::Vector3f outlierRate = baseRate + Eigen::Vector3f(2.0F, 2.0F, 2.0F);
+
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    imuInputs.at(0).angVelBody = baseRate;
+    imuInputs.at(1).angVelBody = outlierRate;  // The outlier
+    imuInputs.at(2).angVelBody = baseRate;
+
+    // Expected: outlier excluded, average of remaining two
+    Eigen::Vector3f expectedAvg = (imuInputs.at(0).angVelBody + imuInputs.at(2).angVelBody) / 2.0F;
+
+    auto out = alg.update(imuInputs, 3U);
+
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.avgAngVelBody[i], expectedAvg[i], 1e-6);
+    }
+    EXPECT_TRUE(out.faultDetected);
+    EXPECT_EQ(out.mimuIndexFaulted, 1);
+}
+
+TEST(MimuMajorityVoteTest, SetupTest) {
+    MimuMajorityVoteAlgorithm alg{};
+
+    // --- Test expected exceptions ---
+
+    // Zero or negative omegaThreshold
+    EXPECT_THROW(alg.setOmegaThreshold(0.0F), fs::invalid_argument);
+    EXPECT_THROW(alg.setOmegaThreshold(-0.1F), fs::invalid_argument);
+
+    // Valid threshold
+    float threshold = 0.5F;
+    EXPECT_NO_THROW(alg.setOmegaThreshold(threshold));
+    EXPECT_NEAR(alg.getOmegaThreshold(), threshold, 1e-6);
+}

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVoteF32.py
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVoteF32.py
@@ -109,7 +109,7 @@ def run_test(
     module = mimuMajorityVoteF32.MimuMajorityVote()
     module.modelTag = "mimuMajorityVote"
 
-    module.setOmegaThreshold(omega_threshold_rad_per_sec)
+    module.omegaThreshold = omega_threshold_rad_per_sec
 
     unit_test_sim.AddModelToTask(unit_task_name, module)
 
@@ -157,7 +157,7 @@ def run_test(
     )
     np.testing.assert_allclose(module_output_fault[-1], expected_output_fault, verbose=True)
     np.testing.assert_allclose(module_output_fault_index[-1], expected_output_fault_index, verbose=True)
-    np.testing.assert_allclose(module.getOmegaThreshold(), omega_threshold_rad_per_sec, rtol=0, atol=1e-7, verbose=True)
+    np.testing.assert_allclose(module.omegaThreshold, omega_threshold_rad_per_sec, rtol=0, atol=1e-7, verbose=True)
 
 
 if __name__ == "__main__":

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVoteF32.py
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVoteF32.py
@@ -34,7 +34,7 @@ def test_mimu_majority_vote_nominal():
     expected_angular_velocity += angular_velocity_3
     expected_angular_velocity /= 3.0
     expected_output_fault = False
-    expected_output_fault_index = -1
+    expected_valid_imus = [True, True, True, False]
 
     run_test(
         angular_velocity_1,
@@ -43,7 +43,7 @@ def test_mimu_majority_vote_nominal():
         omega_threshold_rad_per_sec,
         expected_angular_velocity,
         expected_output_fault,
-        expected_output_fault_index,
+        expected_valid_imus,
     )
 
 
@@ -73,7 +73,7 @@ def test_mimu_majority_vote_off_nominal():
     expected_angular_velocity += angular_velocity_3
     expected_angular_velocity /= 2.0
     expected_output_fault = True
-    expected_output_fault_index = 1
+    expected_valid_imus = [True, False, True, False]
 
     run_test(
         angular_velocity_1,
@@ -82,7 +82,7 @@ def test_mimu_majority_vote_off_nominal():
         omega_threshold_rad_per_sec,
         expected_angular_velocity,
         expected_output_fault,
-        expected_output_fault_index,
+        expected_valid_imus,
     )
 
 
@@ -93,7 +93,7 @@ def run_test(
     omega_threshold_rad_per_sec,
     expected_angular_velocity,
     expected_output_fault,
-    expected_output_fault_index,
+    expected_valid_imus,
 ):
 
     unit_task_name = "unitTask"
@@ -110,6 +110,7 @@ def run_test(
     module.modelTag = "mimuMajorityVote"
 
     module.omegaThreshold = omega_threshold_rad_per_sec
+    module.numberOfImus = 3
 
     unit_test_sim.AddModelToTask(unit_task_name, module)
 
@@ -150,13 +151,13 @@ def run_test(
 
     module_output_angular_velocity = rate_data_log.AngVelBody
     module_output_fault = fault_data_log.faultDetected
-    module_output_fault_index = fault_data_log.mimuIndexFaulted
+    module_output_valid_imus = fault_data_log.validImus
 
     np.testing.assert_allclose(
         module_output_angular_velocity[-1], expected_angular_velocity, rtol=0, atol=1e-7, verbose=True
     )
     np.testing.assert_allclose(module_output_fault[-1], expected_output_fault, verbose=True)
-    np.testing.assert_allclose(module_output_fault_index[-1], expected_output_fault_index, verbose=True)
+    np.testing.assert_array_equal(module_output_valid_imus[-1], expected_valid_imus)
     np.testing.assert_allclose(module.omegaThreshold, omega_threshold_rad_per_sec, rtol=0, atol=1e-7, verbose=True)
 
 

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote_fuzz.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote_fuzz.cpp
@@ -1,0 +1,265 @@
+#include "mimuMajorityVoteTestHelpers.hpp"
+#include <fuzztest/fuzztest.h>
+
+namespace {
+
+constexpr float kMaxAngVel = 1e3F;
+constexpr float kMinThreshold = 1e-2F;
+constexpr float kMaxThreshold = 1e3F;
+constexpr float kCompTol = 1e-3F;
+
+void propertyOutputAlwaysFinite(const std::vector<float>& angVel1,
+                                const std::vector<float>& angVel2,
+                                const std::vector<float>& angVel3,
+                                float omegaThreshold) {
+    constexpr size_t kNumImus = 3U;
+    MimuMajorityVoteAlgorithm alg{};
+    alg.setOmegaThreshold(omegaThreshold);
+    alg.setNumberOfImus(kNumImus);
+
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    imuInputs.at(0).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel1.data());
+    imuInputs.at(1).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel2.data());
+    imuInputs.at(2).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel3.data());
+
+    auto const out = alg.update(imuInputs);
+
+    for (int i = 0; i < 3; ++i) {
+        ASSERT_TRUE(std::isfinite(out.avgAngVelBody[i]));
+    }
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        ASSERT_GE(out.omegaDifferencesMag.at(i), 0.0F);
+        ASSERT_TRUE(std::isfinite(out.omegaDifferencesMag.at(i)));
+    }
+}
+
+void propertyFaultAndValidConsistency(const std::vector<float>& angVel1,
+                                      const std::vector<float>& angVel2,
+                                      const std::vector<float>& angVel3,
+                                      float omegaThreshold) {
+    constexpr size_t kNumImus = 3U;
+    MimuMajorityVoteAlgorithm alg{};
+    alg.setOmegaThreshold(omegaThreshold);
+    alg.setNumberOfImus(kNumImus);
+
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    imuInputs.at(0).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel1.data());
+    imuInputs.at(1).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel2.data());
+    imuInputs.at(2).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel3.data());
+
+    auto const out = alg.update(imuInputs);
+
+    size_t invalidCount = 0U;
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        if (!out.validImus.at(i)) {
+            ++invalidCount;
+        }
+    }
+
+    // Invalid count must be 0 (no fault), 1 (single outlier), or 3 (all invalid)
+    ASSERT_TRUE(invalidCount == 0U || invalidCount == 1U || invalidCount == kNumImus);
+    // faultDetected must be consistent with validImus
+    ASSERT_EQ(out.faultDetected, invalidCount > 0U);
+}
+
+void expectNoFaultAverage(const MimuMajorityVoteOutput& out,
+                          const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs,
+                          size_t numImus) {
+    Eigen::Vector3f expectedAvg = Eigen::Vector3f::Zero();
+    for (size_t i = 0U; i < numImus; ++i) {
+        expectedAvg += imuInputs.at(i).angVelBody;
+    }
+    expectedAvg /= static_cast<float>(numImus);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.avgAngVelBody[i], expectedAvg[i], kCompTol);
+    }
+}
+
+void expectSingleFaultAverage(const MimuMajorityVoteOutput& out,
+                              const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs,
+                              size_t numImus) {
+    size_t faultedIndex = numImus;  // sentinel
+    for (size_t i = 0U; i < numImus; ++i) {
+        if (!out.validImus.at(i)) {
+            faultedIndex = i;
+            break;
+        }
+    }
+    ASSERT_LT(faultedIndex, numImus);
+
+    Eigen::Vector3f expectedAvg = Eigen::Vector3f::Zero();
+    size_t count = 0U;
+    for (size_t i = 0U; i < numImus; ++i) {
+        if (i != faultedIndex) {
+            expectedAvg += imuInputs.at(i).angVelBody;
+            ++count;
+        }
+    }
+    expectedAvg /= static_cast<float>(count);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.avgAngVelBody[i], expectedAvg[i], kCompTol);
+    }
+}
+
+void propertyAverageIsCorrect(const std::vector<float>& angVel1,
+                              const std::vector<float>& angVel2,
+                              const std::vector<float>& angVel3,
+                              float omegaThreshold) {
+    constexpr size_t kNumImus = 3U;
+    MimuMajorityVoteAlgorithm alg{};
+    alg.setOmegaThreshold(omegaThreshold);
+    alg.setNumberOfImus(kNumImus);
+
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    imuInputs.at(0).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel1.data());
+    imuInputs.at(1).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel2.data());
+    imuInputs.at(2).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel3.data());
+
+    auto const out = alg.update(imuInputs);
+
+    size_t invalidCount = 0U;
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        if (!out.validImus.at(i)) {
+            ++invalidCount;
+        }
+    }
+
+    if (invalidCount == 0U) {
+        expectNoFaultAverage(out, imuInputs, kNumImus);
+    } else if (invalidCount == 1U) {
+        // Single outlier excluded: average of the remaining sensors
+        expectSingleFaultAverage(out, imuInputs, kNumImus);
+    }
+    // All-invalid: average is ω̄₂ (Stage 1 outlier excluded); correctness covered by regression test
+}
+
+void propertyIdenticalIMUsNoFault(const std::vector<float>& angVel, float omegaThreshold) {
+    constexpr size_t kNumImus = 3U;
+    MimuMajorityVoteAlgorithm alg{};
+    alg.setOmegaThreshold(omegaThreshold);
+    alg.setNumberOfImus(kNumImus);
+
+    Eigen::Vector3f const v = Eigen::Map<const Eigen::Vector3f>(angVel.data());
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        imuInputs.at(i).angVelBody = v;
+    }
+
+    auto const out = alg.update(imuInputs);
+
+    ASSERT_FALSE(out.faultDetected);
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        ASSERT_TRUE(out.validImus.at(i));
+        ASSERT_NEAR(out.omegaDifferencesMag.at(i), 0.0F, kCompTol);
+    }
+    for (int i = 0; i < 3; ++i) {
+        ASSERT_NEAR(out.avgAngVelBody[i], v[i], kCompTol);
+    }
+}
+
+void propertyClearSingleOutlier(const std::vector<float>& baseAngVel, size_t outlierIndex, float omegaThreshold) {
+    constexpr size_t kNumImus = 3U;
+    constexpr float kOutlierFactor = 10.0F;
+
+    MimuMajorityVoteAlgorithm alg{};
+    alg.setOmegaThreshold(omegaThreshold);
+    alg.setNumberOfImus(kNumImus);
+
+    Eigen::Vector3f const base = Eigen::Map<const Eigen::Vector3f>(baseAngVel.data());
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        imuInputs.at(i).angVelBody = base;
+    }
+    // Make outlier clearly separable: kOutlierFactor × threshold beyond the base pair
+    imuInputs.at(outlierIndex).angVelBody = base + kOutlierFactor * omegaThreshold * Eigen::Vector3f::Ones();
+
+    auto const out = alg.update(imuInputs);
+
+    ASSERT_TRUE(out.faultDetected);
+    ASSERT_FALSE(out.validImus.at(outlierIndex));
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        if (i != outlierIndex) {
+            ASSERT_TRUE(out.validImus.at(i));
+        }
+    }
+}
+
+void propertyCyclicPermutationInvariant(const std::vector<float>& angVel1,
+                                        const std::vector<float>& angVel2,
+                                        const std::vector<float>& angVel3,
+                                        float omegaThreshold) {
+    constexpr size_t kNumImus = 3U;
+    MimuMajorityVoteAlgorithm alg{};
+    alg.setOmegaThreshold(omegaThreshold);
+    alg.setNumberOfImus(kNumImus);
+
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    imuInputs.at(0).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel1.data());
+    imuInputs.at(1).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel2.data());
+    imuInputs.at(2).angVelBody = Eigen::Map<const Eigen::Vector3f>(angVel3.data());
+
+    auto const out0 = alg.update(imuInputs);
+
+    // Cyclic permutation: [v2, v3, v1]
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs1{};
+    imuInputs1.at(0).angVelBody = imuInputs.at(1).angVelBody;
+    imuInputs1.at(1).angVelBody = imuInputs.at(2).angVelBody;
+    imuInputs1.at(2).angVelBody = imuInputs.at(0).angVelBody;
+
+    auto const out1 = alg.update(imuInputs1);
+
+    ASSERT_EQ(out0.faultDetected, out1.faultDetected);
+
+    size_t invalidCount0 = 0U;
+    size_t invalidCount1 = 0U;
+    for (size_t i = 0U; i < kNumImus; ++i) {
+        if (!out0.validImus.at(i)) {
+            ++invalidCount0;
+        }
+        if (!out1.validImus.at(i)) {
+            ++invalidCount1;
+        }
+    }
+    ASSERT_EQ(invalidCount0, invalidCount1);
+}
+
+}  // namespace
+
+FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, regressionTestMimuMajorityVote)
+    .WithDomains(fuzztest::InRange(1e-6F, 1e3F),                                   // omegaThreshold
+                 fuzztest::VectorOf(fuzztest::InRange(-1e3F, 1e3F)).WithSize(3),   // angVel1
+                 fuzztest::VectorOf(fuzztest::InRange(-1e3F, 1e3F)).WithSize(3),   // angVel2
+                 fuzztest::VectorOf(fuzztest::InRange(-1e3F, 1e3F)).WithSize(3));  // angVel3
+
+FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyOutputAlwaysFinite)
+    .WithDomains(fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel1
+                 fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel2
+                 fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel3
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));                            // omegaThreshold
+
+FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyFaultAndValidConsistency)
+    .WithDomains(fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel1
+                 fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel2
+                 fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel3
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));                            // omegaThreshold
+
+FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyAverageIsCorrect)
+    .WithDomains(fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel1
+                 fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel2
+                 fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel3
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));                            // omegaThreshold
+
+FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyIdenticalIMUsNoFault)
+    .WithDomains(fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));                            // omegaThreshold
+
+FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyClearSingleOutlier)
+    .WithDomains(fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // baseAngVel
+                 fuzztest::InRange<size_t>(0, 2),                                             // outlierIndex
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));                            // omegaThreshold
+
+FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyCyclicPermutationInvariant)
+    .WithDomains(fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel1
+                 fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel2
+                 fuzztest::VectorOf(fuzztest::InRange(-kMaxAngVel, kMaxAngVel)).WithSize(3),  // angVel3
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));                            // omegaThreshold

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
@@ -1,5 +1,7 @@
 #include "mimuMajorityVote.h"
 
+#include "architecture/utilities/eigenSupport.h"
+
 void MimuMajorityVote::reset(uint64_t const callTime) {
     // check if at least 3 imus have been connected
     if (this->numberOfImus < 3U) {
@@ -8,16 +10,23 @@ void MimuMajorityVote::reset(uint64_t const callTime) {
 }
 
 void MimuMajorityVote::updateState(uint64_t const callTime) {
+    // Convert message payloads to algorithm input type
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs = {};
     for (size_t index = 0U; index < this->numberOfImus; ++index) {
-        // Unpack the messages into an array of message payloads
-        this->imuPayloads.at(index) = this->imuMessages.at(index).imuSensorBodyInMsg();
+        auto payload = this->imuMessages.at(index).imuSensorBodyInMsg();
+        imuInputs.at(index).angVelBody = cArrayToEigenVector(payload.AngVelBody);
     }
 
-    auto [imuSensorBodyMsgF32Payload, mimuFaultMsgPayload] =
-        this->algorithm.update(this->imuPayloads, this->numberOfImus);
+    auto [avgAngVelBody, faultDetected, mimuIndexFaulted] = this->algorithm.update(imuInputs, this->numberOfImus);
 
-    this->imuSensorBodyOutMsg.write(&imuSensorBodyMsgF32Payload, this->moduleID, callTime);
-    this->mimuFaultMsg.write(&mimuFaultMsgPayload, this->moduleID, callTime);
+    // Convert algorithm output to message payloads
+    IMUSensorBodyMsgF32Payload imuOutPayload{};
+    eigenVectorToCArray(avgAngVelBody, imuOutPayload.AngVelBody);
+
+    MimuFaultMsgPayload faultPayload{.faultDetected = faultDetected, .mimuIndexFaulted = mimuIndexFaulted};
+
+    this->imuSensorBodyOutMsg.write(&imuOutPayload, this->moduleID, callTime);
+    this->mimuFaultMsg.write(&faultPayload, this->moduleID, callTime);
 }
 
 // Add imu to the majority vote module

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
@@ -3,27 +3,33 @@
 #include "architecture/utilities/eigenSupport.h"
 
 void MimuMajorityVote::reset(uint64_t const callTime) {
-    // check if at least 3 imus have been connected
-    if (this->numberOfImus < 3U) {
-        throw std::invalid_argument("You need at least 3 imus for majority vote.");
+    if (this->algorithm.getNumberOfImus() == 0U) {
+        throw std::invalid_argument("Expected number of IMUs has not been configured; call setNumberOfImus().");
+    }
+    if (this->actualNumberOfImus != this->algorithm.getNumberOfImus()) {
+        throw std::invalid_argument(
+            "Number of connected IMU messages does not match the configured expected number of IMUs.");
     }
 }
 
 void MimuMajorityVote::updateState(uint64_t const callTime) {
+    size_t const numImus = this->algorithm.getNumberOfImus();
+
     // Convert message payloads to algorithm input type
     std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs = {};
-    for (size_t index = 0U; index < this->numberOfImus; ++index) {
+    for (size_t index = 0U; index < numImus; ++index) {
         auto payload = this->imuMessages.at(index).imuSensorBodyInMsg();
         imuInputs.at(index).angVelBody = cArrayToEigenVector(payload.AngVelBody);
     }
 
-    auto [avgAngVelBody, faultDetected, mimuIndexFaulted] = this->algorithm.update(imuInputs, this->numberOfImus);
+    auto output = this->algorithm.update(imuInputs);
 
     // Convert algorithm output to message payloads
     IMUSensorBodyMsgF32Payload imuOutPayload{};
-    eigenVectorToCArray(avgAngVelBody, imuOutPayload.AngVelBody);
+    eigenVectorToCArray(output.avgAngVelBody, imuOutPayload.AngVelBody);
 
-    MimuFaultMsgPayload faultPayload{.faultDetected = faultDetected, .mimuIndexFaulted = mimuIndexFaulted};
+    MimuFaultMsgPayload faultPayload{.faultDetected = output.faultDetected,
+                                     .mimuIndexFaulted = output.mimuIndexFaulted};
 
     this->imuSensorBodyOutMsg.write(&imuOutPayload, this->moduleID, callTime);
     this->mimuFaultMsg.write(&faultPayload, this->moduleID, callTime);
@@ -31,8 +37,8 @@ void MimuMajorityVote::updateState(uint64_t const callTime) {
 
 // Add imu to the majority vote module
 void MimuMajorityVote::addImuInput(const ImuMessage& imu) {
-    this->imuMessages.at(this->numberOfImus) = imu;
-    this->numberOfImus++;
+    this->imuMessages.at(this->actualNumberOfImus) = imu;
+    this->actualNumberOfImus++;
 }
 
 void MimuMajorityVote::setOmegaThreshold(float const omegaThreshold) {
@@ -40,3 +46,7 @@ void MimuMajorityVote::setOmegaThreshold(float const omegaThreshold) {
 }
 
 float MimuMajorityVote::getOmegaThreshold() const { return this->algorithm.getOmegaThreshold(); }
+
+void MimuMajorityVote::setNumberOfImus(size_t const numberOfImusIn) { this->algorithm.setNumberOfImus(numberOfImusIn); }
+
+size_t MimuMajorityVote::getNumberOfImus() const { return this->algorithm.getNumberOfImus(); }

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
@@ -22,14 +22,18 @@ void MimuMajorityVote::updateState(uint64_t const callTime) {
         imuInputs.at(index).angVelBody = cArrayToEigenVector(payload.AngVelBody);
     }
 
-    auto output = this->algorithm.update(imuInputs);
+    MimuMajorityVoteOutput output = this->algorithm.update(imuInputs);
 
     // Convert algorithm output to message payloads
     IMUSensorBodyMsgF32Payload imuOutPayload{};
     eigenVectorToCArray(output.avgAngVelBody, imuOutPayload.AngVelBody);
 
-    MimuFaultMsgPayload faultPayload{.faultDetected = output.faultDetected,
-                                     .mimuIndexFaulted = output.mimuIndexFaulted};
+    MimuFaultMsgPayload faultPayload{};
+    faultPayload.faultDetected = output.faultDetected;
+    for (size_t i = 0U; i < static_cast<size_t>(MAX_IMU_VEH_COUNT); ++i) {
+        faultPayload.validImus[i] = output.validImus.at(i);
+        faultPayload.omegaDifferencesMag[i] = output.omegaDifferencesMag.at(i);
+    }
 
     this->imuSensorBodyOutMsg.write(&imuOutPayload, this->moduleID, callTime);
     this->mimuFaultMsg.write(&faultPayload, this->moduleID, callTime);

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.h
@@ -2,7 +2,6 @@
 #define MIMU_MAJORITY_VOTE
 
 #include <Eigen/Core>
-#include <algorithm>
 #include <cstdint>
 
 #include "architecture/messaging/messaging.h"

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.h
@@ -23,12 +23,14 @@ class MimuMajorityVote : public SysModel {
     void addImuInput(const ImuMessage& imu);       //!< Method to add imus to the computation
     void setOmegaThreshold(float omegaThreshold);  //!< Setter method for omegaThreshold
     float getOmegaThreshold() const;               //!< Getter method for omegaThreshold
+    void setNumberOfImus(size_t numberOfImusIn);   //!< Setter method for expected number of IMUs
+    size_t getNumberOfImus() const;                //!< Getter method for expected number of IMUs
 
     Message<IMUSensorBodyMsgF32Payload> imuSensorBodyOutMsg;
     Message<MimuFaultMsgPayload> mimuFaultMsg;
 
    private:
-    size_t numberOfImus = 0U;
+    size_t actualNumberOfImus = 0U;
     MimuMajorityVoteAlgorithm algorithm{};
     std::array<ImuMessage, MAX_IMU_VEH_COUNT> imuMessages;
 };

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.h
@@ -2,6 +2,7 @@
 #define MIMU_MAJORITY_VOTE
 
 #include <Eigen/Core>
+#include <algorithm>
 #include <cstdint>
 
 #include "architecture/messaging/messaging.h"
@@ -31,7 +32,6 @@ class MimuMajorityVote : public SysModel {
     size_t numberOfImus = 0U;
     MimuMajorityVoteAlgorithm algorithm{};
     std::array<ImuMessage, MAX_IMU_VEH_COUNT> imuMessages;
-    std::array<IMUSensorBodyMsgF32Payload, MAX_IMU_VEH_COUNT> imuPayloads = {};
 };
 
 #endif

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.rst
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.rst
@@ -1,0 +1,234 @@
+==================
+MIMU Majority Vote
+==================
+
+-----------------
+Executive Summary
+-----------------
+
+The MIMU Majority Vote module combines the angular velocity measurements from three or more
+Inertial Measurement Units (IMUs) into a single best-estimate body-frame angular velocity.
+It uses a two-stage outlier rejection algorithm: a single faulty sensor is first identified
+by comparing each measurement against the full-sensor average, then the remaining sensors are
+cross-checked against their own average to detect a second level of disagreement.
+The module outputs the best-estimate average, a per-IMU validity array, and the angular
+velocity difference magnitudes for every sensor — providing downstream fault management with
+the information needed to take further action.
+
+-------------------------------
+Module Input/Output Messages
+-------------------------------
+
+The following table lists the Xmera message connections for the ``MimuMajorityVote`` module.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 35 45
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - ``imuSensorBodyInMsg`` (per sensor)
+      - :ref:`IMUSensorBodyMsgF32Payload`
+      - Input message for each connected IMU. One ``ImuMessage`` object is created
+        per sensor and added via ``addImuInput()``.
+    * - ``imuSensorBodyOutMsg``
+      - :ref:`IMUSensorBodyMsgF32Payload`
+      - Output message containing the majority-voted angular velocity estimate in the
+        spacecraft body frame (``AngVelBody``).
+    * - ``mimuFaultMsg``
+      - :ref:`MimuFaultMsgPayload`
+      - Output message containing fault status, per-IMU validity flags
+        (``validImus[4]``), and per-IMU difference magnitudes
+        (``omegaDifferencesMag[4]``).
+
+----------------------------
+Algorithm Description
+----------------------------
+
+The voting algorithm operates on :math:`n \geq 3` IMU measurements
+:math:`\boldsymbol{\omega}_i \in \mathbb{R}^3` (body-frame angular velocity, rad/s)
+and a scalar threshold :math:`T > 0` (rad/s). It runs in two sequential stages every
+update cycle.
+
+**Stage 1 — Full-average outlier detection**
+
+Compute the average of all :math:`n` measurements:
+
+.. math::
+
+   \bar{\boldsymbol{\omega}} = \frac{1}{n} \sum_{i=0}^{n-1} \boldsymbol{\omega}_i
+
+Compute the Euclidean distance of each measurement from the full average:
+
+.. math::
+
+   \delta_i = \lVert \boldsymbol{\omega}_i - \bar{\boldsymbol{\omega}} \rVert_2, \quad i = 0, \ldots, n-1
+
+Identify the worst offender:
+
+.. math::
+
+   k = \arg\max_i \; \delta_i
+
+If :math:`\delta_k \geq T`, IMU :math:`k` is flagged as invalid and removed.
+The average of the remaining :math:`n-1` sensors is recomputed:
+
+.. math::
+
+   \bar{\boldsymbol{\omega}}_2 = \frac{1}{n-1} \sum_{i \neq k} \boldsymbol{\omega}_i
+
+If no measurement exceeds the threshold (:math:`\delta_k < T`), all sensors are
+considered valid and :math:`\bar{\boldsymbol{\omega}}` is returned directly.
+
+**Stage 2 — Reduced-average cross-check**
+
+After removing the outlier, the remaining sensors are re-checked against the new
+reduced average. For each remaining valid sensor :math:`i \neq k`:
+
+.. math::
+
+   \delta_i^{(2)} = \lVert \boldsymbol{\omega}_i - \bar{\boldsymbol{\omega}}_2 \rVert_2
+
+If any :math:`\delta_i^{(2)} \geq T`, the remaining sensors disagree with each other.
+All :math:`n` IMUs are marked invalid. The returned average is still
+:math:`\bar{\boldsymbol{\omega}}_2` (the best estimate obtainable), but the caller is
+informed via the validity array that no sensor can be trusted.
+
+**Difference magnitudes in the output**
+
+The ``omegaDifferencesMag`` array is always populated. After Stage 1 the excluded IMU
+retains its original Stage 1 difference :math:`\delta_k`; the remaining sensors are
+updated to their Stage 2 values :math:`\delta_i^{(2)}`. If no fault is detected all
+entries hold the Stage 1 values.
+
+**Valid-count invariant**
+
+Because Stage 2 either leaves the count unchanged or marks all sensors invalid, the
+number of invalid IMUs for a 3-sensor configuration can only be **0, 1, or 3** — never
+exactly 2.
+
+-----------------------------------
+Standalone Algorithm (C++ API)
+-----------------------------------
+
+``MimuMajorityVoteAlgorithm`` is a plain C++ class with no Xmera dependency.
+
+**Inputs to** ``update()``
+
+.. list-table::
+    :widths: 30 15 60
+    :header-rows: 1
+
+    * - Parameter
+      - Type
+      - Description
+    * - ``imuInputs``
+      - ``std::array<MimuInput, 4>``
+      - Array of IMU measurements. Only the first ``numberOfImus`` entries are used.
+        Each entry contains ``angVelBody`` (:math:`\boldsymbol{\omega}_i`, rad/s).
+
+The number of active IMUs is fixed via ``setNumberOfImus()`` before the first
+``update()`` call. It must be in :math:`[3, \texttt{MAX\_IMU\_VEH\_COUNT}]`; a value
+outside this range throws ``fs::invalid_argument``.
+
+**Output** ``MimuMajorityVoteOutput``
+
+.. list-table::
+    :widths: 35 15 55
+    :header-rows: 1
+
+    * - Field
+      - Type
+      - Description
+    * - ``avgAngVelBody``
+      - ``Eigen::Vector3f``
+      - Best-estimate body-frame angular velocity (rad/s). Equals
+        :math:`\bar{\boldsymbol{\omega}}` when all agree, or
+        :math:`\bar{\boldsymbol{\omega}}_2` when one or more are invalid.
+    * - ``faultDetected``
+      - ``bool``
+      - ``true`` if any IMU has been marked invalid.
+    * - ``omegaDifferencesMag``
+      - ``std::array<float, 4>``
+      - Per-IMU difference magnitude (rad/s) as described above. Always populated.
+    * - ``validImus``
+      - ``std::array<bool, 4>``
+      - Per-IMU validity flag. ``true`` means the sensor is trusted. Entries beyond
+        ``numberOfImus`` are ``false``.
+
+**Configuration**
+
+The detection threshold is set via the ``setOmegaThreshold()`` / ``getOmegaThreshold()``
+accessor pair. The threshold must be strictly positive; a zero or negative value throws
+``fs::invalid_argument``.
+
+.. code-block:: cpp
+
+    MimuMajorityVoteAlgorithm alg{};
+    alg.setOmegaThreshold(0.05F);  // rad/s
+    alg.setNumberOfImus(3U);       // fixed for the lifetime of the object
+
+    std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs{};
+    imuInputs.at(0).angVelBody = omega0;
+    imuInputs.at(1).angVelBody = omega1;
+    imuInputs.at(2).angVelBody = omega2;
+
+    MimuMajorityVoteOutput out = alg.update(imuInputs);
+    // out.avgAngVelBody  — best-estimate rate
+    // out.faultDetected  — true if any IMU was rejected
+    // out.validImus      — per-sensor validity flags
+    // out.omegaDifferencesMag — per-sensor residuals
+
+-----------------------------------
+Module Assumptions and Limitations
+-----------------------------------
+
+- ``setNumberOfImus()`` must be called before ``reset()``, with a value in
+  :math:`[3, \texttt{MAX\_IMU\_VEH\_COUNT}]`. The number of ``addImuInput()`` calls
+  must equal the configured value; a mismatch throws ``std::invalid_argument``.
+- The maximum number of connected IMUs is ``MAX_IMU_VEH_COUNT`` (currently 4).
+- The algorithm is designed for the 3-sensor case. With 4 sensors the same two-stage
+  logic applies: one outlier is removed and the remaining three are cross-checked.
+- The threshold :math:`T` must be chosen to be meaningfully larger than the float32
+  rounding error in the average computation (~3 × :math:`\varepsilon_\text{mach}` ×
+  :math:`|\boldsymbol{\omega}|`). For angular rates up to 1000 rad/s this is
+  approximately 3.6 × 10\ :sup:`−4` rad/s.
+- When two sensors are exactly equidistant from the full average (a tie), the
+  algorithm rejects the one with the lower array index. The returned average therefore
+  depends on sensor ordering when ties occur; however, the fault detection outcome and
+  invalid count are index-order independent.
+- The module does not perform sensor health monitoring over time or persist fault
+  history between update cycles. Each call to ``update()`` is stateless with respect
+  to fault detection.
+
+----------
+User Guide
+----------
+
+The Xmera module is instantiated and configured from Python as follows::
+
+    module = mimuMajorityVoteF32.MimuMajorityVote()
+    module.modelTag = "mimuMajorityVote"
+
+    # Set the detection threshold (rad/s)
+    module.omegaThreshold = omegaThresholdRadPerSec
+
+    # Set the expected number of IMUs (must match the number of addImuInput() calls)
+    module.numberOfImus = len(imu_input_messages)
+
+    # Connect one ImuMessage per sensor
+    for imu_msg in imu_input_messages:
+        imu_entry = mimuMajorityVoteF32.ImuMessage()
+        imu_entry.imuSensorBodyInMsg.subscribeTo(imu_msg)
+        module.addImuInput(imu_entry)
+
+    scSim.AddModelToTask(taskName, module)
+
+The voted angular velocity is available on ``module.imuSensorBodyOutMsg`` and the
+fault status on ``module.mimuFaultMsg``. The ``mimuFaultMsg`` payload fields are:
+
+- ``faultDetected`` — ``bool``, mirrors ``MimuMajorityVoteOutput.faultDetected``.
+- ``validImus[4]`` — per-IMU validity flags; index matches the order sensors were
+  added via ``addImuInput()``.
+- ``omegaDifferencesMag[4]`` — per-IMU difference magnitude (rad/s); same ordering.

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
@@ -3,25 +3,29 @@
 #include "architecture/utilities/eigenSupport.h"
 #include "freestandingInvalidArgument.h"
 
-MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(const std::array<MimuInput, MAX_IMU_VEH_COUNT> &imuInputs,
-                                                         size_t const numberOfImus) {
+MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs) {
+    if (this->numberOfImus < 3U) {
+        FS_THROW_INVALID_ARGUMENT("numberOfImus is not configured; call setNumberOfImus() with a value >= 3");
+    }
+
     // Zero the angular velocity to calculate the average
     Eigen::Vector3f omegaAverage_BN_B{Eigen::Vector3f::Zero()};
-    for (size_t index = 0U; index < numberOfImus; ++index) {
+    for (size_t index = 0U; index < this->numberOfImus; ++index) {
         omegaAverage_BN_B += imuInputs.at(index).angVelBody;
     }
-    omegaAverage_BN_B /= static_cast<float>(numberOfImus);
+    omegaAverage_BN_B /= static_cast<float>(this->numberOfImus);
 
     bool faultDetected = false;
     // Find the difference and difference magnitude for each mimu with respect to the average
+    std::array<float, MAX_IMU_VEH_COUNT> omegaDifferencesMag{};
     size_t maxOmegaDifferenceIndex = 0U;
-    for (size_t index = 0U; index < numberOfImus; ++index) {
+    for (size_t index = 0U; index < this->numberOfImus; ++index) {
         Eigen::Vector3f const omegaDifference = imuInputs.at(index).angVelBody - omegaAverage_BN_B;
-        this->omegaDifferencesMag.at(index) = omegaDifference.norm();
-        if (this->omegaDifferencesMag.at(index) >= this->omegaThreshold) {
+        omegaDifferencesMag.at(index) = omegaDifference.norm();
+        if (omegaDifferencesMag.at(index) >= this->omegaThreshold) {
             faultDetected = true;
         }
-        if (this->omegaDifferencesMag.at(index) > this->omegaDifferencesMag.at(maxOmegaDifferenceIndex)) {
+        if (omegaDifferencesMag.at(index) > omegaDifferencesMag.at(maxOmegaDifferenceIndex)) {
             maxOmegaDifferenceIndex = index;
         }
     }
@@ -47,3 +51,12 @@ void MimuMajorityVoteAlgorithm::setOmegaThreshold(const float omegaThresholdIn) 
 }
 
 float MimuMajorityVoteAlgorithm::getOmegaThreshold() const { return this->omegaThreshold; }
+
+void MimuMajorityVoteAlgorithm::setNumberOfImus(const size_t numberOfImusIn) {
+    if (numberOfImusIn < 3U || numberOfImusIn > static_cast<size_t>(MAX_IMU_VEH_COUNT)) {
+        FS_THROW_INVALID_ARGUMENT("numberOfImus must be between 3 and MAX_IMU_VEH_COUNT (inclusive)");
+    }
+    this->numberOfImus = numberOfImusIn;
+}
+
+size_t MimuMajorityVoteAlgorithm::getNumberOfImus() const { return this->numberOfImus; }

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
@@ -12,24 +12,24 @@ MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(std::array<MimuInput, M
     }
     omegaAverage_BN_B /= static_cast<float>(numberOfImus);
 
-    this->faultDetected = false;
+    bool faultDetected = false;
     // Find the difference and difference magnitude for each mimu with respect to the average
     size_t maxOmegaDifferenceIndex = 0U;
     for (size_t index = 0U; index < numberOfImus; ++index) {
         Eigen::Vector3f const omegaDifference = imuInputs.at(index).angVelBody - omegaAverage_BN_B;
         this->omegaDifferencesMag.at(index) = omegaDifference.norm();
         if (this->omegaDifferencesMag.at(index) >= this->omegaThreshold) {
-            this->faultDetected = true;
+            faultDetected = true;
         }
         if (this->omegaDifferencesMag.at(index) > this->omegaDifferencesMag.at(maxOmegaDifferenceIndex)) {
             maxOmegaDifferenceIndex = index;
         }
     }
 
-    MimuMajorityVoteOutput mimuMajorityVoteOutput{.faultDetected = this->faultDetected, .mimuIndexFaulted = -1};
+    MimuMajorityVoteOutput mimuMajorityVoteOutput{.faultDetected = faultDetected, .mimuIndexFaulted = -1};
 
     // If a fault has been detected, subtract outlier from average and indicate which mimu has been faulted
-    if (this->faultDetected) {
+    if (faultDetected) {
         omegaAverage_BN_B = (3 * omegaAverage_BN_B - imuInputs.at(maxOmegaDifferenceIndex).angVelBody) / 2;
         mimuMajorityVoteOutput.mimuIndexFaulted = static_cast<int>(maxOmegaDifferenceIndex);
     }

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
@@ -3,13 +3,12 @@
 #include "architecture/utilities/eigenSupport.h"
 #include "freestandingInvalidArgument.h"
 
-MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
-    std::array<IMUSensorBodyMsgF32Payload, MAX_IMU_VEH_COUNT> imuPayloads,
-    size_t const numberOfImus) {
+MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs,
+                                                         size_t const numberOfImus) {
     // Zero the angular velocity to calculate the average
     Eigen::Vector3f omegaAverage_BN_B{Eigen::Vector3f::Zero()};
     for (size_t index = 0U; index < numberOfImus; ++index) {
-        omegaAverage_BN_B += Eigen::Map<const Eigen::Vector3f>(imuPayloads.at(index).AngVelBody);
+        omegaAverage_BN_B += imuInputs.at(index).angVelBody;
     }
     omegaAverage_BN_B /= static_cast<float>(numberOfImus);
 
@@ -17,8 +16,7 @@ MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
     // Find the difference and difference magnitude for each mimu with respect to the average
     size_t maxOmegaDifferenceIndex = 0U;
     for (size_t index = 0U; index < numberOfImus; ++index) {
-        Eigen::Vector3f const omegaDifference =
-            Eigen::Map<const Eigen::Vector3f>(imuPayloads.at(index).AngVelBody) - omegaAverage_BN_B;
+        Eigen::Vector3f const omegaDifference = imuInputs.at(index).angVelBody - omegaAverage_BN_B;
         this->omegaDifferencesMag.at(index) = omegaDifference.norm();
         if (this->omegaDifferencesMag.at(index) >= this->omegaThreshold) {
             this->faultDetected = true;
@@ -28,19 +26,15 @@ MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
         }
     }
 
-    MimuMajorityVoteOutput mimuMajorityVoteOutput{};
-    mimuMajorityVoteOutput.mimuFaultMsgPayload.faultDetected = this->faultDetected;
-    mimuMajorityVoteOutput.mimuFaultMsgPayload.mimuIndexFaulted = -1;
+    MimuMajorityVoteOutput mimuMajorityVoteOutput{.faultDetected = this->faultDetected, .mimuIndexFaulted = -1};
 
     // If a fault has been detected, subtract outlier from average and indicate which mimu has been faulted
     if (this->faultDetected) {
-        omegaAverage_BN_B = (3 * omegaAverage_BN_B -
-                             Eigen::Map<const Eigen::Vector3f>(imuPayloads.at(maxOmegaDifferenceIndex).AngVelBody)) /
-                            2;
-        mimuMajorityVoteOutput.mimuFaultMsgPayload.mimuIndexFaulted = static_cast<int>(maxOmegaDifferenceIndex);
+        omegaAverage_BN_B = (3 * omegaAverage_BN_B - imuInputs.at(maxOmegaDifferenceIndex).angVelBody) / 2;
+        mimuMajorityVoteOutput.mimuIndexFaulted = static_cast<int>(maxOmegaDifferenceIndex);
     }
 
-    eigenVectorToCArray(omegaAverage_BN_B, mimuMajorityVoteOutput.imuSensorBodyMsgF32Payload.AngVelBody);
+    mimuMajorityVoteOutput.avgAngVelBody = omegaAverage_BN_B;
 
     return mimuMajorityVoteOutput;
 }

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
@@ -3,7 +3,7 @@
 #include "architecture/utilities/eigenSupport.h"
 #include "freestandingInvalidArgument.h"
 
-MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs,
+MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(const std::array<MimuInput, MAX_IMU_VEH_COUNT> &imuInputs,
                                                          size_t const numberOfImus) {
     // Zero the angular velocity to calculate the average
     Eigen::Vector3f omegaAverage_BN_B{Eigen::Vector3f::Zero()};

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
@@ -3,44 +3,70 @@
 #include "architecture/utilities/eigenSupport.h"
 #include "freestandingInvalidArgument.h"
 
-MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs) {
+MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
+    const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs) const {
     if (this->numberOfImus < 3U) {
         FS_THROW_INVALID_ARGUMENT("numberOfImus is not configured; call setNumberOfImus() with a value >= 3");
     }
 
-    // Zero the angular velocity to calculate the average
-    Eigen::Vector3f omegaAverage_BN_B{Eigen::Vector3f::Zero()};
-    for (size_t index = 0U; index < this->numberOfImus; ++index) {
-        omegaAverage_BN_B += imuInputs.at(index).angVelBody;
+    // Stage 1: Compute average of all IMUs and find differences from average
+    Eigen::Vector3f omegaAverage_BN_B = Eigen::Vector3f::Zero();
+    for (size_t i = 0U; i < this->numberOfImus; ++i) {
+        omegaAverage_BN_B += imuInputs.at(i).angVelBody;
     }
     omegaAverage_BN_B /= static_cast<float>(this->numberOfImus);
 
-    bool faultDetected = false;
-    // Find the difference and difference magnitude for each mimu with respect to the average
-    std::array<float, MAX_IMU_VEH_COUNT> omegaDifferencesMag{};
-    size_t maxOmegaDifferenceIndex = 0U;
-    for (size_t index = 0U; index < this->numberOfImus; ++index) {
-        Eigen::Vector3f const omegaDifference = imuInputs.at(index).angVelBody - omegaAverage_BN_B;
-        omegaDifferencesMag.at(index) = omegaDifference.norm();
-        if (omegaDifferencesMag.at(index) >= this->omegaThreshold) {
-            faultDetected = true;
+    MimuMajorityVoteOutput output{};
+    size_t maxDiffIndex = 0U;
+    for (size_t i = 0U; i < this->numberOfImus; ++i) {
+        output.omegaDifferencesMag.at(i) = (imuInputs.at(i).angVelBody - omegaAverage_BN_B).norm();
+        if (output.omegaDifferencesMag.at(i) > output.omegaDifferencesMag.at(maxDiffIndex)) {
+            maxDiffIndex = i;
         }
-        if (omegaDifferencesMag.at(index) > omegaDifferencesMag.at(maxOmegaDifferenceIndex)) {
-            maxOmegaDifferenceIndex = index;
+        output.validImus.at(i) = true;
+    }
+
+    if (output.omegaDifferencesMag.at(maxDiffIndex) < this->omegaThreshold) {
+        // No fault - all IMUs agree within threshold
+        output.avgAngVelBody = omegaAverage_BN_B;
+        return output;
+    }
+
+    // Stage 2: Outlier detected - exclude it and recheck remaining IMUs
+    output.faultDetected = true;
+    output.validImus.at(maxDiffIndex) = false;
+
+    Eigen::Vector3f remainingAverage_BN_B = Eigen::Vector3f::Zero();
+    size_t remainingCount = 0U;
+    for (size_t i = 0U; i < this->numberOfImus; ++i) {
+        if (i != maxDiffIndex) {
+            remainingAverage_BN_B += imuInputs.at(i).angVelBody;
+            ++remainingCount;
+        }
+    }
+    remainingAverage_BN_B /= static_cast<float>(remainingCount);
+
+    // Recheck each remaining IMU against the remaining-IMU average; update their Stage 2 differences
+    bool remainingDisagree = false;
+    for (size_t i = 0U; i < this->numberOfImus; ++i) {
+        if (i != maxDiffIndex) {
+            float const remainingDiff = (imuInputs.at(i).angVelBody - remainingAverage_BN_B).norm();
+            output.omegaDifferencesMag.at(i) = remainingDiff;
+            if (remainingDiff >= this->omegaThreshold) {
+                remainingDisagree = true;
+            }
         }
     }
 
-    MimuMajorityVoteOutput mimuMajorityVoteOutput{.faultDetected = faultDetected, .mimuIndexFaulted = -1};
-
-    // If a fault has been detected, subtract outlier from average and indicate which mimu has been faulted
-    if (faultDetected) {
-        omegaAverage_BN_B = (3 * omegaAverage_BN_B - imuInputs.at(maxOmegaDifferenceIndex).angVelBody) / 2;
-        mimuMajorityVoteOutput.mimuIndexFaulted = static_cast<int>(maxOmegaDifferenceIndex);
+    if (remainingDisagree) {
+        // Remaining IMUs disagree - flag all as invalid; best estimate is still remainingAverage_BN_B
+        for (size_t j = 0U; j < this->numberOfImus; ++j) {
+            output.validImus.at(j) = false;
+        }
     }
 
-    mimuMajorityVoteOutput.avgAngVelBody = omegaAverage_BN_B;
-
-    return mimuMajorityVoteOutput;
+    output.avgAngVelBody = remainingAverage_BN_B;
+    return output;
 }
 
 void MimuMajorityVoteAlgorithm::setOmegaThreshold(const float omegaThresholdIn) {

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
@@ -1,24 +1,16 @@
 #ifndef MIMU_MAJORITY_VOTE_ALGORITHM
 #define MIMU_MAJORITY_VOTE_ALGORITHM
 
-#include "msgPayloadDef/IMUSensorBodyMsgF32Payload.h"
-#include "msgPayloadDef/MimuFaultMsgPayload.h"
-
 #include <Eigen/Core>
+#include <array>
 #include <cstdint>
 
-constexpr uint32_t MAX_IMU_VEH_COUNT = 4U;
-
-struct MimuMajorityVoteOutput {
-    IMUSensorBodyMsgF32Payload imuSensorBodyMsgF32Payload;
-    MimuFaultMsgPayload mimuFaultMsgPayload;
-};
+#include "mimuMajorityVoteTypes.h"
 
 /*!@brief Module to compute the majority vote of the mimus. */
 class MimuMajorityVoteAlgorithm {
    public:
-    MimuMajorityVoteOutput update(std::array<IMUSensorBodyMsgF32Payload, MAX_IMU_VEH_COUNT> imuPayloads,
-                                  size_t numberOfImus);
+    MimuMajorityVoteOutput update(std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs, size_t numberOfImus);
     void setOmegaThreshold(float omegaThresholdIn);  //!< Setter method for omegaThreshold
     float getOmegaThreshold() const;                 //!< Getter method for omegaThreshold
 

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
@@ -10,7 +10,7 @@
 /*!@brief Module to compute the majority vote of the mimus. */
 class MimuMajorityVoteAlgorithm {
    public:
-    MimuMajorityVoteOutput update(std::array<MimuInput, MAX_IMU_VEH_COUNT> imuInputs, size_t numberOfImus);
+    MimuMajorityVoteOutput update(const std::array<MimuInput, MAX_IMU_VEH_COUNT> &imuInputs, size_t numberOfImus);
     void setOmegaThreshold(float omegaThresholdIn);  //!< Setter method for omegaThreshold
     float getOmegaThreshold() const;                 //!< Getter method for omegaThreshold
 

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
@@ -10,13 +10,15 @@
 /*!@brief Module to compute the majority vote of the mimus. */
 class MimuMajorityVoteAlgorithm {
    public:
-    MimuMajorityVoteOutput update(const std::array<MimuInput, MAX_IMU_VEH_COUNT> &imuInputs, size_t numberOfImus);
+    MimuMajorityVoteOutput update(const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs);
     void setOmegaThreshold(float omegaThresholdIn);  //!< Setter method for omegaThreshold
     float getOmegaThreshold() const;                 //!< Getter method for omegaThreshold
+    void setNumberOfImus(size_t numberOfImusIn);     //!< Setter method for numberOfImus
+    size_t getNumberOfImus() const;                  //!< Getter method for numberOfImus
 
    private:
     float omegaThreshold = 1.0F;  // The threshold in which we will determine one of the mimus is faulted (rad/s)
-    std::array<float, MAX_IMU_VEH_COUNT - 1U> omegaDifferencesMag = {};
+    size_t numberOfImus = 0U;     // Fixed number of IMUs used in each update call
 };
 
 #endif

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
@@ -15,7 +15,6 @@ class MimuMajorityVoteAlgorithm {
     float getOmegaThreshold() const;                 //!< Getter method for omegaThreshold
 
    private:
-    bool faultDetected = false;
     float omegaThreshold = 1.0F;  // The threshold in which we will determine one of the mimus is faulted (rad/s)
     std::array<float, MAX_IMU_VEH_COUNT - 1U> omegaDifferencesMag = {};
 };

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
@@ -10,7 +10,7 @@
 /*!@brief Module to compute the majority vote of the mimus. */
 class MimuMajorityVoteAlgorithm {
    public:
-    MimuMajorityVoteOutput update(const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs);
+    MimuMajorityVoteOutput update(const std::array<MimuInput, MAX_IMU_VEH_COUNT>& imuInputs) const;
     void setOmegaThreshold(float omegaThresholdIn);  //!< Setter method for omegaThreshold
     float getOmegaThreshold() const;                 //!< Getter method for omegaThreshold
     void setNumberOfImus(size_t numberOfImusIn);     //!< Setter method for numberOfImus

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteF32.i
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteF32.i
@@ -6,6 +6,7 @@
 
 %include <attribute.i>
 %attribute(MimuMajorityVote, float, omegaThreshold, getOmegaThreshold, setOmegaThreshold)
+%attribute(MimuMajorityVote, size_t, numberOfImus, getNumberOfImus, setNumberOfImus)
 
 %include <std_string.i>
 %include <swig_conly_data.i>

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteF32.i
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteF32.i
@@ -4,6 +4,9 @@
    #include "utilities/timeConstants.h"
 %}
 
+%include <attribute.i>
+%attribute(MimuMajorityVote, float, omegaThreshold, getOmegaThreshold, setOmegaThreshold)
+
 %include <std_string.i>
 %include <swig_conly_data.i>
 %include <sys_model.i>

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
@@ -1,0 +1,24 @@
+/*
+ MIT License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ */
+
+#ifndef F32XIMERA_MIMU_MAJORITY_VOTE_TYPES_H
+#define F32XIMERA_MIMU_MAJORITY_VOTE_TYPES_H
+
+constexpr uint32_t MAX_IMU_VEH_COUNT = 4U;
+
+/*! @brief Input angular velocity from a single IMU */
+struct MimuInput {
+    Eigen::Vector3f angVelBody{}; /*!< [rad/s] Angular velocity in body frame */
+};
+
+/*! @brief Output from the MIMU majority vote algorithm */
+struct MimuMajorityVoteOutput {
+    Eigen::Vector3f avgAngVelBody{}; /*!< [rad/s] Averaged angular velocity in body frame */
+    bool faultDetected{};            /*!< Whether a MIMU fault was detected */
+    int mimuIndexFaulted{};          /*!< Index of faulted MIMU (-1 if no fault) */
+};
+
+#endif  // F32XIMERA_MIMU_MAJORITY_VOTE_TYPES_H

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
@@ -7,6 +7,10 @@
 #ifndef F32XIMERA_MIMU_MAJORITY_VOTE_TYPES_H
 #define F32XIMERA_MIMU_MAJORITY_VOTE_TYPES_H
 
+#include <Eigen/Core>
+#include <array>
+#include <cstdint>
+
 constexpr uint32_t MAX_IMU_VEH_COUNT = 4U;
 
 /*! @brief Input angular velocity from a single IMU */
@@ -18,7 +22,9 @@ struct MimuInput {
 struct MimuMajorityVoteOutput {
     Eigen::Vector3f avgAngVelBody{}; /*!< [rad/s] Averaged angular velocity in body frame */
     bool faultDetected{};            /*!< Whether a MIMU fault was detected */
-    int mimuIndexFaulted{};          /*!< Index of faulted MIMU (-1 if no fault) */
+    std::array<float, MAX_IMU_VEH_COUNT>
+        omegaDifferencesMag{}; /*!< [rad/s] Each IMU's difference magnitude from the 3-IMU average */
+    std::array<bool, MAX_IMU_VEH_COUNT> validImus{}; /*!< Whether each IMU is considered valid */
 };
 
 #endif  // F32XIMERA_MIMU_MAJORITY_VOTE_TYPES_H

--- a/algorithms/msgPayloadDef/MimuFaultMsgPayload.h
+++ b/algorithms/msgPayloadDef/MimuFaultMsgPayload.h
@@ -5,8 +5,9 @@
 
 /*! @brief Structure used to define the mimu fault message */
 typedef struct {
-    bool faultDetected;    //!< fault detected bool
-    int mimuIndexFaulted;  //!< mimu faulted index
+    bool faultDetected;            //!< fault detected bool
+    bool validImus[4];             //!< valid IMU flags for each IMU
+    float omegaDifferencesMag[4];  //!< [rad/s] magnitude of each IMU's difference from the 3-IMU average
 } MimuFaultMsgPayload;
 
 #endif /* mimuFaultMsg_h */


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2059
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR prepares mimuMajorityVote as a flight algorithm. The first commit separates the algorithm interface from the xmera message types. The subsequent reduce variable scope, and `const` where possible, remove unused includes, and adds a missing accessor method. The final commits add C++ google tests, fuzz testing, and refactors the voting logic two a two phase voting. This logic is described in the documentation added in the final commit.

## Verification
Google test and fuzz tests added.

## Documentation
New documentation added.

## Future work
None
