### PR TITLE
Update load fuzz corpus

### DIFF
--- a/.github/scripts/run_long_fuzzers.sh
+++ b/.github/scripts/run_long_fuzzers.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <build_dir> <log_dir> [--fuzz-for <duration>] [--corpus <path>]" >&2
+  exit 2
+fi
+
+BUILD_DIR="$1"
+LOG_DIR="$2"
+shift 2
+
+FUZZ_DURATION="120s"
+CORPUS_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fuzz-for)
+      [[ $# -ge 2 ]] || { echo "--fuzz-for requires a value" >&2; exit 2; }
+      FUZZ_DURATION="$2"
+      shift 2
+      ;;
+    --corpus)
+      [[ $# -ge 2 ]] || { echo "--corpus requires a path" >&2; exit 2; }
+      CORPUS_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$LOG_DIR"
+if [[ -n "$CORPUS_DIR" ]]; then
+  mkdir -p "$CORPUS_DIR"
+fi
+
+# Discover fuzz binaries via CTest labels
+FUZZ_BINS=$(BUILD_DIR="$BUILD_DIR" python3 - <<'PY'
+import json, os, subprocess
+build_dir = os.environ["BUILD_DIR"]
+proc = subprocess.run(
+    ["ctest", "--show-only=json-v1", "-L", "fuzz"],
+    capture_output=True, text=True, check=True,
+    cwd=build_dir
+)
+data = json.loads(proc.stdout or "{}")
+seen = []
+for test in data.get("tests", []):
+    cmd = test.get("command", [])
+    if cmd:
+        exe = cmd[0]
+        if exe not in seen:
+            seen.append(exe)
+print("\n".join(seen))
+PY
+)
+
+if [[ -z "$FUZZ_BINS" ]]; then
+  echo "No fuzz executables discovered via CTest labels." >&2
+  exit 1
+fi
+
+CRASH_COUNT=0
+
+while IFS= read -r fuzz_bin; do
+  [[ -z "$fuzz_bin" ]] && continue
+  fuzz_name="$(basename "$fuzz_bin")"
+  echo ">>> Running long fuzz session for ${fuzz_name}"
+  cmd=("$fuzz_bin")
+  if [[ -n "$FUZZ_DURATION" ]]; then
+    cmd+=("--fuzz_for=${FUZZ_DURATION}")
+  fi
+  if [[ -n "$CORPUS_DIR" ]]; then
+    cmd+=("--corpus_database=${CORPUS_DIR}")
+  fi
+  if "${cmd[@]}" 2>&1 | tee "$LOG_DIR/${fuzz_name}.log"; then
+    echo ">>> ${fuzz_name}: OK"
+  else
+    echo ">>> ${fuzz_name}: FAILED (exit $?)"
+    CRASH_COUNT=$((CRASH_COUNT + 1))
+  fi
+done <<< "$FUZZ_BINS"
+
+if [[ $CRASH_COUNT -gt 0 ]]; then
+  echo "ERROR: ${CRASH_COUNT} fuzz target(s) reported crashes." >&2
+  exit 1
+fi

--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -1,0 +1,238 @@
+name: Daily Fuzz Testing
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # midnight MDT (07:00 UTC)
+  workflow_dispatch:
+    inputs:
+      fuzz_duration:
+        description: 'Duration per fuzz target (e.g. 120s, 10m)'
+        default: '120s'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+env:
+  USERNAME: ${{ github.repository_owner }}
+  FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+  VCPKG_BINARY_SOURCES: "clear"
+  VCPKG_FEATURE_FLAGS: "manifests,registries,binarycaching"
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_OUTPUT_ON_FAILURE: 1
+  XMERA_FUZZTEST_CORPUS_DIR: ${{ github.workspace }}/.fuzztest_corpus
+
+jobs:
+  fuzz:
+    name: Extended fuzzing (ubuntu-24.04 / Clang)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    steps:
+      - name: Checkout fp32-fsw-xmera
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Checkout Xmera core
+        uses: actions/checkout@v6
+        with:
+          repository: lasp/xmera
+          path: xmera
+          persist-credentials: false
+
+      - name: Restore fuzz corpus cache
+        id: fuzz-corpus-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .fuzztest_corpus
+          key: fuzz-corpus-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ runner.os }}-
+
+      - name: Ensure fuzz corpus directory exists
+        run: mkdir -p .fuzztest_corpus
+
+      - name: Install Clang 18
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-18 lld-18
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 180
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 180
+          sudo update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld-18 180
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ninja-build build-essential \
+            pkg-config autoconf automake libtool \
+            zip unzip \
+            bison swig \
+            mono-complete \
+            ccache
+
+      - name: Set up Python 3.11
+        id: setup-py
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            xmera/**/requirements.txt
+            xmera/**/pyproject.toml
+            **/requirements.txt
+            **/requirements*.txt
+
+      - name: Pin Python interpreter
+        run: |
+          PY="$(python -c 'import sys; print(sys.executable)')"
+          echo "PYTHON_EXE=$PY" >> "$GITHUB_ENV"
+
+      - name: Setup CMake 3.28.3
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.28.3'
+
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgDirectory: ${{ github.workspace }}/b/vcpkg
+          vcpkgJsonGlob: "xmera/src/vcpkg.json"
+          vcpkgConfigurationJsonGlob: "xmera/src/vcpkg-configuration.json"
+        env:
+          VCPKG_KEEP_ENV_VARS: CC;CXX;CMAKE_GENERATOR;CMAKE_MAKE_PROGRAM
+          VCPKG_MAX_CONCURRENCY: "1"
+          CMAKE_GENERATOR: Ninja
+          CMAKE_MAKE_PROGRAM: /usr/bin/ninja
+          VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
+      - name: Configure vcpkg binary cache
+        run: |
+          echo "VCPKG_BINARY_SOURCES=clear;nuget,${FEED_URL},readwrite" >> "$GITHUB_ENV"
+
+      - name: Add NuGet sources for vcpkg binary cache
+        env:
+          VCPKG_EXE: ${{ github.workspace }}/b/vcpkg/vcpkg
+        run: |
+          set -euo pipefail
+          NUGET="$("${VCPKG_EXE}" fetch nuget | awk 'NF{last=$0} END{print last}')"
+
+          declare -a NUGET_CMD=()
+          if [[ "$NUGET" == *.exe ]]; then
+            NUGET_CMD=(mono "$NUGET")
+          else
+            NUGET_CMD=("$NUGET")
+          fi
+
+          echo "Using NuGet CLI: ${NUGET_CMD[*]}"
+
+          "${NUGET_CMD[@]}" sources add \
+            -Source "${FEED_URL}" \
+            -StorePasswordInClearText \
+            -Name GitHubPackages \
+            -UserName "${USERNAME}" \
+            -Password "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}"
+
+          "${NUGET_CMD[@]}" setapikey "${{ secrets.FP32_XMERA_GH_VCPKG_PACKAGES_TOKEN }}" \
+            -Source "${FEED_URL}"
+
+      - name: Configure (Clang + fuzz-test preset)
+        working-directory: xmera/src
+        env:
+          CC: clang
+          CXX: clang++
+        run: |
+          ln -s "${GITHUB_WORKSPACE}" .
+          cmake --preset fuzz-test \
+            "-DXMERA_MODULE_ROOTS=${GITHUB_WORKSPACE}/xmera/src/fswAlgorithms/;${GITHUB_WORKSPACE}/xmera/src/simulation/;${GITHUB_WORKSPACE}/xmera/src/moduleTemplates/;${GITHUB_WORKSPACE}/xmera/src/fp32-fsw-xmera/algorithms" \
+            "-DXMERA_ENABLE_GROUPS=simulation;fswAlgorithms;moduleTemplates;fp32"
+
+      - name: Build
+        working-directory: xmera/src
+        env:
+          CC: clang
+          CXX: clang++
+        run: cmake --build ../build --parallel
+
+      - name: Run fuzz smoke tests (CTest)
+        working-directory: xmera/build
+        env:
+          XMERA_FUZZTEST_REPLAY_CORPUS: __ALL__
+          XMERA_FUZZTEST_REPLAY_FOR: inf
+        run: ctest --output-on-failure -L fuzz
+
+      - name: Run extended fuzz sessions
+        working-directory: xmera/build
+        env:
+          ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1:check_initialization_order=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:suppressions=/dev/null
+        run: |
+          FUZZ_DURATION="${{ inputs.fuzz_duration || '120s' }}"
+          "${GITHUB_WORKSPACE}/.github/scripts/run_long_fuzzers.sh" \
+            "$(pwd)" \
+            "${GITHUB_WORKSPACE}/fuzz-logs" \
+            --fuzz-for "$FUZZ_DURATION" \
+            --corpus "${XMERA_FUZZTEST_CORPUS_DIR}"
+
+      - name: Generate fuzz report summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## Daily Fuzz Report — $(date -u +%Y-%m-%d)"
+            echo ""
+            echo "| Target | Corpus Files | Status |"
+            echo "|--------|-------------|--------|"
+
+            for log in fuzz-logs/*.log; do
+              [[ -f "$log" ]] || continue
+              name="$(basename "$log" .log)"
+
+              # Count corpus files for this target
+              corpus_count=0
+              if [[ -d ".fuzztest_corpus" ]]; then
+                corpus_count=$(find ".fuzztest_corpus" -type f -path "*${name}*" 2>/dev/null | wc -l || echo 0)
+              fi
+
+              # Check for crash indicators in log
+              if grep -qiE '(SUMMARY:.*Sanitizer|crash-|==ERROR)' "$log" 2>/dev/null; then
+                status="CRASH"
+              else
+                status="OK"
+              fi
+
+              echo "| ${name} | ${corpus_count} | ${status} |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Archive fuzz logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-logs-${{ github.run_id }}
+          path: fuzz-logs/
+          retention-days: 30
+
+      - name: Upload fuzz corpus artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-corpus-${{ github.run_id }}
+          path: .fuzztest_corpus
+          retention-days: 7
+
+      - name: Save fuzz corpus cache
+        if: ${{ always() }}
+        uses: actions/cache/save@v5
+        with:
+          path: .fuzztest_corpus
+          key: fuzz-corpus-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,7 +41,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: .pre-commit-config.yaml
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Upload coverage artifacts (Linux only)
         if: ${{ runner.os == 'Linux' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: external-modules-coverage
           path: |
@@ -348,7 +348,7 @@ jobs:
 
       - name: Upload pytest test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-${{ matrix.os }}
           path: junit/test-results-${{ matrix.os }}.xml
@@ -356,7 +356,7 @@ jobs:
 
       - name: Upload CTest results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ctest-${{ matrix.os }}
           path: junit/ctest-${{ matrix.os }}.xml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -99,7 +99,7 @@ jobs:
 
       - name: Set up Python 3.11
         id: setup-py
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -75,13 +75,13 @@ jobs:
       security-events: write
     steps:
       - name: Checkout fp32-fsw-xmera
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Checkout Xmera core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: lasp/xmera
           path: xmera


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2085
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR add daily fuzzing to the project. The fuzzing input domain is saved in a corpus file to allow the the daily tests to incrementally over the entire input domain. 

Currently fuzz tests only run in PR CI as quick smoke tests. The goal is a daily workflow that runs extended fuzzing with Clang/libFuzzer, persists the corpus between runs, and reports input domain coverage. 
- Time budget: 2 minutes per FUZZ_TEST entry (~1 hour total)
- Schedule: Daily at midnight Denver time (cron: '0 7 * * *' = 07:00 UTC) 

## Verification
CI is run successfully.

## Documentation
NA

## Future work
None
