### PR TITLE
averageMimu V & V, with feedback

### DIFF
--- a/algorithms/averageMimuData/CMakeLists.txt
+++ b/algorithms/averageMimuData/CMakeLists.txt
@@ -14,3 +14,5 @@ target_sources("${module}" PRIVATE
 target_include_directories("${module}" PRIVATE "..")
 
 target_link_libraries("${module}" PRIVATE Eigen3::Eigen)
+
+add_subdirectory(_tests)

--- a/algorithms/averageMimuData/_tests/CMakeLists.txt
+++ b/algorithms/averageMimuData/_tests/CMakeLists.txt
@@ -1,0 +1,41 @@
+add_executable(test_averageMimuData
+  ../averageMimuDataAlgorithm.cpp
+  averageMimuDataTestHelpers.hpp
+  test_averageMimuData.cpp
+)
+
+target_include_directories(test_averageMimuData PRIVATE "../..")
+target_include_directories(test_averageMimuData PRIVATE "..")
+target_include_directories(test_averageMimuData PRIVATE "${CMAKE_SOURCE_DIR}")
+
+target_link_libraries(test_averageMimuData PRIVATE
+    Eigen3::Eigen
+    GTest::gtest_main
+  )
+
+gtest_discover_tests(test_averageMimuData)
+
+if(XMERA_ENABLE_FUZZTESTS)
+  fuzztest_setup_fuzzing_flags()
+
+  add_executable(test_averageMimuData_fuzz
+    ../averageMimuDataAlgorithm.cpp
+    averageMimuDataTestHelpers.hpp
+    test_averageMimuData_fuzz.cpp
+  )
+
+  target_include_directories(test_averageMimuData_fuzz PRIVATE "../..")
+  target_include_directories(test_averageMimuData_fuzz PRIVATE "..")
+  target_include_directories(test_averageMimuData_fuzz PRIVATE "${CMAKE_SOURCE_DIR}")
+
+  target_link_libraries(test_averageMimuData_fuzz PRIVATE
+    Eigen3::Eigen
+    fuzztest::fuzztest
+    fuzztest::fuzztest_gtest_main
+  )
+
+  gtest_discover_tests(test_averageMimuData_fuzz
+    PROPERTIES
+      LABELS "fuzz\;fuzz-smoke"
+  )
+endif()

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -7,24 +7,13 @@
 #include <architecture/utilities/macroDefinitions.h>
 #include <gtest/gtest.h>
 
-    // Assuming pkt.gyro_B and pkt.accel_B are float[3]
-    pkt.gyro_B[0] = gyro[0];
-    pkt.gyro_B[1] = gyro[1];
-    pkt.gyro_B[2] = gyro[2];
-    pkt.accel_B[0] = accel[0];
-    pkt.accel_B[1] = accel[1];
-    pkt.accel_B[2] = accel[2];
-}
-
-OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts,
-    const AverageMimuDataAlgorithm& alg)
-{
+OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const AverageMimuDataAlgorithm& alg) {
     uint64_t maxTimeTag = 0U;
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
         maxTimeTag = std::max(localPkts.measTime[i], maxTimeTag);
     }
 
-    Eigen::Vector3f gyroSum_P  = Eigen::Vector3f::Zero();
+    Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
     Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
     uint64_t measAvgCount = 0U;
 
@@ -33,7 +22,7 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts,
 
         // Rolling average with averaging window as window width or the maximum buffer size
         if (static_cast<float>(maxTimeTag - measTime) * NANO2SEC <= alg.getAveragingWindow()) {
-            gyroSum_P  += localPkts.gyro_P[i];
+            gyroSum_P += localPkts.gyro_P[i];
             accelSum_P += localPkts.accel_P[i];
             measAvgCount++;
         }
@@ -41,13 +30,12 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts,
 
     OutputAverageAccelAngleVel out{};
     if (measAvgCount > 0U) {
-        const float invCount = 1.0f / static_cast<float>(measAvgCount);
-
-        gyroSum_P *= invCount;
-        accelSum_P *= invCount;
-
-        out.gyroOmega_B = alg.getDcmPltfToBdy() * gyroSum_P;
-        out.accel_B  = alg.getDcmPltfToBdy() * accelSum_P;
+        gyroSum_P /= static_cast<float>(measAvgCount);
+        Eigen::Vector3f const gyroSum_B = alg.getDcmPltfToBdy() * gyroSum_P;
+        accelSum_P /= static_cast<float>(measAvgCount);
+        Eigen::Vector3f const accelSum_B = alg.getDcmPltfToBdy() * accelSum_P;
+        out.gyroOmega_B = gyroSum_B;
+        out.accel_B = accelSum_B;
     }
 
     return out;
@@ -57,245 +45,43 @@ using Vec3Arr = std::array<float, 3>;
 
 inline Eigen::Vector3f toVec3(Vec3Arr const& a) { return Eigen::Vector3f{a[0], a[1], a[2]}; }
 
-inline void regressionTestaverageMimuData(float window,
-                                          float time_meas_factor_0,
-                                          float time_meas_factor_1,
-                                          float time_meas_factor_2,
-                                          Vec3Arr const& gyro_0,
-                                          Vec3Arr const& accel_0,
-                                          Vec3Arr const& gyro_1,
-                                          Vec3Arr const& accel_1,
-                                          Vec3Arr const& gyro_2,
-                                          Vec3Arr const& accel_2,
-                                          Vec3Arr const& gyro_3,
-                                          Vec3Arr const& accel_3) {
+struct InputData {
+    uint64_t measTime = 0U;
+    Vec3Arr gyro_P{{0.0F, 0.0F, 0.0F}};
+    Vec3Arr accel_P{{0.0F, 0.0F, 0.0F}};
+};
+
+inline void regressionTestAverageMimuData(std::size_t N,
+                                          float window,
+                                          std::array<InputData, MAX_ACC_BUF_PKT> const& input) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setAveragingWindow(window);
 
+    // Clamp N to valid range
+    if (N > MAX_ACC_BUF_PKT) {
+        N = MAX_ACC_BUF_PKT;
+    }
+    // Build the algorithm input buffer (max size), but only populate first N.
+    // The rest are neutral so they cannot affect maxTimeTag or the average.
     InputPktsData in{};
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
         in.measTime[i] = 0U;
-        in.gyro_P[i]   = Eigen::Vector3f::Zero();
-        in.accel_P[i]  = Eigen::Vector3f::Zero();
+        in.gyro_P[i] = Eigen::Vector3f::Zero();
+        in.accel_P[i] = Eigen::Vector3f::Zero();
     }
 
-    constexpr uint64_t t_ref = SEC2NANO;
-
-    // Build Eigen vectors from arrays
-    const Eigen::Vector3f g0 = toVec3(gyro_0);
-    const Eigen::Vector3f a0 = toVec3(accel_0);
-    const Eigen::Vector3f g1 = toVec3(gyro_1);
-    const Eigen::Vector3f a1 = toVec3(accel_1);
-    const Eigen::Vector3f g2 = toVec3(gyro_2);
-    const Eigen::Vector3f a2 = toVec3(accel_2);
-    const Eigen::Vector3f g3 = toVec3(gyro_3);
-    const Eigen::Vector3f a3 = toVec3(accel_3);
-
-    // Directly assign the first 4 packets
-    in.measTime[0] = t_ref;
-    in.gyro_P[0]   = g0;
-    in.accel_P[0]  = a0;
-
-    in.measTime[1] = t_ref - static_cast<uint64_t>(SEC2NANO * time_meas_factor_0);
-    in.gyro_P[1]   = g1;
-    in.accel_P[1]  = a1;
-
-    in.measTime[2] = t_ref - static_cast<uint64_t>(SEC2NANO * time_meas_factor_1);
-    in.gyro_P[2]   = g2;
-    in.accel_P[2]  = a2;
-
-    in.measTime[3] = t_ref - static_cast<uint64_t>(SEC2NANO * time_meas_factor_2);
-    in.gyro_P[3]   = g3;
-    in.accel_P[3]  = a3;
+    for (std::size_t i = 0; i < N; ++i) {
+        in.measTime[i] = input[i].measTime;
+        in.gyro_P[i] = toVec3(input[i].gyro_P);
+        in.accel_P[i] = toVec3(input[i].accel_P);
+    }
 
     const OutputAverageAccelAngleVel out_alg = alg.update(in);
-    const OutputAverageAccelAngleVel out_ref = referenceUpdate(in, alg);  // <-- update referenceUpdate signature too
+    const OutputAverageAccelAngleVel out_ref = referenceUpdate(in, alg);
 
-    // Use tolerant comparison for floats
-    constexpr float tol = 1e-5f;
-    EXPECT_TRUE(out_alg.gyroOmega_B.isApprox(out_ref.gyroOmega_B, tol));
-    EXPECT_TRUE(out_alg.accel_B.isApprox(out_ref.accel_B, tol));
-}
-
-inline void testKnownSolaverageMimuData() {
-    // -----------------------
-    // Fixed algorithm settings
-    // -----------------------
-    AverageMimuDataAlgorithm alg;
-
-    // 90 deg rotation about +Z:
-    // [ 0 -1  0
-    //   1  0  0
-    //   0  0  1 ]
-    Eigen::Matrix3f dcm_BP;
-    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
-
-    alg.setDcmPltfToBdy(dcm_BP);
-
-    // Time window (seconds)
-    // Choose 0.26 so ages 0.00, 0.05, 0.15 are included; 0.30 excluded
-    constexpr float window = 0.26f;
-    alg.setAveragingWindow(window);
-
-    // -----------------------
-    // Fixed synthetic packets (DIRECT)
-    // -----------------------
-    InputPktsData in{};  // <-- directly build unpacked input
-
-    // zero everything (Eigen::Vector3f default in std::array is uninitialized)
-    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        in.measTime[i] = 0U;
-        in.gyro_P[i]   = Eigen::Vector3f::Zero();
-        in.accel_P[i]  = Eigen::Vector3f::Zero();
-    }
-
-    // Reference time = 1.0s (ns)
-    constexpr uint64_t t_ref = SEC2NANO;
-
-    // Ages in seconds: 0.00, 0.05, 0.15, 0.30 (cleanly away from boundary)
-    const uint64_t t0 = t_ref;
-    const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
-    const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
-    const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
-
-    // Choose easy vectors so the mean is simple.
-    const Eigen::Vector3f gyro0{ 1.f, 2.f, 3.f};
-    const Eigen::Vector3f gyro1{ 3.f, 2.f, 1.f};
-    const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
-    const Eigen::Vector3f gyro3{ 9.f, 9.f, 9.f};  // excluded by averagingWindow
-
-    const Eigen::Vector3f acc0{4.f, 0.f, 0.f};
-    const Eigen::Vector3f acc1{0.f, 4.f, 0.f};
-    const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
-    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};    // excluded by averagingWindow
-
-    // Put packets in the first few slots
-    in.measTime[0] = t0;  in.gyro_P[0] = gyro0;  in.accel_P[0] = acc0;
-    in.measTime[1] = t1;  in.gyro_P[1] = gyro1;  in.accel_P[1] = acc1;
-    in.measTime[2] = t2;  in.gyro_P[2] = gyro2;  in.accel_P[2] = acc2;
-    in.measTime[3] = t3;  in.gyro_P[3] = gyro3;  in.accel_P[3] = acc3;
-
-    // -----------------------
-    // Run algorithm under test
-    // -----------------------
-    const OutputAverageAccelAngleVel out_alg = alg.update(in);
-    // -----------------------
-    // True known solution:
-    // include packets 0,1,2 only (ages 0, 0.05, 0.15 < 0.26)
-    // mean_P = (v0 + v1 + v2) / 3
-    // out_B = dcm_BP * mean_P
-    // -----------------------
-    const Eigen::Vector3f gyroMean_P = (gyro0 + gyro1 + gyro2) / 3.f;
-    const Eigen::Vector3f accMean_P = (acc0 + acc1 + acc2) / 3.f;
-
-    const Eigen::Vector3f gyroTrue_B = dcm_BP * gyroMean_P;
-    const Eigen::Vector3f accTrue_B = dcm_BP * accMean_P;
-
-    EXPECT_EQ(out_alg.gyroOmega_B, gyroTrue_B);
-    EXPECT_EQ(out_alg.accel_B, accTrue_B);
-}
-
-inline void testZeroAveragingWindow() {
-    // -----------------------
-    // Fixed algorithm settings
-    // -----------------------
-    AverageMimuDataAlgorithm alg;
-
-    Eigen::Matrix3f dcm_BP;
-    dcm_BP << 0.f, -1.f, 0.f,
-              1.f,  0.f, 0.f,
-              0.f,  0.f, 1.f;
-    alg.setDcmPltfToBdy(dcm_BP);
-
-    // averagingWindow = 0 => should pick the packet(s) at maxTimeTag
-    alg.setAveragingWindow(0.0f);
-
-    // -----------------------
-    // Fixed synthetic packets (DIRECT)
-    // -----------------------
-    InputPktsData in{};
-
-    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        in.measTime[i] = 0U;
-        in.gyro_P[i]   = Eigen::Vector3f::Zero();
-        in.accel_P[i]  = Eigen::Vector3f::Zero();
-    }
-
-    constexpr uint64_t t_ref = SEC2NANO;
-
-    // Make packet 0 the unique maxTimeTag
-    const uint64_t t0 = t_ref;                                    // max
-    const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
-    const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
-    const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
-
-    const Eigen::Vector3f gyro0{ 1.f, 2.f, 3.f};
-    const Eigen::Vector3f gyro1{ 3.f, 2.f, 1.f};
-    const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
-    const Eigen::Vector3f gyro3{ 9.f, 9.f, 9.f};
-
-    const Eigen::Vector3f acc0{4.f, 0.f, 0.f};
-    const Eigen::Vector3f acc1{0.f, 4.f, 0.f};
-    const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
-    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};
-
-    in.measTime[0] = t0;  in.gyro_P[0] = gyro0;  in.accel_P[0] = acc0;
-    in.measTime[1] = t1;  in.gyro_P[1] = gyro1;  in.accel_P[1] = acc1;
-    in.measTime[2] = t2;  in.gyro_P[2] = gyro2;  in.accel_P[2] = acc2;
-    in.measTime[3] = t3;  in.gyro_P[3] = gyro3;  in.accel_P[3] = acc3;
-
-    // -----------------------
-    // Run algorithm under test
-    // -----------------------
-    const OutputAverageAccelAngleVel out_alg = alg.update(in);
-
-    // -----------------------
-    // True known solution (averagingWindow = 0):
-    // use ONLY the packet with maxTimeTag (packet 0 here)
-    // out_B = dcm_BP * v0
-    // -----------------------
-    const Eigen::Vector3f gyroTrue_B = dcm_BP * gyro0;
-    const Eigen::Vector3f accTrue_B  = dcm_BP * acc0;
-
-    EXPECT_EQ(out_alg.gyroOmega_B, gyroTrue_B);
-    EXPECT_EQ(out_alg.accel_B, accTrue_B);
-}
-
-inline void testSetupAverageMimuData() {
-    AverageMimuDataAlgorithm alg;
-
-    // 1) Setters should not throw
-    EXPECT_THROW(alg.setAveragingWindow(-0.1), fs::invalid_argument);
-    EXPECT_NO_THROW(alg.setAveragingWindow(0.25f));
-    // Not orthonormal (scaling matrix), det != 1 as well
-    Eigen::Matrix3f badOrtho = Eigen::Matrix3f::Identity();
-    badOrtho(0, 0) = 2.0F;
-    EXPECT_THROW(alg.setDcmPltfToBdy(badOrtho), fs::invalid_argument);
-    // det = -1 (reflection), orthonormal but not a proper rotation
-    Eigen::Matrix3f badDet = Eigen::Matrix3f::Identity();
-    badDet(0, 0) = -1.0F;
-    EXPECT_THROW(alg.setDcmPltfToBdy(badDet), fs::invalid_argument);
-    EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
-
-    // 2) Round-trip expectations
-    EXPECT_FLOAT_EQ(alg.getAveragingWindow(), 0.25f);
-    EXPECT_TRUE(alg.getDcmPltfToBdy().isApprox(Eigen::Matrix3f::Identity(), 0.0f));
-
-    // 3) update() should not throw for a basic input
-    InputPktsData in{};
-    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        in.measTime[i] = 0U;
-        in.gyro_P[i]   = Eigen::Vector3f::Zero();
-        in.accel_P[i]  = Eigen::Vector3f::Zero();
-    }
-
-    // Add one non-zero packet so we exercise the averaging path
-    in.measTime[0] = SEC2NANO;
-    in.gyro_P[0]   = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
-    in.accel_P[0]  = Eigen::Vector3f(4.0f, 5.0f, 6.0f);
-
-    EXPECT_NO_THROW((void)alg.update(in));
+    EXPECT_EQ(out_alg.gyroOmega_B, out_ref.gyroOmega_B);
+    EXPECT_EQ(out_alg.accel_B, out_ref.accel_B);
 }
 
 #endif

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -32,7 +32,7 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts,
         const uint64_t measTime = localPkts.measTime[i];
 
         // Rolling average with timeDelta as window width or the maximum buffer size
-        if (static_cast<float>(maxTimeTag - measTime) * NANO2SEC < alg.getTimeDelta()) {
+        if (static_cast<float>(maxTimeTag - measTime) * NANO2SEC <= alg.getTimeDelta()) {
             gyroSum_P  += localPkts.gyro_P[i];
             accelSum_P += localPkts.accel_P[i];
             measAvgCount++;
@@ -196,10 +196,77 @@ inline void testKnownSolaverageMimuData() {
     EXPECT_EQ(out_alg.accel_B, accTrue_B);
 }
 
+inline void testZeroTimeDelta() {
+    // -----------------------
+    // Fixed algorithm settings
+    // -----------------------
+    AverageMimuDataAlgorithm alg;
+
+    Eigen::Matrix3f dcm_BP;
+    dcm_BP << 0.f, -1.f, 0.f,
+              1.f,  0.f, 0.f,
+              0.f,  0.f, 1.f;
+    alg.setDcmPltfToBdy(dcm_BP);
+
+    // timeDelta = 0 => should pick the packet(s) at maxTimeTag
+    alg.setTimeDelta(0.0f);
+
+    // -----------------------
+    // Fixed synthetic packets (DIRECT)
+    // -----------------------
+    InputPktsData in{};
+
+    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.measTime[i] = 0U;
+        in.gyro_P[i]   = Eigen::Vector3f::Zero();
+        in.accel_P[i]  = Eigen::Vector3f::Zero();
+    }
+
+    constexpr uint64_t t_ref = SEC2NANO;
+
+    // Make packet 0 the unique maxTimeTag
+    const uint64_t t0 = t_ref;                                    // max
+    const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
+    const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
+    const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
+
+    const Eigen::Vector3f gyro0{ 1.f, 2.f, 3.f};
+    const Eigen::Vector3f gyro1{ 3.f, 2.f, 1.f};
+    const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
+    const Eigen::Vector3f gyro3{ 9.f, 9.f, 9.f};
+
+    const Eigen::Vector3f acc0{4.f, 0.f, 0.f};
+    const Eigen::Vector3f acc1{0.f, 4.f, 0.f};
+    const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
+    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};
+
+    in.measTime[0] = t0;  in.gyro_P[0] = gyro0;  in.accel_P[0] = acc0;
+    in.measTime[1] = t1;  in.gyro_P[1] = gyro1;  in.accel_P[1] = acc1;
+    in.measTime[2] = t2;  in.gyro_P[2] = gyro2;  in.accel_P[2] = acc2;
+    in.measTime[3] = t3;  in.gyro_P[3] = gyro3;  in.accel_P[3] = acc3;
+
+    // -----------------------
+    // Run algorithm under test
+    // -----------------------
+    const OutputAverageAccelAngleVel out_alg = alg.update(in);
+
+    // -----------------------
+    // True known solution (timeDelta = 0):
+    // use ONLY the packet with maxTimeTag (packet 0 here)
+    // out_B = dcm_BP * v0
+    // -----------------------
+    const Eigen::Vector3f gyroTrue_B = dcm_BP * gyro0;
+    const Eigen::Vector3f accTrue_B  = dcm_BP * acc0;
+
+    EXPECT_EQ(out_alg.gyroOmega_B, gyroTrue_B);
+    EXPECT_EQ(out_alg.accel_B, accTrue_B);
+}
+
 inline void testSetupAverageMimuData() {
     AverageMimuDataAlgorithm alg;
 
     // 1) Setters should not throw
+    EXPECT_THROW(alg.setTimeDelta(-0.1), fs::invalid_argument);
     EXPECT_NO_THROW(alg.setTimeDelta(0.25f));
     EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
 

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -31,8 +31,8 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts,
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
         const uint64_t measTime = localPkts.measTime[i];
 
-        // Rolling average with timeDelta as window width or the maximum buffer size
-        if (static_cast<float>(maxTimeTag - measTime) * NANO2SEC <= alg.getTimeDelta()) {
+        // Rolling average with averaging window as window width or the maximum buffer size
+        if (static_cast<float>(maxTimeTag - measTime) * NANO2SEC <= alg.getAveragingWindow()) {
             gyroSum_P  += localPkts.gyro_P[i];
             accelSum_P += localPkts.accel_P[i];
             measAvgCount++;
@@ -57,7 +57,7 @@ using Vec3Arr = std::array<float, 3>;
 
 inline Eigen::Vector3f toVec3(Vec3Arr const& a) { return Eigen::Vector3f{a[0], a[1], a[2]}; }
 
-inline void regressionTestaverageMimuData(float timeDelta,
+inline void regressionTestaverageMimuData(float window,
                                           float time_meas_factor_0,
                                           float time_meas_factor_1,
                                           float time_meas_factor_2,
@@ -71,7 +71,7 @@ inline void regressionTestaverageMimuData(float timeDelta,
                                           Vec3Arr const& accel_3) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setTimeDelta(timeDelta);
+    alg.setAveragingWindow(window);
 
     InputPktsData in{};
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
@@ -135,8 +135,8 @@ inline void testKnownSolaverageMimuData() {
 
     // Time window (seconds)
     // Choose 0.26 so ages 0.00, 0.05, 0.15 are included; 0.30 excluded
-    constexpr float timeDelta = 0.26f;
-    alg.setTimeDelta(timeDelta);
+    constexpr float window = 0.26f;
+    alg.setAveragingWindow(window);
 
     // -----------------------
     // Fixed synthetic packets (DIRECT)
@@ -163,12 +163,12 @@ inline void testKnownSolaverageMimuData() {
     const Eigen::Vector3f gyro0{ 1.f, 2.f, 3.f};
     const Eigen::Vector3f gyro1{ 3.f, 2.f, 1.f};
     const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
-    const Eigen::Vector3f gyro3{ 9.f, 9.f, 9.f};  // excluded by timeDelta
+    const Eigen::Vector3f gyro3{ 9.f, 9.f, 9.f};  // excluded by averagingWindow
 
     const Eigen::Vector3f acc0{4.f, 0.f, 0.f};
     const Eigen::Vector3f acc1{0.f, 4.f, 0.f};
     const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
-    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};    // excluded by timeDelta
+    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};    // excluded by averagingWindow
 
     // Put packets in the first few slots
     in.measTime[0] = t0;  in.gyro_P[0] = gyro0;  in.accel_P[0] = acc0;
@@ -196,7 +196,7 @@ inline void testKnownSolaverageMimuData() {
     EXPECT_EQ(out_alg.accel_B, accTrue_B);
 }
 
-inline void testZeroTimeDelta() {
+inline void testZeroAveragingWindow() {
     // -----------------------
     // Fixed algorithm settings
     // -----------------------
@@ -208,8 +208,8 @@ inline void testZeroTimeDelta() {
               0.f,  0.f, 1.f;
     alg.setDcmPltfToBdy(dcm_BP);
 
-    // timeDelta = 0 => should pick the packet(s) at maxTimeTag
-    alg.setTimeDelta(0.0f);
+    // averagingWindow = 0 => should pick the packet(s) at maxTimeTag
+    alg.setAveragingWindow(0.0f);
 
     // -----------------------
     // Fixed synthetic packets (DIRECT)
@@ -251,7 +251,7 @@ inline void testZeroTimeDelta() {
     const OutputAverageAccelAngleVel out_alg = alg.update(in);
 
     // -----------------------
-    // True known solution (timeDelta = 0):
+    // True known solution (averagingWindow = 0):
     // use ONLY the packet with maxTimeTag (packet 0 here)
     // out_B = dcm_BP * v0
     // -----------------------
@@ -266,12 +266,12 @@ inline void testSetupAverageMimuData() {
     AverageMimuDataAlgorithm alg;
 
     // 1) Setters should not throw
-    EXPECT_THROW(alg.setTimeDelta(-0.1), fs::invalid_argument);
-    EXPECT_NO_THROW(alg.setTimeDelta(0.25f));
+    EXPECT_THROW(alg.setAveragingWindow(-0.1), fs::invalid_argument);
+    EXPECT_NO_THROW(alg.setAveragingWindow(0.25f));
     EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
 
     // 2) Round-trip expectations
-    EXPECT_FLOAT_EQ(alg.getTimeDelta(), 0.25f);
+    EXPECT_FLOAT_EQ(alg.getAveragingWindow(), 0.25f);
     EXPECT_TRUE(alg.getDcmPltfToBdy().isApprox(Eigen::Matrix3f::Identity(), 0.0f));
 
     // 3) update() should not throw for a basic input

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -268,6 +268,14 @@ inline void testSetupAverageMimuData() {
     // 1) Setters should not throw
     EXPECT_THROW(alg.setAveragingWindow(-0.1), fs::invalid_argument);
     EXPECT_NO_THROW(alg.setAveragingWindow(0.25f));
+    // Not orthonormal (scaling matrix), det != 1 as well
+    Eigen::Matrix3f badOrtho = Eigen::Matrix3f::Identity();
+    badOrtho(0, 0) = 2.0F;
+    EXPECT_THROW(alg.setDcmPltfToBdy(badOrtho), fs::invalid_argument);
+    // det = -1 (reflection), orthonormal but not a proper rotation
+    Eigen::Matrix3f badDet = Eigen::Matrix3f::Identity();
+    badDet(0, 0) = -1.0F;
+    EXPECT_THROW(alg.setDcmPltfToBdy(badDet), fs::invalid_argument);
     EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
 
     // 2) Round-trip expectations

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -1,0 +1,226 @@
+#ifndef TEST_EPHEMERIDESRECENTER_H
+#define TEST_EPHEMERIDESRECENTER_H
+
+#include "../freestandingInvalidArgument.h"
+#include "architecture/utilities/eigenSupport.h"
+#include "averageMimuDataAlgorithm.h"
+#include <architecture/utilities/macroDefinitions.h>
+#include <gtest/gtest.h>
+
+    // Assuming pkt.gyro_B and pkt.accel_B are float[3]
+    pkt.gyro_B[0] = gyro[0];
+    pkt.gyro_B[1] = gyro[1];
+    pkt.gyro_B[2] = gyro[2];
+    pkt.accel_B[0] = accel[0];
+    pkt.accel_B[1] = accel[1];
+    pkt.accel_B[2] = accel[2];
+}
+
+OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts,
+    const AverageMimuDataAlgorithm& alg)
+{
+    uint64_t maxTimeTag = 0U;
+    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        maxTimeTag = std::max(localPkts.measTime[i], maxTimeTag);
+    }
+
+    Eigen::Vector3f gyroSum_P  = Eigen::Vector3f::Zero();
+    Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
+    uint64_t measAvgCount = 0U;
+
+    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        const uint64_t measTime = localPkts.measTime[i];
+
+        // Rolling average with timeDelta as window width or the maximum buffer size
+        if (static_cast<float>(maxTimeTag - measTime) * NANO2SEC < alg.getTimeDelta()) {
+            gyroSum_P  += localPkts.gyro_P[i];
+            accelSum_P += localPkts.accel_P[i];
+            measAvgCount++;
+        }
+    }
+
+    OutputAverageAccelAngleVel out{};
+    if (measAvgCount > 0U) {
+        const float invCount = 1.0f / static_cast<float>(measAvgCount);
+
+        gyroSum_P *= invCount;
+        accelSum_P *= invCount;
+
+        out.gyroOmega_B = alg.getDcmPltfToBdy() * gyroSum_P;
+        out.accel_B  = alg.getDcmPltfToBdy() * accelSum_P;
+    }
+
+    return out;
+}
+
+using Vec3Arr = std::array<float, 3>;
+
+inline Eigen::Vector3f toVec3(Vec3Arr const& a) { return Eigen::Vector3f{a[0], a[1], a[2]}; }
+
+inline void regressionTestaverageMimuData(float timeDelta,
+                                          float time_meas_factor_0,
+                                          float time_meas_factor_1,
+                                          float time_meas_factor_2,
+                                          Vec3Arr const& gyro_0,
+                                          Vec3Arr const& accel_0,
+                                          Vec3Arr const& gyro_1,
+                                          Vec3Arr const& accel_1,
+                                          Vec3Arr const& gyro_2,
+                                          Vec3Arr const& accel_2,
+                                          Vec3Arr const& gyro_3,
+                                          Vec3Arr const& accel_3) {
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setTimeDelta(timeDelta);
+
+    InputPktsData in{};
+    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.measTime[i] = 0U;
+        in.gyro_P[i]   = Eigen::Vector3f::Zero();
+        in.accel_P[i]  = Eigen::Vector3f::Zero();
+    }
+
+    constexpr uint64_t t_ref = SEC2NANO;
+
+    // Build Eigen vectors from arrays
+    const Eigen::Vector3f g0 = toVec3(gyro_0);
+    const Eigen::Vector3f a0 = toVec3(accel_0);
+    const Eigen::Vector3f g1 = toVec3(gyro_1);
+    const Eigen::Vector3f a1 = toVec3(accel_1);
+    const Eigen::Vector3f g2 = toVec3(gyro_2);
+    const Eigen::Vector3f a2 = toVec3(accel_2);
+    const Eigen::Vector3f g3 = toVec3(gyro_3);
+    const Eigen::Vector3f a3 = toVec3(accel_3);
+
+    // Directly assign the first 4 packets
+    in.measTime[0] = t_ref;
+    in.gyro_P[0]   = g0;
+    in.accel_P[0]  = a0;
+
+    in.measTime[1] = t_ref - static_cast<uint64_t>(SEC2NANO * time_meas_factor_0);
+    in.gyro_P[1]   = g1;
+    in.accel_P[1]  = a1;
+
+    in.measTime[2] = t_ref - static_cast<uint64_t>(SEC2NANO * time_meas_factor_1);
+    in.gyro_P[2]   = g2;
+    in.accel_P[2]  = a2;
+
+    in.measTime[3] = t_ref - static_cast<uint64_t>(SEC2NANO * time_meas_factor_2);
+    in.gyro_P[3]   = g3;
+    in.accel_P[3]  = a3;
+
+    const OutputAverageAccelAngleVel out_alg = alg.update(in);
+    const OutputAverageAccelAngleVel out_ref = referenceUpdate(in, alg);  // <-- update referenceUpdate signature too
+
+    // Use tolerant comparison for floats
+    constexpr float tol = 1e-5f;
+    EXPECT_TRUE(out_alg.gyroOmega_B.isApprox(out_ref.gyroOmega_B, tol));
+    EXPECT_TRUE(out_alg.accel_B.isApprox(out_ref.accel_B, tol));
+}
+
+inline void testKnownSolaverageMimuData() {
+    // -----------------------
+    // Fixed algorithm settings
+    // -----------------------
+    AverageMimuDataAlgorithm alg;
+
+    // 90 deg rotation about +Z:
+    // [ 0 -1  0
+    //   1  0  0
+    //   0  0  1 ]
+    Eigen::Matrix3f dcm_BP;
+    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
+
+    alg.setDcmPltfToBdy(dcm_BP);
+
+    // Time window (seconds)
+    // Choose 0.26 so ages 0.00, 0.05, 0.15 are included; 0.30 excluded
+    constexpr float timeDelta = 0.26f;
+    alg.setTimeDelta(timeDelta);
+
+    // -----------------------
+    // Fixed synthetic packets (DIRECT)
+    // -----------------------
+    InputPktsData in{};  // <-- directly build unpacked input
+
+    // zero everything (Eigen::Vector3f default in std::array is uninitialized)
+    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.measTime[i] = 0U;
+        in.gyro_P[i]   = Eigen::Vector3f::Zero();
+        in.accel_P[i]  = Eigen::Vector3f::Zero();
+    }
+
+    // Reference time = 1.0s (ns)
+    constexpr uint64_t t_ref = SEC2NANO;
+
+    // Ages in seconds: 0.00, 0.05, 0.15, 0.30 (cleanly away from boundary)
+    const uint64_t t0 = t_ref;
+    const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
+    const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
+    const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
+
+    // Choose easy vectors so the mean is simple.
+    const Eigen::Vector3f gyro0{ 1.f, 2.f, 3.f};
+    const Eigen::Vector3f gyro1{ 3.f, 2.f, 1.f};
+    const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
+    const Eigen::Vector3f gyro3{ 9.f, 9.f, 9.f};  // excluded by timeDelta
+
+    const Eigen::Vector3f acc0{4.f, 0.f, 0.f};
+    const Eigen::Vector3f acc1{0.f, 4.f, 0.f};
+    const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
+    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};    // excluded by timeDelta
+
+    // Put packets in the first few slots
+    in.measTime[0] = t0;  in.gyro_P[0] = gyro0;  in.accel_P[0] = acc0;
+    in.measTime[1] = t1;  in.gyro_P[1] = gyro1;  in.accel_P[1] = acc1;
+    in.measTime[2] = t2;  in.gyro_P[2] = gyro2;  in.accel_P[2] = acc2;
+    in.measTime[3] = t3;  in.gyro_P[3] = gyro3;  in.accel_P[3] = acc3;
+
+    // -----------------------
+    // Run algorithm under test
+    // -----------------------
+    const OutputAverageAccelAngleVel out_alg = alg.update(in);
+    // -----------------------
+    // True known solution:
+    // include packets 0,1,2 only (ages 0, 0.05, 0.15 < 0.26)
+    // mean_P = (v0 + v1 + v2) / 3
+    // out_B = dcm_BP * mean_P
+    // -----------------------
+    const Eigen::Vector3f gyroMean_P = (gyro0 + gyro1 + gyro2) / 3.f;
+    const Eigen::Vector3f accMean_P = (acc0 + acc1 + acc2) / 3.f;
+
+    const Eigen::Vector3f gyroTrue_B = dcm_BP * gyroMean_P;
+    const Eigen::Vector3f accTrue_B = dcm_BP * accMean_P;
+
+    EXPECT_EQ(out_alg.gyroOmega_B, gyroTrue_B);
+    EXPECT_EQ(out_alg.accel_B, accTrue_B);
+}
+
+inline void testSetupAverageMimuData() {
+    AverageMimuDataAlgorithm alg;
+
+    // 1) Setters should not throw
+    EXPECT_NO_THROW(alg.setTimeDelta(0.25f));
+    EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
+
+    // 2) Round-trip expectations
+    EXPECT_FLOAT_EQ(alg.getTimeDelta(), 0.25f);
+    EXPECT_TRUE(alg.getDcmPltfToBdy().isApprox(Eigen::Matrix3f::Identity(), 0.0f));
+
+    // 3) update() should not throw for a basic input
+    InputPktsData in{};
+    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.measTime[i] = 0U;
+        in.gyro_P[i]   = Eigen::Vector3f::Zero();
+        in.accel_P[i]  = Eigen::Vector3f::Zero();
+    }
+
+    // Add one non-zero packet so we exercise the averaging path
+    in.measTime[0] = SEC2NANO;
+    in.gyro_P[0]   = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
+    in.accel_P[0]  = Eigen::Vector3f(4.0f, 5.0f, 6.0f);
+
+    EXPECT_NO_THROW((void)alg.update(in));
+}
+
+#endif

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -18,6 +18,6 @@ TEST(averageMimuDataTest, RegressionTest) {
 
 TEST(averageMimuDataTest, PropertyKnownSolution) { testKnownSolaverageMimuData(); }
 
-TEST(averageMimuDataTest, PropertyZeroTimeDelta){ testZeroTimeDelta(); }
+TEST(averageMimuDataTest, PropertyZeroAveragingWindow){ testZeroAveragingWindow(); }
 
 TEST(averageMimuDataTest, SetupTest) { testSetupAverageMimuData(); }

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -18,4 +18,6 @@ TEST(averageMimuDataTest, RegressionTest) {
 
 TEST(averageMimuDataTest, PropertyKnownSolution) { testKnownSolaverageMimuData(); }
 
+TEST(averageMimuDataTest, PropertyZeroTimeDelta){ testZeroTimeDelta(); }
+
 TEST(averageMimuDataTest, SetupTest) { testSetupAverageMimuData(); }

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -1,23 +1,235 @@
 #include "averageMimuDataTestHelpers.hpp"
 #include <gtest/gtest.h>
 
-TEST(averageMimuDataTest, RegressionTest) {
-    regressionTestaverageMimuData(0.5f,
-                                  0.6f,
-                                  0.2f,
-                                  0.3f,
-                                  Vec3Arr{0.1f, 0.3f, -0.1f},
-                                  Vec3Arr{0.5f, -0.2f, 2.0f},
-                                  Vec3Arr{1.1f, 0.8f, 0.7f},
-                                  Vec3Arr{11.5f, -0.2f, 6.0f},
-                                  Vec3Arr{-0.3f, -4.3f, -6.1f},
-                                  Vec3Arr{-0.9f, -0.2f, -2.4f},
-                                  Vec3Arr{7.1f, -0.9f, -0.0f},
-                                  Vec3Arr{-80.5f, 0.4f, 2.8f});
+inline void testKnownSolAverageMimuData() {
+    // -----------------------
+    // Fixed algorithm settings
+    // -----------------------
+    AverageMimuDataAlgorithm alg;
+
+    // 90 deg rotation about +Z:
+    // [ 0 -1  0
+    //   1  0  0
+    //   0  0  1 ]
+    Eigen::Matrix3f dcm_BP;
+    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
+
+    alg.setDcmPltfToBdy(dcm_BP);
+
+    // Time window (seconds)
+    // Choose 0.26 so ages 0.00, 0.05, 0.15 are included; 0.30 excluded
+    constexpr float window = 0.26f;
+    alg.setAveragingWindow(window);
+
+    // -----------------------
+    // Fixed synthetic packets (DIRECT)
+    // -----------------------
+    InputPktsData in{};  // <-- directly build unpacked input
+
+    // zero everything (Eigen::Vector3f default in std::array is uninitialized)
+    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.measTime[i] = 0U;
+        in.gyro_P[i] = Eigen::Vector3f::Zero();
+        in.accel_P[i] = Eigen::Vector3f::Zero();
+    }
+
+    // Reference time = 1.0s (ns)
+    constexpr uint64_t t_ref = SEC2NANO;
+
+    // Ages in seconds: 0.00, 0.05, 0.15, 0.30 (cleanly away from boundary)
+    const uint64_t t0 = t_ref;
+    const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
+    const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
+    const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
+
+    // Choose easy vectors so the mean is simple.
+    const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
+    const Eigen::Vector3f gyro1{3.f, 2.f, 1.f};
+    const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
+    const Eigen::Vector3f gyro3{9.f, 9.f, 9.f};  // excluded by averagingWindow
+
+    const Eigen::Vector3f acc0{4.f, 0.f, 0.f};
+    const Eigen::Vector3f acc1{0.f, 4.f, 0.f};
+    const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
+    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};  // excluded by averagingWindow
+
+    // Put packets in the first few slots
+    in.measTime[0] = t0;
+    in.gyro_P[0] = gyro0;
+    in.accel_P[0] = acc0;
+    in.measTime[1] = t1;
+    in.gyro_P[1] = gyro1;
+    in.accel_P[1] = acc1;
+    in.measTime[2] = t2;
+    in.gyro_P[2] = gyro2;
+    in.accel_P[2] = acc2;
+    in.measTime[3] = t3;
+    in.gyro_P[3] = gyro3;
+    in.accel_P[3] = acc3;
+
+    // -----------------------
+    // Run algorithm under test
+    // -----------------------
+    const OutputAverageAccelAngleVel out_alg = alg.update(in);
+
+    // -----------------------
+    // True known solution:
+    // include packets 0,1,2 only (ages 0, 0.05, 0.15 < 0.26)
+    // mean_P = (v0 + v1 + v2) / 3
+    // out_B = dcm_BP * mean_P
+    // -----------------------
+    const Eigen::Vector3f gyroMean_P = (gyro0 + gyro1 + gyro2) / 3.f;
+    const Eigen::Vector3f accMean_P = (acc0 + acc1 + acc2) / 3.f;
+
+    const Eigen::Vector3f gyroTrue_B = dcm_BP * gyroMean_P;
+    const Eigen::Vector3f accTrue_B = dcm_BP * accMean_P;
+
+    EXPECT_EQ(out_alg.gyroOmega_B, gyroTrue_B);
+    EXPECT_EQ(out_alg.accel_B, accTrue_B);
 }
 
-TEST(averageMimuDataTest, PropertyKnownSolution) { testKnownSolaverageMimuData(); }
+inline void testZeroAveragingWindow() {
+    // -----------------------
+    // Fixed algorithm settings
+    // -----------------------
+    AverageMimuDataAlgorithm alg;
 
-TEST(averageMimuDataTest, PropertyZeroAveragingWindow){ testZeroAveragingWindow(); }
+    Eigen::Matrix3f dcm_BP;
+    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
+    alg.setDcmPltfToBdy(dcm_BP);
+
+    // averagingWindow = 0 => should pick the packet(s) at maxTimeTag
+    alg.setAveragingWindow(0.0f);
+
+    // -----------------------
+    // Fixed synthetic packets (DIRECT)
+    // -----------------------
+    InputPktsData in{};
+
+    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.measTime[i] = 0U;
+        in.gyro_P[i] = Eigen::Vector3f::Zero();
+        in.accel_P[i] = Eigen::Vector3f::Zero();
+    }
+
+    constexpr uint64_t t_ref = SEC2NANO;
+
+    // Make packet 0 the unique maxTimeTag
+    const uint64_t t0 = t_ref;  // max
+    const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
+    const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
+    const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
+
+    const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
+    const Eigen::Vector3f gyro1{3.f, 2.f, 1.f};
+    const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
+    const Eigen::Vector3f gyro3{9.f, 9.f, 9.f};
+
+    const Eigen::Vector3f acc0{4.f, 0.f, 0.f};
+    const Eigen::Vector3f acc1{0.f, 4.f, 0.f};
+    const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
+    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};
+
+    in.measTime[0] = t0;
+    in.gyro_P[0] = gyro0;
+    in.accel_P[0] = acc0;
+    in.measTime[1] = t1;
+    in.gyro_P[1] = gyro1;
+    in.accel_P[1] = acc1;
+    in.measTime[2] = t2;
+    in.gyro_P[2] = gyro2;
+    in.accel_P[2] = acc2;
+    in.measTime[3] = t3;
+    in.gyro_P[3] = gyro3;
+    in.accel_P[3] = acc3;
+
+    // -----------------------
+    // Run algorithm under test
+    // -----------------------
+    const OutputAverageAccelAngleVel out_alg = alg.update(in);
+
+    // -----------------------
+    // True known solution (averagingWindow = 0):
+    // use ONLY the packet with maxTimeTag (packet 0 here)
+    // out_B = dcm_BP * v0
+    // -----------------------
+    const Eigen::Vector3f gyroTrue_B = dcm_BP * gyro0;
+    const Eigen::Vector3f accTrue_B = dcm_BP * acc0;
+
+    EXPECT_EQ(out_alg.gyroOmega_B, gyroTrue_B);
+    EXPECT_EQ(out_alg.accel_B, accTrue_B);
+}
+
+inline void testSetupAverageMimuData() {
+    AverageMimuDataAlgorithm alg;
+
+    // 1) Setters should not throw
+    EXPECT_THROW(alg.setAveragingWindow(-0.1), fs::invalid_argument);
+    EXPECT_NO_THROW(alg.setAveragingWindow(0.25f));
+    // Not orthonormal (scaling matrix), det != 1 as well
+    Eigen::Matrix3f badOrtho = Eigen::Matrix3f::Identity();
+    badOrtho(0, 0) = 2.0F;
+    EXPECT_THROW(alg.setDcmPltfToBdy(badOrtho), fs::invalid_argument);
+    // det = -1 (reflection), orthonormal but not a proper rotation
+    Eigen::Matrix3f badDet = Eigen::Matrix3f::Identity();
+    badDet(0, 0) = -1.0F;
+    EXPECT_THROW(alg.setDcmPltfToBdy(badDet), fs::invalid_argument);
+    EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
+
+    // 2) Round-trip expectations
+    EXPECT_EQ(alg.getAveragingWindow(), 0.25f);
+    EXPECT_EQ(alg.getDcmPltfToBdy(), Eigen::Matrix3f::Identity());
+
+    // 3) update() should not throw for a basic input
+    InputPktsData in{};
+    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.measTime[i] = 0U;
+        in.gyro_P[i] = Eigen::Vector3f::Zero();
+        in.accel_P[i] = Eigen::Vector3f::Zero();
+    }
+
+    // Add one non-zero packet so we exercise the averaging path
+    in.measTime[0] = SEC2NANO;
+    in.gyro_P[0] = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
+    in.accel_P[0] = Eigen::Vector3f(4.0f, 5.0f, 6.0f);
+
+    EXPECT_NO_THROW((void)alg.update(in));
+}
+
+TEST(averageMimuDataTest, RegressionTest) {
+    constexpr std::size_t N = 4U;
+    constexpr float windowSec = 0.5F;
+
+    std::array<InputData, MAX_ACC_BUF_PKT> input{};
+
+    // Optional: set a reference time (like before)
+    constexpr uint64_t t_ref = SEC2NANO;
+
+    // Packet 0 (newest)
+    input[0].measTime = t_ref;
+    input[0].gyro_P = Vec3Arr{0.1F, 0.3F, -0.1F};
+    input[0].accel_P = Vec3Arr{0.5F, -0.2F, 2.0F};
+
+    // Packet 1 (older by 0.6s)
+    input[1].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.6F);
+    input[1].gyro_P = Vec3Arr{1.1F, 0.8F, 0.7F};
+    input[1].accel_P = Vec3Arr{11.5F, -0.2F, 6.0F};
+
+    // Packet 2 (older by 0.2s)
+    input[2].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.2F);
+    input[2].gyro_P = Vec3Arr{-0.3F, -4.3F, -6.1F};
+    input[2].accel_P = Vec3Arr{-0.9F, -0.2F, -2.4F};
+
+    // Packet 3 (older by 0.3s)
+    input[3].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.3F);
+    input[3].gyro_P = Vec3Arr{7.1F, -0.9F, -0.0F};
+    input[3].accel_P = Vec3Arr{-80.5F, 0.4F, 2.8F};
+
+    regressionTestAverageMimuData(N, windowSec, input);
+}
+
+TEST(averageMimuDataTest, PropertyKnownSolution) { testKnownSolAverageMimuData(); }
+
+TEST(averageMimuDataTest, PropertyZeroAveragingWindow) { testZeroAveragingWindow(); }
 
 TEST(averageMimuDataTest, SetupTest) { testSetupAverageMimuData(); }

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -1,0 +1,21 @@
+#include "averageMimuDataTestHelpers.hpp"
+#include <gtest/gtest.h>
+
+TEST(averageMimuDataTest, RegressionTest) {
+    regressionTestaverageMimuData(0.5f,
+                                  0.6f,
+                                  0.2f,
+                                  0.3f,
+                                  Vec3Arr{0.1f, 0.3f, -0.1f},
+                                  Vec3Arr{0.5f, -0.2f, 2.0f},
+                                  Vec3Arr{1.1f, 0.8f, 0.7f},
+                                  Vec3Arr{11.5f, -0.2f, 6.0f},
+                                  Vec3Arr{-0.3f, -4.3f, -6.1f},
+                                  Vec3Arr{-0.9f, -0.2f, -2.4f},
+                                  Vec3Arr{7.1f, -0.9f, -0.0f},
+                                  Vec3Arr{-80.5f, 0.4f, 2.8f});
+}
+
+TEST(averageMimuDataTest, PropertyKnownSolution) { testKnownSolaverageMimuData(); }
+
+TEST(averageMimuDataTest, SetupTest) { testSetupAverageMimuData(); }

--- a/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
+++ b/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
@@ -17,7 +17,10 @@ def test_average_mimu_data():
 
     # Create test thread
     fsw_frequency = 10  # Set fsw frequency to 10 Hz
-    mimu_frequency = 100  # Set mimu sensor frequency to 10 Hz
+    mimu_frequency = 100  # Set mimu sensor frequency to 100 Hz
+    num_fsw_steps = 12
+    samples_per_fsw = int(mimu_frequency / fsw_frequency)
+    max_acc_buf_pkt = 120  # matches MAX_ACC_BUF_PKT in C++
     delta_time_sim = 1 / fsw_frequency  # The averageMimuData module will run at the fsw frequency
     test_process_rate = macros.sec2nano(delta_time_sim)  # update process rate update time
     test_proc = unit_test_sim.CreateNewProcess(unit_process_name)
@@ -28,9 +31,9 @@ def test_average_mimu_data():
     module.modelTag = "averageMimuData"
 
     # Define parameters
-    dcm_pltf_to_body = RigidBodyKinematics.euler3212C([0.01, -0.04, 0.06])
+    dcm_pltf_to_body = RigidBodyKinematics.euler3212C([0.01, -0.04, 0.06]).astype(np.float32)
     module.setDcmPltfToBdy(dcm_pltf_to_body)
-    duration_window = 1.0e10
+    duration_window = 1.0e10 # make the time window so huge that average is taken over all packets
     module.setAveragingWindow(duration_window)
 
     # Initialize message for message connection
@@ -55,24 +58,24 @@ def test_average_mimu_data():
     meas_time = 0
     sim_time = 0
     counter = 0
-    gyro_sum = np.zeros(3)
-    accel_sum = np.zeros(3)
-    average_imu_output = np.zeros([12, 3])
-    average_acc_output = np.zeros([12, 3])
-    for index in range(12):
-        for _ in range(int(mimu_frequency / fsw_frequency)):
+    gyro_sum = np.zeros(3, dtype=np.float32)
+    accel_sum = np.zeros(3,dtype=np.float32)
+    average_imu_output = np.zeros([num_fsw_steps, 3], dtype=np.float32)
+    average_acc_output = np.zeros([num_fsw_steps, 3], dtype=np.float32)
+    for index in range(num_fsw_steps):
+        for _ in range(samples_per_fsw):
             meas_time += delta_time
             acc_data.accPkts[counter].measTime = macros.sec2nano(meas_time)
-            random_array = np.random.normal(loc=2, scale=1, size=3)
+            random_array = np.random.normal(loc=2, scale=1, size=3).astype(np.float32)
             gyro_sum += random_array
             acc_data.accPkts[counter].gyro_B = random_array.tolist()
-            random_array = np.random.normal(loc=2, scale=1, size=3)
+            random_array = np.random.normal(loc=2, scale=1, size=3).astype(np.float32)
             accel_sum += random_array
             acc_data.accPkts[counter].accel_B = random_array.tolist()
             counter += 1
-        gyro_average = gyro_sum / 120
+        gyro_average = gyro_sum / max_acc_buf_pkt
         gyro_average = np.dot(dcm_pltf_to_body, gyro_average)
-        accel_average = accel_sum / 120
+        accel_average = accel_sum / max_acc_buf_pkt
         accel_average = np.dot(dcm_pltf_to_body, accel_average)
         average_imu_output[index, :] = gyro_average
         average_acc_output[index, :] = accel_average

--- a/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
+++ b/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
@@ -30,8 +30,8 @@ def test_average_mimu_data():
     # Define parameters
     dcm_pltf_to_body = RigidBodyKinematics.euler3212C([0.01, -0.04, 0.06])
     module.setDcmPltfToBdy(dcm_pltf_to_body)
-    time_delta = 1.0e10
-    module.setTimeDelta(time_delta)
+    duration_window = 1.0e10
+    module.setAveragingWindow(duration_window)
 
     # Initialize message for message connection
     acc_data = messaging.AccDataMsgF32Payload()
@@ -83,7 +83,7 @@ def test_average_mimu_data():
         unit_test_sim.ExecuteSimulation()
 
     # Test the getters
-    np.testing.assert_allclose(time_delta, module.getTimeDelta(), rtol=1e-8, atol=1e-6, verbose=True)
+    np.testing.assert_allclose(duration_window, module.getAveragingWindow(), rtol=1e-8, atol=1e-6, verbose=True)
     np.testing.assert_allclose(dcm_pltf_to_body, module.getDcmPltfToBdy(), rtol=1e-8, atol=1e-6, verbose=True)
 
     # Pull logged data

--- a/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
@@ -1,0 +1,19 @@
+#include "averageMimuDataTestHelpers.hpp"
+#include <fuzztest/fuzztest.h>
+#include <array>
+#include <vector>
+
+FUZZ_TEST(averageMimuDataFuzz, regressionTestaverageMimuData)
+    .WithDomains(fuzztest::InRange(0.0f, 1.0f),                         // timeDelta
+                 fuzztest::InRange(0.0f, 1.0f),                         // factor0
+                 fuzztest::InRange(0.0f, 1.0f),                         // factor1
+                 fuzztest::InRange(0.0f, 1.0f),                         // factor2
+                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // gyro0
+                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // accel0
+                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // gyro1
+                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // accel1
+                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // gyro2
+                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // accel2
+                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // gyro3
+                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f))   // accel3
+    );

--- a/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
@@ -1,19 +1,10 @@
 #include "averageMimuDataTestHelpers.hpp"
 #include <fuzztest/fuzztest.h>
-#include <array>
-#include <vector>
 
-FUZZ_TEST(averageMimuDataFuzz, regressionTestaverageMimuData)
-    .WithDomains(fuzztest::InRange(0.0f, 1.0f),                         // timeDelta
-                 fuzztest::InRange(0.0f, 1.0f),                         // factor0
-                 fuzztest::InRange(0.0f, 1.0f),                         // factor1
-                 fuzztest::InRange(0.0f, 1.0f),                         // factor2
-                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // gyro0
-                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // accel0
-                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // gyro1
-                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // accel1
-                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // gyro2
-                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // accel2
-                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f)),  // gyro3
-                 fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6f, 1e6f))   // accel3
-    );
+FUZZ_TEST(averageMimuDataFuzz, regressionTestAverageMimuData)
+    .WithDomains(fuzztest::InRange<std::size_t>(0U, MAX_ACC_BUF_PKT),
+                 fuzztest::InRange(0.0F, 1.0F),
+                 fuzztest::ArrayOf<MAX_ACC_BUF_PKT>(
+                     fuzztest::StructOf<InputData>(fuzztest::InRange<uint64_t>(0U, 10U * SEC2NANO),
+                                                   fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6F, 1e6F)),
+                                                   fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6F, 1e6F)))));

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -33,9 +33,9 @@ void AverageMimuData::updateState(uint64_t const callTime) {
     this->imuOutMsg.write(&localOutput, this->moduleID, callTime);
 }
 
-void AverageMimuData::setTimeDelta(float const timeDelta) { this->algorithm.setTimeDelta(timeDelta); }
+void AverageMimuData::setAveragingWindow(float const window) { this->algorithm.setAveragingWindow(window); }
 
-float AverageMimuData::getTimeDelta() const { return this->algorithm.getTimeDelta(); }
+float AverageMimuData::getAveragingWindow() const { return this->algorithm.getAveragingWindow(); }
 
 void AverageMimuData::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BP) { this->algorithm.setDcmPltfToBdy(dcm_BP); }
 

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -1,4 +1,5 @@
 #include "averageMimuData.h"
+#include "architecture/utilities/eigenSupport.h"
 
 void AverageMimuData::reset(uint64_t const callTime) {
     // check if the required message has not been connected
@@ -17,7 +18,17 @@ void AverageMimuData::updateState(uint64_t const callTime) {
     this->prevInMsgTime = writeTime;
 
     const AccDataMsgF32Payload localPkts = this->accDataInMsg();
-    IMUSensorBodyMsgF32Payload localOutput = this->algorithm.update(localPkts);
+    InputPktsData in{};
+    for (std::size_t i = 0; i < MAX_BUF_PKT; ++i) {
+        const auto& [measTime, gyro_B, accel_B] = localPkts.accPkts[i];
+        in.measTime[i] = measTime;
+        in.gyro_P[i] = Eigen::Vector3f(gyro_B[0], gyro_B[1], gyro_B[2]);
+        in.accel_P[i] = Eigen::Vector3f(accel_B[0], accel_B[1], accel_B[2]);
+    }
+    const auto [accel_B, gyroOmega_B] = this->algorithm.update(in);
+    IMUSensorBodyMsgF32Payload localOutput{};
+    eigenVectorToCArray(gyroOmega_B, localOutput.AngVelBody);
+    eigenVectorToCArray(accel_B, localOutput.AccelBody);
 
     this->imuOutMsg.write(&localOutput, this->moduleID, callTime);
 }

--- a/algorithms/averageMimuData/averageMimuData.h
+++ b/algorithms/averageMimuData/averageMimuData.h
@@ -1,8 +1,9 @@
 #ifndef AVERAGE_MIMU_DATA_H
 #define AVERAGE_MIMU_DATA_H
-// NOLINTBEGIN
+
 #include "architecture/messaging/messaging.h"
 #include "averageMimuDataAlgorithm.h"
+#include "msgPayloadDef/IMUSensorBodyMsgF32Payload.h"
 
 #include <cstdint>
 
@@ -24,5 +25,4 @@ class AverageMimuData : public SysModel {
 
     AverageMimuDataAlgorithm algorithm{};
 };
-// NOLINTEND
 #endif

--- a/algorithms/averageMimuData/averageMimuData.h
+++ b/algorithms/averageMimuData/averageMimuData.h
@@ -11,8 +11,8 @@ class AverageMimuData : public SysModel {
    public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
-    void setTimeDelta(float timeDelta);                   //!< Setter method for timeDelta
-    float getTimeDelta() const;                           //!< Getter method for timeDelta
+    void setAveragingWindow(float window);                //!< [s] Setter method for averagingWindow
+    float getAveragingWindow() const;                     //!< [s] Getter method for averagingWindow
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BP);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;              //!< Getter method for dcm from platform to body
 

--- a/algorithms/averageMimuData/averageMimuData.rst
+++ b/algorithms/averageMimuData/averageMimuData.rst
@@ -1,0 +1,190 @@
+```rst
+.. raw:: latex
+
+    {\LARGE \textbf{averageMimuData}}
+
+Executive Summary
+-----------------
+The ``averageMimuData`` algorithm computes a rolling average of recent gyro and accelerometer samples from a MIMU
+packet buffer. It uses the newest packet timestamp as the reference time, selects all packets whose age is within a
+user-specified window (``timeDelta``), averages the selected measurements, and outputs the averaged values expressed in
+the body frame using a user-provided direction cosine matrix (DCM) ``dcm_BP``.
+
+Message Connection Descriptions
+-------------------------------
+The following table lists the algorithm input and output data structures. The input is a packet buffer containing
+time-tagged measurements, and the output is the averaged body-frame angular velocity and acceleration.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Variable Name
+      - Type
+      - Description
+    * - localPkts
+      - :ref:`AccDataMsgF32Payload`
+      - Input packet buffer containing samples ``(measTime, gyro_B, accel_B)``
+    * - out
+      - ``OutData``
+      - Output averages in body frame: ``AngVelBody`` and ``AccelBody`` (both ``Eigen::Vector3f``)
+
+Module Parameters
+-----------------
+The following table lists all parameters that can be set. Parameters are optional unless indicated
+(if not specified, the default is used).
+
+.. list-table:: Module Parameters
+    :widths: 22 18 12 16 22 30
+    :header-rows: 1
+
+    * - Parameter Name
+      - Type
+      - Units
+      - Default
+      - Setter / Getter
+      - Description
+    * - timeDelta
+      - float
+      - [s]
+      - 0.0
+      - ``setTimeDelta()`` / ``getTimeDelta()``
+      - Rolling-window width measured backward from the newest packet timestamp. Packets with age ``< timeDelta`` are included
+    * - dcm_BP
+      - Eigen::Matrix3f
+      - [-]
+      - Identity
+      - ``setDcmPltfToBdy()`` / ``getDcmPltfToBdy()``
+      - DCM mapping to body-frame vectors
+
+Module Assumptions and Limitations
+----------------------------------
+- The packet timestamps ``measTime`` are assumed to be in nanoseconds and converted using ``NANO2SEC``.
+- Packets are included if ``(maxTimeTag - measTime) * NANO2SEC < timeDelta`` (strict inequality).
+- If ``timeDelta`` is 0, no packets satisfy the strict inequality and the output is zero.
+- If no packets fall within the time window, the output vectors are zero.
+- The algorithm performs an unweighted arithmetic mean (no weighting, outlier rejection, or bias correction).
+
+Initialization
+--------------
+Configure the time window and the platform-to-body DCM::
+
+    AverageMimuDataAlgorithm alg;
+    alg.setTimeDelta(0.05f);          // seconds
+    alg.setDcmPltfToBdy(dcm_BP);      // Eigen::Matrix3f (platform-to-body)
+
+Then call the update method each cycle::
+
+    OutData out = alg.update(localPkts);
+
+Detailed Module Description
+---------------------------
+General Function
+^^^^^^^^^^^^^^^^
+Given an input packet buffer ``localPkts.accPkts``, the algorithm:
+
+1. Finds the newest packet time tag ``maxTimeTag`` across the buffer.
+2. Iterates over each packet and computes its age relative to ``maxTimeTag``.
+3. Includes packets whose age is strictly less than ``timeDelta`` seconds.
+4. Sums the selected gyro and accelerometer vectors (as 3-vectors).
+5. Divides by the number of selected packets to form the average in the platform frame.
+6. Transforms the averaged vectors to the body frame using ``dcm_BP`` and returns them.
+
+Algorithm
+^^^^^^^^^
+Let :math:`t_{\max}` be the newest packet time in the buffer. A packet with timestamp :math:`t_i` is *kept* if its age
+(relative to :math:`t_{\max}`) is within the time window:
+
+.. math::
+    (t_{\max} - t_i)\,\texttt{NANO2SEC} < \texttt{timeDelta}.
+
+Let :math:`\mathcal{I}` be the set of indices of all kept packets, and let :math:`M = |\mathcal{I}|` be the number of
+kept packets.
+
+If :math:`M = 0`, return zeros:
+
+.. math::
+    ^B\omega_{\text{avg}} = \mathbf{0}, \qquad ^Ba_{\text{avg}} = \mathbf{0}.
+
+Otherwise, average in the platform frame:
+
+.. math::
+    ^P\omega_{\text{avg}} = \frac{1}{M}\sum_{i\in\mathcal{I}}\, ^P\omega_i,
+    \qquad
+    ^Pa_{\text{avg}} = \frac{1}{M}\sum_{i\in\mathcal{I}}\, ^P a_i.
+
+Finally, rotate the averages into the body frame:
+
+.. math::
+    ^B\omega_{\text{avg}} = \texttt{dcm\_BP}\,^P\omega_{\text{avg}},
+    \qquad
+    ^Ba_{\text{avg}} = \texttt{dcm\_BP}\,^Pa_{\text{avg}}.
+
+
+User Guide
+----------
+Inputs
+^^^^^^
+The input payload contains an array of packets. Each packet provides:
+
+- ``measTime``: measurement timestamp (assumed nanoseconds)
+- ``gyro_B``: 3-axis angular rate sample (stored as a 3-element array)
+- ``accel_B``: 3-axis acceleration sample (stored as a 3-element array)
+
+Although the packet fields are named with ``_B`` in the payload, this algorithm treats the raw packet vectors as being
+in the platform frame for averaging (consistent with the internal variable naming ``gyroSum_P`` and ``accelSum_P``),
+and then applies ``dcm_BP`` to express the averages in the body frame.
+
+Configuration
+^^^^^^^^^^^^^
+1. Set ``timeDelta`` to define how far back (from the newest measurement) to include samples in the average.
+2. Set ``dcm_BP`` to map platform-frame vectors into the body frame.
+
+Recommended Practices
+^^^^^^^^^^^^^^^^^^^^^
+- Choose ``timeDelta`` based on the expected packet update rate and desired smoothing. Larger values increase smoothing
+  but introduce more latency.
+- Ensure ``dcm_BP`` is a proper DCM (orthonormal, right-handed) consistent with your frame definitions.
+
+Outputs
+^^^^^^^
+The algorithm returns::
+
+    struct OutData {
+        Eigen::Vector3f AccelBody;   // body-frame averaged acceleration
+        Eigen::Vector3f AngVelBody;  // body-frame averaged angular velocity
+    };
+
+If no packets fall within the window, both output vectors are returned as zeros.
+
+API Reference
+-------------
+Class Interface
+^^^^^^^^^^^^^^^
+The algorithm is implemented by::
+
+    class AverageMimuDataAlgorithm {
+       public:
+        void setTimeDelta(float timeDeltaIn);
+        float getTimeDelta() const;
+
+        void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);
+        Eigen::Matrix3f getDcmPltfToBdy() const;
+
+        OutData update(AccDataMsgF32Payload const& localPkts) const;
+    };
+
+Return Type
+^^^^^^^^^^^
+The return type is::
+
+    struct OutData {
+        Eigen::Vector3f AccelBody = Eigen::Vector3f::Zero();
+        Eigen::Vector3f AngVelBody = Eigen::Vector3f::Zero();
+    };
+
+Notes
+-----
+- The averaging window is anchored to the newest timestamp present in the buffer, not to the current system time.
+- The output is deterministic given the input packet buffer, ``timeDelta``, and ``dcm_BP``.
+```

--- a/algorithms/averageMimuData/averageMimuData.rst
+++ b/algorithms/averageMimuData/averageMimuData.rst
@@ -7,7 +7,7 @@ Executive Summary
 -----------------
 The ``averageMimuData`` algorithm computes a rolling average of recent gyro and accelerometer samples from a MIMU
 packet buffer. It uses the newest packet timestamp as the reference time, selects all packets whose age is within a
-user-specified window (``timeDelta``), averages the selected measurements, and outputs the averaged values expressed in
+user-specified window (``averagingWindow``), averages the selected measurements, and outputs the averaged values expressed in
 the body frame using a user-provided direction cosine matrix (DCM) ``dcm_BP``.
 
 Message Connection Descriptions
@@ -44,12 +44,12 @@ The following table lists all parameters that can be set. Parameters are optiona
       - Default
       - Setter / Getter
       - Description
-    * - timeDelta
+    * - averagingWindow
       - float
       - [s]
       - 0.0
-      - ``setTimeDelta()`` / ``getTimeDelta()``
-      - Rolling-window width measured backward from the newest packet timestamp. Packets with age ``< timeDelta`` are included
+      - ``setAveragingWindow()`` / ``getAveragingWindow()``
+      - Rolling-window width measured backward from the newest packet timestamp. Packets with age ``< averagingWindow`` are included
     * - dcm_BP
       - Eigen::Matrix3f
       - [-]
@@ -60,8 +60,8 @@ The following table lists all parameters that can be set. Parameters are optiona
 Module Assumptions and Limitations
 ----------------------------------
 - The packet timestamps ``measTime`` are assumed to be in nanoseconds and converted using ``NANO2SEC``.
-- Packets are included if ``(maxTimeTag - measTime) * NANO2SEC < timeDelta`` (strict inequality).
-- If ``timeDelta`` is 0, no packets satisfy the strict inequality and the output is zero.
+- Packets are included if ``(maxTimeTag - measTime) * NANO2SEC < averagingWindow`` (strict inequality).
+- If ``averagingWindow`` is 0, no packets satisfy the strict inequality and the output is zero.
 - If no packets fall within the time window, the output vectors are zero.
 - The algorithm performs an unweighted arithmetic mean (no weighting, outlier rejection, or bias correction).
 
@@ -70,7 +70,7 @@ Initialization
 Configure the time window and the platform-to-body DCM::
 
     AverageMimuDataAlgorithm alg;
-    alg.setTimeDelta(0.05f);          // seconds
+    alg.setAveragingWindow(0.05f);          // seconds
     alg.setDcmPltfToBdy(dcm_BP);      // Eigen::Matrix3f (platform-to-body)
 
 Then call the update method each cycle::
@@ -85,7 +85,7 @@ Given an input packet buffer ``localPkts.accPkts``, the algorithm:
 
 1. Finds the newest packet time tag ``maxTimeTag`` across the buffer.
 2. Iterates over each packet and computes its age relative to ``maxTimeTag``.
-3. Includes packets whose age is strictly less than ``timeDelta`` seconds.
+3. Includes packets whose age is strictly less than ``averagingWindow`` seconds.
 4. Sums the selected gyro and accelerometer vectors (as 3-vectors).
 5. Divides by the number of selected packets to form the average in the platform frame.
 6. Transforms the averaged vectors to the body frame using ``dcm_BP`` and returns them.
@@ -96,7 +96,7 @@ Let :math:`t_{\max}` be the newest packet time in the buffer. A packet with time
 (relative to :math:`t_{\max}`) is within the time window:
 
 .. math::
-    (t_{\max} - t_i)\,\texttt{NANO2SEC} < \texttt{timeDelta}.
+    (t_{\max} - t_i)\,\texttt{NANO2SEC} < \texttt{averagingWindow}.
 
 Let :math:`\mathcal{I}` be the set of indices of all kept packets, and let :math:`M = |\mathcal{I}|` be the number of
 kept packets.
@@ -137,12 +137,12 @@ and then applies ``dcm_BP`` to express the averages in the body frame.
 
 Configuration
 ^^^^^^^^^^^^^
-1. Set ``timeDelta`` to define how far back (from the newest measurement) to include samples in the average.
+1. Set ``averagingWindow`` to define how far back (from the newest measurement) to include samples in the average.
 2. Set ``dcm_BP`` to map platform-frame vectors into the body frame.
 
 Recommended Practices
 ^^^^^^^^^^^^^^^^^^^^^
-- Choose ``timeDelta`` based on the expected packet update rate and desired smoothing. Larger values increase smoothing
+- Choose ``averagingWindow`` based on the expected packet update rate and desired smoothing. Larger values increase smoothing
   but introduce more latency.
 - Ensure ``dcm_BP`` is a proper DCM (orthonormal, right-handed) consistent with your frame definitions.
 
@@ -165,8 +165,8 @@ The algorithm is implemented by::
 
     class AverageMimuDataAlgorithm {
        public:
-        void setTimeDelta(float timeDeltaIn);
-        float getTimeDelta() const;
+        void setAveragingWindow(float window);
+        float getAveragingWindow() const;
 
         void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);
         Eigen::Matrix3f getDcmPltfToBdy() const;
@@ -186,5 +186,5 @@ The return type is::
 Notes
 -----
 - The averaging window is anchored to the newest timestamp present in the buffer, not to the current system time.
-- The output is deterministic given the input packet buffer, ``timeDelta``, and ``dcm_BP``.
+- The output is deterministic given the input packet buffer, ``averagingWindow``, and ``dcm_BP``.
 ```

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -12,7 +12,8 @@
  *  age is within `averagingWindow` seconds.
  *  @param localPkts AccDataMsgF32Payload : an array of AccPktDataMsgF32Payload, each AccPktDataMsgF32Payload contains
  * (measTime, gyro_P, accel_P).
- *  @return OutputAverageAccelAngleVel : body-frame average (AngVelBody, AccelBody). If no packets are in the window, returns zeros.
+ *  @return OutputAverageAccelAngleVel : body-frame average (AngVelBody, AccelBody). If no packets are in the window,
+ * returns zeros.
  */
 OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const& localPkts) const {
     uint64_t maxTimeTag = 0U;
@@ -47,7 +48,7 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
 }
 
 void AverageMimuDataAlgorithm::setAveragingWindow(float const window) {
-    if(window < 0.0F){
+    if (window < 0.0F) {
         FS_THROW_INVALID_ARGUMENT("AveragingWindow cannot be smaller than 0.0");
     }
     this->averagingWindow = window;

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -8,7 +8,7 @@
 
 /*! @brief Average recent gyro/accel samples and output them in the body frame.
  *  Uses the newest packet time as a reference, then averages all packets whose
- *  age is within `timeDelta` seconds.
+ *  age is within `averagingWindow` seconds.
  *  @param localPkts AccDataMsgF32Payload : an array of AccPktDataMsgF32Payload, each AccPktDataMsgF32Payload contains
  * (measTime, gyro_P, accel_P).
  *  @return OutputAverageAccelAngleVel : body-frame average (AngVelBody, AccelBody). If no packets are in the window, returns zeros.
@@ -25,7 +25,7 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
 
     for (uint32_t i = 0; i < MAX_BUF_PKT; ++i) {
         // Rolling average with averagingWindow as window width or the maximum buffer size
-        if (static_cast<float>(maxTimeTag - localPkts.measTime.at(i)) * kNano2SecF <= this->timeDelta) {
+        if (static_cast<float>(maxTimeTag - localPkts.measTime.at(i)) * kNano2SecF <= this->averagingWindow) {
             gyroSum_P += localPkts.gyro_P.at(i);
             accelSum_P += localPkts.accel_P.at(i);
             measAvgCount++;
@@ -45,14 +45,14 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
     return out;
 }
 
-void AverageMimuDataAlgorithm::setTimeDelta(float const timeDeltaIn) {
-    if(timeDeltaIn < 0.0F){
-        FS_THROW_INVALID_ARGUMENT("windowSec cannot be smaller than 0.0");
+void AverageMimuDataAlgorithm::setAveragingWindow(float const window) {
+    if(window < 0.0F){
+        FS_THROW_INVALID_ARGUMENT("AveragingWindow cannot be smaller than 0.0");
     }
-    this->timeDelta = timeDeltaIn;
+    this->averagingWindow = window;
 }
 
-float AverageMimuDataAlgorithm::getTimeDelta() const { return this->timeDelta; }
+float AverageMimuDataAlgorithm::getAveragingWindow() const { return this->averagingWindow; }
 
 void AverageMimuDataAlgorithm::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn) { this->dcm_BP = dcm_BPIn; }
 

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -1,5 +1,5 @@
 #include "averageMimuDataAlgorithm.h"
-
+#include "../freestandingInvalidArgument.h"
 #include "architecture/utilities/eigenSupport.h"
 #include "utilities/timeConstants.h"
 
@@ -26,8 +26,8 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
     for (uint32_t i = 0; i < MAX_BUF_PKT; ++i) {
         // Rolling average with averagingWindow as window width or the maximum buffer size
         if (static_cast<float>(maxTimeTag - localPkts.measTime.at(i)) * kNano2SecF <= this->timeDelta) {
-            gyroSum_P += localPkts.gyro_P[i];
-            accelSum_P += localPkts.accel_P[i];
+            gyroSum_P += localPkts.gyro_P.at(i);
+            accelSum_P += localPkts.accel_P.at(i);
             measAvgCount++;
         }
     }
@@ -45,7 +45,12 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
     return out;
 }
 
-void AverageMimuDataAlgorithm::setTimeDelta(float const timeDeltaIn) { this->timeDelta = timeDeltaIn; }
+void AverageMimuDataAlgorithm::setTimeDelta(float const timeDeltaIn) {
+    if(timeDeltaIn < 0.0F){
+        FS_THROW_INVALID_ARGUMENT("windowSec cannot be smaller than 0.0");
+    }
+    this->timeDelta = timeDeltaIn;
+}
 
 float AverageMimuDataAlgorithm::getTimeDelta() const { return this->timeDelta; }
 

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -6,36 +6,43 @@
 #include <algorithm>
 #include <cstdint>
 
-IMUSensorBodyMsgF32Payload AverageMimuDataAlgorithm::update(AccDataMsgF32Payload const& localPkts) const {
+/*! @brief Average recent gyro/accel samples and output them in the body frame.
+ *  Uses the newest packet time as a reference, then averages all packets whose
+ *  age is within `timeDelta` seconds.
+ *  @param localPkts AccDataMsgF32Payload : an array of AccPktDataMsgF32Payload, each AccPktDataMsgF32Payload contains
+ * (measTime, gyro_P, accel_P).
+ *  @return OutputAverageAccelAngleVel : body-frame average (AngVelBody, AccelBody). If no packets are in the window, returns zeros.
+ */
+OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const& localPkts) const {
     uint64_t maxTimeTag = 0U;
-    for (auto const& accPkt : localPkts.accPkts) {
-        maxTimeTag = std::max(accPkt.measTime, maxTimeTag);
+    for (auto const& time : localPkts.measTime) {
+        maxTimeTag = std::max(time, maxTimeTag);
     }
 
     Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
     Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
     uint64_t measAvgCount = 0U;
 
-    for (const auto& [measTime, gyro_B, accel_B] : localPkts.accPkts) {
-        // Rolling average with timeDelta as window width or the maximum buffer size
-        if (static_cast<float>(maxTimeTag - measTime) * kNano2SecF < this->timeDelta) {
-            gyroSum_P += Eigen::Map<const Eigen::Vector3f>(gyro_B);
-            accelSum_P += Eigen::Map<const Eigen::Vector3f>(accel_B);
+    for (uint32_t i = 0; i < MAX_BUF_PKT; ++i) {
+        // Rolling average with averagingWindow as window width or the maximum buffer size
+        if (static_cast<float>(maxTimeTag - localPkts.measTime.at(i)) * kNano2SecF <= this->timeDelta) {
+            gyroSum_P += localPkts.gyro_P[i];
+            accelSum_P += localPkts.accel_P[i];
             measAvgCount++;
         }
     }
 
-    IMUSensorBodyMsgF32Payload localOutput{};
+    OutputAverageAccelAngleVel out{};
     if (measAvgCount > 0U) {
         gyroSum_P /= static_cast<float>(measAvgCount);
         Eigen::Vector3f const gyroSum_B = this->dcm_BP * gyroSum_P;
-        eigenVectorToCArray(gyroSum_B, localOutput.AngVelBody);
         accelSum_P /= static_cast<float>(measAvgCount);
         Eigen::Vector3f const accelSum_B = this->dcm_BP * accelSum_P;
-        eigenVectorToCArray(accelSum_B, localOutput.AccelBody);
+        out.gyroOmega_B = gyroSum_B;
+        out.accel_B = accelSum_B;
     }
 
-    return localOutput;
+    return out;
 }
 
 void AverageMimuDataAlgorithm::setTimeDelta(float const timeDeltaIn) { this->timeDelta = timeDeltaIn; }

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -2,6 +2,7 @@
 #include "../freestandingInvalidArgument.h"
 #include "architecture/utilities/eigenSupport.h"
 #include "utilities/timeConstants.h"
+#include "utilities/validDcmCheck.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -54,6 +55,11 @@ void AverageMimuDataAlgorithm::setAveragingWindow(float const window) {
 
 float AverageMimuDataAlgorithm::getAveragingWindow() const { return this->averagingWindow; }
 
-void AverageMimuDataAlgorithm::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn) { this->dcm_BP = dcm_BPIn; }
+void AverageMimuDataAlgorithm::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn) {
+    if (!isValidDcm(dcm_BPIn)) {
+        FS_THROW_INVALID_ARGUMENT("dcm_BP must be orthonormal with det=+1.");
+    }
+    this->dcm_BP = dcm_BPIn;
+}
 
 Eigen::Matrix3f AverageMimuDataAlgorithm::getDcmPltfToBdy() const { return this->dcm_BP; }

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -2,9 +2,22 @@
 #define AVERAGE_MIMU_DATA_ALGORITHM_H
 
 #include "msgPayloadDef/AccDataMsgF32Payload.h"
-#include "msgPayloadDef/IMUSensorBodyMsgF32Payload.h"
 
 #include <Eigen/Core>
+
+constexpr std::size_t MAX_BUF_PKT = 120;
+
+struct InputPktsData
+{
+    std::array<std::uint64_t, MAX_BUF_PKT> measTime{};
+    std::array<Eigen::Vector3f, MAX_BUF_PKT> gyro_P{};
+    std::array<Eigen::Vector3f, MAX_BUF_PKT> accel_P{};
+};
+
+struct OutputAverageAccelAngleVel {
+    Eigen::Vector3f accel_B = Eigen::Vector3f::Zero();
+    Eigen::Vector3f gyroOmega_B = Eigen::Vector3f::Zero();
+};
 
 class AverageMimuDataAlgorithm {
    public:
@@ -12,7 +25,7 @@ class AverageMimuDataAlgorithm {
     float getTimeDelta() const;                             //!< Getter method for timeDelta
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;                //!< Getter method for dcm from platform to body
-    IMUSensorBodyMsgF32Payload update(AccDataMsgF32Payload const& localPkts) const;
+    OutputAverageAccelAngleVel update(InputPktsData const& localPkts) const;
 
    private:
     float timeDelta{0.0F};                                 //!< [s] Allowable time difference from "latest"

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -7,8 +7,7 @@
 
 constexpr std::size_t MAX_BUF_PKT = 120;
 
-struct InputPktsData
-{
+struct InputPktsData {
     std::array<std::uint64_t, MAX_BUF_PKT> measTime{};
     std::array<Eigen::Vector3f, MAX_BUF_PKT> gyro_P{};
     std::array<Eigen::Vector3f, MAX_BUF_PKT> accel_P{};

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -21,14 +21,14 @@ struct OutputAverageAccelAngleVel {
 
 class AverageMimuDataAlgorithm {
    public:
-    void setTimeDelta(float timeDeltaIn);                   //!< Setter method for timeDelta
-    float getTimeDelta() const;                             //!< Getter method for timeDelta
+    void setAveragingWindow(float window);                  //!< [s] Setter method for windowSec
+    float getAveragingWindow() const;                       //!< [s] Getter method for windowSec
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;                //!< Getter method for dcm from platform to body
     OutputAverageAccelAngleVel update(InputPktsData const& localPkts) const;
 
    private:
-    float timeDelta{0.0F};                                 //!< [s] Allowable time difference from "latest"
+    float averagingWindow{0.0F};                           //!< [s] Allowable time difference from "latest"
     Eigen::Matrix3f dcm_BP = Eigen::Matrix3f::Identity();  //!< [-] Transformation from the platform frame to body
 };
 

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
@@ -48,12 +48,12 @@ IMUSensorBodyMsgF32Payload AverageMimuDataAlgorithm_update(const AverageMimuData
     return result;
 }
 
-void AverageMimuDataAlgorithm_setTimeDelta(AverageMimuDataAlgorithm* self, float timeDelta) {
-    reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->setTimeDelta(timeDelta);
+void AverageMimuDataAlgorithm_setAveragingWindow(AverageMimuDataAlgorithm* self, float window) {
+    reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->setAveragingWindow(window);
 }
 
-float AverageMimuDataAlgorithm_getTimeDelta(const AverageMimuDataAlgorithm* self) {
-    return reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getTimeDelta();
+float AverageMimuDataAlgorithm_getAveragingWindow(const AverageMimuDataAlgorithm* self) {
+    return reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getAveragingWindow();
 }
 
 void AverageMimuDataAlgorithm_setDcmPltfToBdy(AverageMimuDataAlgorithm* self, Matrix3f_c dcm_BP) {

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
@@ -87,16 +87,16 @@ IMUSensorBodyMsgF32Payload AverageMimuDataAlgorithm_update(const AverageMimuData
 /**
  * @brief Set the allowable time delta for averaging window.
  * @param self      Pointer to the instance.
- * @param timeDelta Time delta in seconds.
+ * @param window    Average window duration in seconds.
  */
-void AverageMimuDataAlgorithm_setTimeDelta(AverageMimuDataAlgorithm* self, float timeDelta);
+void AverageMimuDataAlgorithm_setAveragingWindow(AverageMimuDataAlgorithm* self, float window);
 
 /**
  * @brief Get the current time delta for averaging window.
  * @param self Pointer to the instance.
  * @return float  The current time delta in seconds.
  */
-float AverageMimuDataAlgorithm_getTimeDelta(const AverageMimuDataAlgorithm* self);
+float AverageMimuDataAlgorithm_getAveragingWindow(const AverageMimuDataAlgorithm* self);
 
 /**
  * @brief Set the DCM from platform frame to body frame.

--- a/algorithms/utilities/_tests/CMakeLists.txt
+++ b/algorithms/utilities/_tests/CMakeLists.txt
@@ -1,3 +1,15 @@
+add_executable(test_validDcm
+               test_validDcm.cpp
+  utilitiesHelpers.hpp
+)
+
+target_link_libraries(test_validDcm PRIVATE
+    Eigen3::Eigen
+    GTest::gtest_main
+  )
+
+gtest_discover_tests(test_validDcm)
+
 add_executable(test_validateInertia
   test_validateInertia.cpp
   utilitiesHelpers.hpp
@@ -25,6 +37,21 @@ gtest_discover_tests(test_chebyshevUtilities)
 
 if(XMERA_ENABLE_FUZZTESTS)
   fuzztest_setup_fuzzing_flags()
+
+  add_executable(test_validDcm_fuzz
+                 test_validDcm_fuzz.cpp
+  )
+
+  target_link_libraries(test_validDcm_fuzz PRIVATE
+    Eigen3::Eigen
+    fuzztest::fuzztest
+    fuzztest::fuzztest_gtest_main
+  )
+
+  gtest_discover_tests(test_validDcm_fuzz
+    PROPERTIES
+      LABELS "fuzz\;fuzz-smoke"
+  )
 
   add_executable(test_validateInertia_fuzz
     utilitiesHelpers.hpp

--- a/algorithms/utilities/_tests/test_validDcm.cpp
+++ b/algorithms/utilities/_tests/test_validDcm.cpp
@@ -1,0 +1,15 @@
+#include "../validDcmCheck.h"
+#include <gtest/gtest.h>
+
+#include "utilitiesHelpers.hpp"
+
+TEST(ValidDcm, KnownBadDcm) {
+    // --- Test expected exceptions ---
+    Eigen::Matrix3f badDcm = Eigen::Matrix3f::Identity();
+    badDcm << 1, 0, 0, 0, 1, 0, 0, 0, 0;  // not orthogonal, not +1 determinant
+    EXPECT_FALSE(isValidDcm(badDcm));
+    badDcm << 1, 0, 0, 0, 1, 0, 0, 1, 1;  // not orthogonal, +1 determinant
+    EXPECT_FALSE(isValidDcm(badDcm));
+    badDcm << 1, 0, 0, 0, 1, 0, 0, 0, -1;  // orthogonal, not +1 determinant
+    EXPECT_FALSE(isValidDcm(badDcm));
+}

--- a/algorithms/utilities/_tests/test_validDcm_fuzz.cpp
+++ b/algorithms/utilities/_tests/test_validDcm_fuzz.cpp
@@ -1,0 +1,5 @@
+#include "utilitiesHelpers.hpp"
+#include <fuzztest/fuzztest.h>
+
+FUZZ_TEST(DcmFuzz, testDcmValidity)
+    .WithDomains(fuzztest::InRange(1e-6F, 1.0F), fuzztest::InRange(1e-6F, 1.0F), fuzztest::InRange(1e-6F, 1.0F));

--- a/algorithms/utilities/_tests/utilitiesHelpers.hpp
+++ b/algorithms/utilities/_tests/utilitiesHelpers.hpp
@@ -1,16 +1,18 @@
+#include "../validDcmCheck.h"
 #include "../validInertiaCheck.h"
+
 #include <gtest/gtest.h>
 #include <Eigen/Core>
 
 /* Function to generate a cross product operator from a vector */
-inline Eigen::Matrix3f tildeMatrix(const Eigen::Vector3f &vector) {
+inline Eigen::Matrix3f tildeMatrix(const Eigen::Vector3f& vector) {
     Eigen::Matrix3f tilde;
     tilde << 0.0F, -vector(2), vector(1), vector(2), 0.0F, -vector(0), -vector(1), vector(0), 0.0F;
     return tilde;
 }
 
 /* Function to generate a dcm from an mrp */
-inline Eigen::Matrix3f mrpToDcm(const Eigen::Vector3f &mrp) {
+inline Eigen::Matrix3f mrpToDcm(const Eigen::Vector3f& mrp) {
     const Eigen::Matrix3f t = tildeMatrix(mrp);
     const float denom = (1.0 + mrp.dot(mrp));
     const Eigen::Matrix3f dcm = (8.0 * t * t - 4.0 * (1.0 - mrp.dot(mrp)) * t) / (denom * denom);
@@ -53,4 +55,21 @@ inline void testInertiaValidity(float eigen1, float eigen2, float sigma1, float 
     const Eigen::Matrix3f inertia = GenerateValidInertiaMatrix(eigen1, eigen2, sigma1, sigma2, sigma3);
 
     EXPECT_TRUE(inertiaIsValid(inertia));
+}
+
+/* Function to generate a general inertia matrix */
+inline Eigen::Matrix3f generateValidDCM(float const sigma1, float const sigma2, float const sigma3) {
+    Eigen::Vector3f mrp(sigma1, sigma2, sigma3);
+    if (mrp.squaredNorm() > 1) {
+        mrp = -mrp / mrp.squaredNorm();
+    }
+    Eigen::Matrix3f dcm = mrpToDcm(mrp);
+
+    return dcm;
+}
+
+inline void testDcmValidity(float const sigma1, float const sigma2, float const sigma3) {
+    const Eigen::Matrix3f dcm = generateValidDCM(sigma1, sigma2, sigma3);
+
+    EXPECT_TRUE(isValidDcm(dcm));
 }

--- a/algorithms/utilities/validDcmCheck.h
+++ b/algorithms/utilities/validDcmCheck.h
@@ -1,0 +1,18 @@
+#ifndef FP32_XMERA_FSW_ALGORITHMS_VALID_DCM_H
+#define FP32_XMERA_FSW_ALGORITHMS_VALID_DCM_H
+
+#include <Eigen/Core>
+
+inline constexpr float kToleranceF = 1.0e-5F;
+
+inline bool isValidDcm(Eigen::Matrix3f const& dcm) {
+    bool valid = true;
+    const bool isOrthogonal = (dcm.transpose() * dcm).isApprox(Eigen::Matrix3f::Identity(), kToleranceF);
+    const bool detIsValid = std::abs(dcm.determinant() - 1.0F) <= kToleranceF;
+    if (!isOrthogonal || !detIsValid) {
+        valid = false;
+    }
+    return valid;
+}
+
+#endif  // FP32_XMERA_FSW_ALGORITHMS_VALID_DCM_H


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2027
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR refactors the averageMimuData algorithm for flight software integration and a first V & V pass.
The first commit - Introduces InputPktsData and OutputAverageAccelAnglevel structs, decouples algorithm from message payload types. The following commit introduces a google test C++ regression and fuzz tests. In commit three an .rst documentation is added. 

Commit 4 adds validation to check that a negative timeDelta throws exception; changes < to <= for zero-window edge case; also adds testZeroTimeDelta() test. Commit 5 renames timeDelta to averagingWindow. Commit 6 and 7 add a function which checks a dcm is valid and then uses that validation in setter. 

Finally, the last two commits simplify the tests and apply formatting.

## Verification
Ci runs successfully

## Documentation
The algorithm .rst is updated.

## Future work
None
