### PR TITLE
Feature/2040 orbital motion

### DIFF
--- a/algorithms/utilities/_tests/CMakeLists.txt
+++ b/algorithms/utilities/_tests/CMakeLists.txt
@@ -47,6 +47,34 @@ target_link_libraries(test_safeMath PRIVATE
 
 gtest_discover_tests(test_safeMath)
 
+add_executable(test_orbitalMotion_functions
+        test_orbitalMotion_functions.cpp
+  ../orbitalMotion.cpp
+)
+
+target_include_directories(test_orbitalMotion_functions PRIVATE "..")
+
+target_link_libraries(test_orbitalMotion_functions PRIVATE
+  Eigen3::Eigen
+  GTest::gtest_main
+)
+
+gtest_discover_tests(test_orbitalMotion_functions)
+
+add_executable(test_orbitalMotion_degenerate
+  test_orbitalMotion_degenerate.cpp
+  ../orbitalMotion.cpp
+)
+
+target_include_directories(test_orbitalMotion_degenerate PRIVATE "..")
+
+target_link_libraries(test_orbitalMotion_degenerate PRIVATE
+  Eigen3::Eigen
+  GTest::gtest_main
+)
+
+gtest_discover_tests(test_orbitalMotion_degenerate)
+
 if(XMERA_ENABLE_FUZZTESTS)
   fuzztest_setup_fuzzing_flags()
 
@@ -109,9 +137,26 @@ if(XMERA_ENABLE_FUZZTESTS)
     fuzztest::fuzztest_gtest_main
   )
 
+  add_executable(test_orbitalMotion_fuzz
+    test_orbitalMotion_fuzz.cpp
+    ../orbitalMotion.cpp
+  )
+
+  target_include_directories(test_orbitalMotion_fuzz PRIVATE "..")
+
+  target_link_libraries(test_orbitalMotion_fuzz PRIVATE
+    Eigen3::Eigen
+    fuzztest::fuzztest
+    fuzztest::fuzztest_gtest_main
+  )
+
   gtest_discover_tests(test_safeMath_fuzz
     PROPERTIES
       LABELS "fuzz\;fuzz-smoke"
   )
 
+  gtest_discover_tests(test_orbitalMotion_fuzz
+    PROPERTIES
+      LABELS "fuzz\;fuzz-smoke"
+  )
 endif()

--- a/algorithms/utilities/_tests/test_orbitalMotion_degenerate.cpp
+++ b/algorithms/utilities/_tests/test_orbitalMotion_degenerate.cpp
@@ -1,0 +1,247 @@
+/*
+ MIT License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+ Tests for degenerate / singular orbital geometries:
+   - Near-parabolic elliptic (e → 1⁻)
+   - Exactly parabolic (e = 1)
+   - Rectilinear (h = 0, purely radial motion)
+   - Near-rectilinear (h → 0⁺)
+*/
+
+#include "../orbitalMotion.hpp"
+
+#include <gtest/gtest.h>
+#include <Eigen/Geometry>
+#include <cmath>
+
+constexpr double kMuEarth = 3.986004418e14;  // m³/s²
+constexpr double kRpM = 7.0e6;               // periapsis radius, m
+
+// ============================================================================
+// Near-parabolic elliptic (e → 1⁻)
+//
+// As e → 1 the semi-latus rectum p = a(1−e²) → 0 and the semi-major axis
+// a → ∞. The closed-form anomaly functions use sqrt(1−e) and sqrt(1+e), both
+// of which remain finite. The Newton solver for meanToEccentric is tested at a
+// small mean anomaly to keep the converged E inside the solver's safe range.
+// ============================================================================
+
+class NearParabolicEllipticTest : public ::testing::Test {
+   protected:
+    static constexpr float kE = 0.9999f;  // eccentricity near 1
+    static constexpr float kF = 0.5f;     // true anomaly — within safe trig range
+    static constexpr float kEc = 0.4f;    // eccentric anomaly seed
+};
+
+// All closed-form anomaly conversions must return finite values.
+TEST_F(NearParabolicEllipticTest, ClosedFormAnomalies_AllFinite) {
+    const float E = OrbitalMotion::trueToEccentricAnomalyF32(kF, kE);
+    EXPECT_TRUE(std::isfinite(E)) << "trueToEccentric";
+
+    const float f_back = OrbitalMotion::eccentricToTrueAnomalyF32(kEc, kE);
+    EXPECT_TRUE(std::isfinite(f_back)) << "eccentricToTrue";
+
+    const float M = OrbitalMotion::eccentricToMeanAnomalyF32(kEc, kE);
+    EXPECT_TRUE(std::isfinite(M)) << "eccentricToMean";
+
+    const float M2 = OrbitalMotion::trueToMeanAnomalyF32(kF, kE);
+    EXPECT_TRUE(std::isfinite(M2)) << "trueToMean";
+}
+
+// The Newton solver must converge to a finite E for small M.
+// Small M keeps the converged E near zero where the solver's safe
+// trig calls (safeSinf, safeCosf) are exact and the denominator
+// 1 − e·cos(E) stays well away from zero.
+TEST_F(NearParabolicEllipticTest, NewtonSolver_SmallM_Converges) {
+    const float E = OrbitalMotion::meanToEccentricAnomalyF32(0.005f, kE);
+    EXPECT_TRUE(std::isfinite(E));
+    // Verify it actually satisfies Kepler's equation to solver tolerance.
+    EXPECT_NEAR(E - kE * sinf(E), 0.005f, 1e-4f);
+}
+
+// elementsToCartesianStateF32 must produce a finite Cartesian state.
+TEST_F(NearParabolicEllipticTest, ElementsToCartesian_AllFinite) {
+    ClassicalElementsF32 el;
+    el.semiMajorAxis = kRpM / (1.0 - kE);  // very large but finite
+    el.eccentricity = kE;
+    el.inclination = 0.3f;
+    el.rightAscensionAscendingNode = 0.0f;
+    el.argPeriapsis = 0.0f;
+    el.trueAnomaly = kF;  // near periapsis
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMuEarth, el);
+
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_TRUE(std::isfinite(state.position[i])) << "position[" << i << ']';
+        EXPECT_TRUE(std::isfinite(state.velocity[i])) << "velocity[" << i << ']';
+    }
+}
+
+// Vis-viva must hold at periapsis (f = 0) where the orbit is most numerically stable.
+TEST_F(NearParabolicEllipticTest, VisViva_AtPeriapsis) {
+    ClassicalElementsF32 el;
+    el.semiMajorAxis = kRpM / (1.0 - kE);
+    el.eccentricity = kE;
+    el.inclination = 0.3f;
+    el.rightAscensionAscendingNode = 0.0f;
+    el.argPeriapsis = 0.0f;
+    el.trueAnomaly = 0.0f;  // periapsis: most stable
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMuEarth, el);
+    const double r = state.position.norm();
+    const double v2 = state.velocity.squaredNorm();
+    const double v2_expected = kMuEarth * (2.0 / r - 1.0 / el.semiMajorAxis);
+
+    EXPECT_TRUE(std::isfinite(v2));
+    EXPECT_NEAR(v2, v2_expected, v2_expected * 1e-3);
+}
+
+// ============================================================================
+// Exactly parabolic (e = 1)
+//
+// Closed-form functions: sqrt(1−e) = 0, but atan2(y, 0) is well-defined,
+// so trueToEccentric, eccentricToTrue, and trueToMean all remain finite.
+//
+// elementsToCartesianStateF32: p = a(1−e²) = 0 → h = sqrt(μp) = 0 →
+// velocity = μ/h × (…) = Inf. This is a genuine singularity; the tests
+// document it explicitly.
+//
+// cartesianStateToElementsF32: the eccentricity vector magnitude equals 1
+// for a parabolic / rectilinear trajectory.
+// ============================================================================
+
+TEST(ParabolicOrbitTest, TrueToEccentric_Finite) {
+    // sqrt(1−1) = 0, cos_part = 0; atan2(y, 0) = ±π/2 (defined).
+    for (const float f : {-0.7f, -0.3f, 0.0f, 0.3f, 0.7f}) {
+        const float E = OrbitalMotion::trueToEccentricAnomalyF32(f, 1.0f);
+        EXPECT_TRUE(std::isfinite(E)) << "f=" << f;
+    }
+}
+
+TEST(ParabolicOrbitTest, EccentricToTrue_Finite) {
+    for (const float E : {-0.7f, -0.3f, 0.0f, 0.3f, 0.7f}) {
+        const float f = OrbitalMotion::eccentricToTrueAnomalyF32(E, 1.0f);
+        EXPECT_TRUE(std::isfinite(f)) << "E=" << E;
+    }
+}
+
+TEST(ParabolicOrbitTest, TrueToMean_Finite) {
+    // Chains trueToEccentric (finite) then eccentricToMean (E − sin E, finite).
+    for (const float f : {-0.7f, -0.3f, 0.0f, 0.3f, 0.7f}) {
+        const float M = OrbitalMotion::trueToMeanAnomalyF32(f, 1.0f);
+        EXPECT_TRUE(std::isfinite(M)) << "f=" << f;
+    }
+}
+
+// The Newton solver denominator 1 − e·cos(E) is zero at E = 0 when e = 1,
+// so meanToEccentric(0, 1) is singular. Non-zero M starts the solver away
+// from E = 0, giving a finite (if not exact) result.
+TEST(ParabolicOrbitTest, MeanToEccentric_NonzeroM_Finite) {
+    const float E = OrbitalMotion::meanToEccentricAnomalyF32(0.5f, 1.0f);
+    EXPECT_TRUE(std::isfinite(E));
+}
+
+// elementsToCartesianStateF32 with a = r_p/(1−e): for e = 1 this is Inf,
+// so p = a(1−e²) = Inf * 0, which is NaN. Set a directly from the parabolic
+// semi-latus rectum p = 2·r_p, with a = 0 (the parabolic limit stored by
+// cartesianStateToElementsF32). This exercises the h = 0 branch explicitly.
+TEST(ParabolicOrbitTest, ElementsToCartesian_ZeroSemiMajorAxis_VelocityInfinite) {
+    // cartesianStateToElementsF32 sets semiMajorAxis = 0 when alpha ≈ 0.
+    // Passing that back through elementsToCartesianStateF32 gives p = 0, h = 0,
+    // and velocity = μ/0 = ±Inf.  This test documents the singularity.
+    ClassicalElementsF32 el;
+    el.semiMajorAxis = 0.0;  // as stored after round-trip through parabolic state
+    el.eccentricity = 1.0f;
+    el.inclination = 0.3f;
+    el.rightAscensionAscendingNode = 0.0f;
+    el.argPeriapsis = 0.0f;
+    el.trueAnomaly = 0.0f;
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMuEarth, el);
+
+    // Position is zero (r = p/(1+cos f) = 0/2 = 0) — finite but degenerate.
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_TRUE(std::isfinite(state.position[i])) << "position[" << i << ']';
+    }
+    // Velocity diverges: v = μ/h × (…), h = 0.
+    const double v2 = state.velocity.squaredNorm();
+    EXPECT_FALSE(std::isfinite(v2)) << "Expected infinite velocity for zero-a parabolic input; got " << v2;
+}
+
+// ============================================================================
+// Rectilinear orbit  (h = 0, purely radial velocity)
+//
+// r × v = 0 when v is parallel to r.  cartesianStateToElementsF32 divides
+// by h to compute inclination and uses hVec.normalized() for omega and f.
+// Both produce NaN when h = 0.  The tests document these singularities and
+// verify the code does not crash or invoke undefined behaviour.
+// ============================================================================
+
+// Configuration: r along +x, v purely radial along +x.
+static const Eigen::Vector3d kRVecRadial(kRpM, 0.0, 0.0);
+static const Eigen::Vector3d kVVecRadial(1000.0, 0.0, 0.0);
+
+TEST(RectilinearOrbitTest, CartesianToElements_DoesNotCrash) {
+    EXPECT_NO_FATAL_FAILURE(OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, kVVecRadial));
+}
+
+// For purely radial motion the eccentricity vector has magnitude 1.
+TEST(RectilinearOrbitTest, Eccentricity_IsOne) {
+    const ClassicalElementsF32 el = OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, kVVecRadial);
+    EXPECT_NEAR(el.eccentricity, 1.0f, 1e-4f);
+}
+
+// Inclination, argPeriapsis, and trueAnomaly are undefined (NaN) when h = 0.
+TEST(RectilinearOrbitTest, RectilinearDefaults) {
+    const ClassicalElementsF32 el = OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, kVVecRadial);
+    EXPECT_TRUE(el.inclination == 0.0F) << "expected 0 inclination for h=0";
+    EXPECT_TRUE(el.argPeriapsis == 0.0F) << "expected 0 argPeriapsis for h=0";
+    EXPECT_TRUE(el.trueAnomaly == static_cast<float>(M_PI)) << "expected pi trueAnomaly for h=0";
+}
+
+// ============================================================================
+// Near-rectilinear  (h → 0⁺, tiny transverse velocity)
+//
+// Configuration: r along +x, v = (v_radial, 0, v_transverse).
+// This gives hVec along −y (a polar orbit), so:
+//   inclination = acos(0)   = π/2  (finite)
+//   nVec = UnitZ × hVec     along +x (finite)
+//   hVec.normalized()       = (0, −1, 0) (finite for v_t > 0)
+// All elements remain finite even as v_transverse → 0⁺.
+// ============================================================================
+
+class NearRectilinearTest : public ::testing::Test {
+   protected:
+    static Eigen::Vector3d makeVelocity(double v_transverse) { return {1000.0, 0.0, v_transverse}; }
+};
+
+TEST_F(NearRectilinearTest, AllElements_Finite) {
+    for (const double vt : {10.0, 1.0, 0.1, 0.01}) {
+        const ClassicalElementsF32 el =
+            OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, makeVelocity(vt));
+
+        EXPECT_TRUE(std::isfinite(el.semiMajorAxis)) << "sma,  vt=" << vt;
+        EXPECT_TRUE(std::isfinite(el.eccentricity)) << "ecc,  vt=" << vt;
+        EXPECT_TRUE(std::isfinite(el.inclination)) << "inc,  vt=" << vt;
+        EXPECT_TRUE(std::isfinite(el.rightAscensionAscendingNode)) << "raan, vt=" << vt;
+        EXPECT_TRUE(std::isfinite(el.argPeriapsis)) << "aop,  vt=" << vt;
+        EXPECT_TRUE(std::isfinite(el.trueAnomaly)) << "ta,   vt=" << vt;
+    }
+}
+
+// As transverse velocity shrinks toward zero the eccentricity must approach 1.
+TEST_F(NearRectilinearTest, Eccentricity_ApproachesOne) {
+    float prev_ecc = 0.0f;
+    for (const double vt : {100.0, 10.0, 1.0}) {
+        const ClassicalElementsF32 el =
+            OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, makeVelocity(vt));
+        EXPECT_GT(el.eccentricity, prev_ecc) << "ecc should increase as vt decreases; vt=" << vt;
+        prev_ecc = el.eccentricity;
+    }
+    // At vt = 0.1 m/s, eccentricity should be very close to 1.
+    const ClassicalElementsF32 el =
+        OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, makeVelocity(0.01));
+    EXPECT_NEAR(el.eccentricity, 1.0f, 0.01f);
+}

--- a/algorithms/utilities/_tests/test_orbitalMotion_functions.cpp
+++ b/algorithms/utilities/_tests/test_orbitalMotion_functions.cpp
@@ -1,0 +1,424 @@
+#include "../orbitalMotion.hpp"
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+#include <cmath>
+
+// Test constants
+const double muEarth = 3.986004418e14;  // m^3/s^2
+inline constexpr float kAnomalyTol = 1e-5f;
+inline constexpr double kStateRelTol = 1e-3;
+
+// =============================================================================
+// Anomaly Conversion Tests
+// =============================================================================
+
+class AnomalyConversionTest : public ::testing::Test {
+   protected:
+    const float e_circular = 0.0f;
+    const float e_elliptical = 0.5f;
+    const float e_parabolic = 1.0f;
+    const float e_hyperbolic = 1.5f;
+};
+
+// Eccentric to True Anomaly Tests
+TEST_F(AnomalyConversionTest, EccentricToTrueAnomaly_ZeroEccentricity) {
+    float E = M_PI / 4.0f;
+    float f = OrbitalMotion::eccentricToTrueAnomalyF32(E, e_circular);
+    ASSERT_TRUE(std::isfinite(f));
+    EXPECT_NEAR(f, E, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, EccentricToTrueAnomaly_EllipticalOrbit) {
+    float E = M_PI / 3.0f;
+    float f = OrbitalMotion::eccentricToTrueAnomalyF32(E, e_elliptical);
+    ASSERT_TRUE(std::isfinite(f));
+    // Expected value: f = 2*atan(sqrt((1+e)/(1-e))*tan(E/2))
+    float expected = 2.0f * std::atan(std::sqrt((1.0f + e_elliptical) / (1.0f - e_elliptical)) * std::tan(E / 2.0f));
+    EXPECT_NEAR(f, expected, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, EccentricToTrueAnomaly_AtPeriapsis) {
+    float f = OrbitalMotion::eccentricToTrueAnomalyF32(0.0f, e_elliptical);
+    ASSERT_TRUE(std::isfinite(f));
+    EXPECT_NEAR(f, 0.0f, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, EccentricToTrueAnomaly_AtApoapsis) {
+    float f = OrbitalMotion::eccentricToTrueAnomalyF32(M_PI, e_elliptical);
+    ASSERT_TRUE(std::isfinite(f));
+    EXPECT_NEAR(f, M_PI, kAnomalyTol);
+}
+
+// Eccentric to Mean Anomaly Tests
+TEST_F(AnomalyConversionTest, EccentricToMeanAnomaly_Circular) {
+    float E = M_PI / 4.0f;
+    float M = OrbitalMotion::eccentricToMeanAnomalyF32(E, e_circular);
+    ASSERT_TRUE(std::isfinite(M));
+    EXPECT_NEAR(M, E, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, EccentricToMeanAnomaly_Elliptical) {
+    float E = M_PI / 3.0f;
+    float M = OrbitalMotion::eccentricToMeanAnomalyF32(E, e_elliptical);
+    ASSERT_TRUE(std::isfinite(M));
+    float expected = E - e_elliptical * std::sin(E);
+    EXPECT_NEAR(M, expected, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, EccentricToMeanAnomaly_Zero) {
+    float M = OrbitalMotion::eccentricToMeanAnomalyF32(0.0f, e_elliptical);
+    ASSERT_TRUE(std::isfinite(M));
+    EXPECT_NEAR(M, 0.0f, kAnomalyTol);
+}
+
+// True to Eccentric Anomaly Tests
+TEST_F(AnomalyConversionTest, TrueToEccentricAnomaly_Circular) {
+    float f = M_PI / 4.0f;
+    float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e_circular);
+    ASSERT_TRUE(std::isfinite(E));
+    EXPECT_NEAR(E, f, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, TrueToEccentricAnomaly_Elliptical) {
+    float f = M_PI / 3.0f;
+    float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e_elliptical);
+    ASSERT_TRUE(std::isfinite(E));
+    // Expected value: E = 2*atan(sqrt((1-e)/(1+e))*tan(f/2))
+    float expected = 2.0f * std::atan(std::sqrt((1.0f - e_elliptical) / (1.0f + e_elliptical)) * std::tan(f / 2.0f));
+    EXPECT_NEAR(E, expected, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, TrueToEccentricAnomaly_RoundTrip) {
+    float E_original = M_PI / 4.0f;
+    float f = OrbitalMotion::eccentricToTrueAnomalyF32(E_original, e_elliptical);
+    ASSERT_TRUE(std::isfinite(f));
+    float E_result = OrbitalMotion::trueToEccentricAnomalyF32(f, e_elliptical);
+    ASSERT_TRUE(std::isfinite(E_result));
+    EXPECT_NEAR(E_result, E_original, kAnomalyTol);
+}
+
+// True to Hyperbolic Anomaly Tests
+TEST_F(AnomalyConversionTest, TrueToHyperbolicAnomaly_HyperbolicOrbit) {
+    float f = M_PI / 6.0f;
+    float H = OrbitalMotion::trueToHyperbolicAnomalyF32(f, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(H));
+    // Expected value: H = 2*atanh(sqrt((e-1)/(e+1))*tan(f/2))
+    float expected = 2.0f * std::atanh(std::sqrt((e_hyperbolic - 1.0f) / (e_hyperbolic + 1.0f)) * std::tan(f / 2.0f));
+    EXPECT_NEAR(H, expected, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, TrueToHyperbolicAnomaly_AtPeriapsis) {
+    float H = OrbitalMotion::trueToHyperbolicAnomalyF32(0.0f, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(H));
+    EXPECT_NEAR(H, 0.0f, kAnomalyTol);
+}
+
+// True to Mean Anomaly Tests
+TEST_F(AnomalyConversionTest, TrueToMeanAnomaly_Circular) {
+    float f = M_PI / 4.0f;
+    float M = OrbitalMotion::trueToMeanAnomalyF32(f, e_circular);
+    ASSERT_TRUE(std::isfinite(M));
+    EXPECT_NEAR(M, f, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, TrueToMeanAnomaly_Elliptical) {
+    float f = M_PI / 3.0f;
+    float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e_elliptical);
+    float M = OrbitalMotion::trueToMeanAnomalyF32(f, e_elliptical);
+    ASSERT_TRUE(std::isfinite(M));
+    float expected = E - e_elliptical * std::sin(E);
+    EXPECT_NEAR(M, expected, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, TrueToMeanAnomaly_RoundTrip) {
+    float f_original = M_PI / 4.0f;
+    float M = OrbitalMotion::trueToMeanAnomalyF32(f_original, e_elliptical);
+    ASSERT_TRUE(std::isfinite(M));
+    float f_result = OrbitalMotion::meanToTrueAnomalyF32(M, e_elliptical);
+    ASSERT_TRUE(std::isfinite(f_result));
+    EXPECT_NEAR(f_result, f_original, kAnomalyTol);
+}
+
+// Hyperbolic to True Anomaly Tests
+TEST_F(AnomalyConversionTest, HyperbolicToTrueAnomaly_HyperbolicOrbit) {
+    float H = 0.5f;
+    float f = OrbitalMotion::hyperbolicToTrueAnomalyF32(H, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(f));
+    // Expected value: f = 2*atan(sqrt((e+1)/(e-1))*tanh(H/2))
+    float expected = 2.0f * std::atan(std::sqrt((e_hyperbolic + 1.0f) / (e_hyperbolic - 1.0f)) * std::tanh(H / 2.0f));
+    EXPECT_NEAR(f, expected, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, HyperbolicToTrueAnomaly_RoundTrip) {
+    float f_original = M_PI / 6.0f;
+    float H = OrbitalMotion::trueToHyperbolicAnomalyF32(f_original, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(H));
+    float f_result = OrbitalMotion::hyperbolicToTrueAnomalyF32(H, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(f_result));
+    EXPECT_NEAR(f_result, f_original, kAnomalyTol);
+}
+
+// Hyperbolic to Mean Anomaly Tests
+TEST_F(AnomalyConversionTest, HyperbolicToMeanAnomaly_HyperbolicOrbit) {
+    float H = 0.5f;
+    float N = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(N));
+    float expected = e_hyperbolic * std::sinh(H) - H;
+    EXPECT_NEAR(N, expected, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, HyperbolicToMeanAnomaly_Zero) {
+    float N = OrbitalMotion::hyperbolicToMeanAnomalyF32(0.0f, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(N));
+    EXPECT_NEAR(N, 0.0f, kAnomalyTol);
+}
+
+// Mean to Eccentric Anomaly Tests
+TEST_F(AnomalyConversionTest, MeanToEccentricAnomaly_Circular) {
+    float M = M_PI / 4.0f;
+    float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e_circular);
+    ASSERT_TRUE(std::isfinite(E));
+    EXPECT_NEAR(E, M, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, MeanToEccentricAnomaly_Elliptical) {
+    float M = M_PI / 4.0f;
+    float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e_elliptical);
+    ASSERT_TRUE(std::isfinite(E));
+    // Verify Kepler's equation: M = E - e*sin(E)
+    float M_check = E - e_elliptical * std::sin(E);
+    EXPECT_NEAR(M_check, M, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, MeanToEccentricAnomaly_RoundTrip) {
+    float E_original = M_PI / 4.0f;
+    float M = OrbitalMotion::eccentricToMeanAnomalyF32(E_original, e_elliptical);
+    ASSERT_TRUE(std::isfinite(M));
+    float E_result = OrbitalMotion::meanToEccentricAnomalyF32(M, e_elliptical);
+    ASSERT_TRUE(std::isfinite(E_result));
+    EXPECT_NEAR(E_result, E_original, kAnomalyTol);
+}
+
+// Mean to True Anomaly Tests
+TEST_F(AnomalyConversionTest, MeanToTrueAnomaly_Circular) {
+    float M = M_PI / 4.0f;
+    float f = OrbitalMotion::meanToTrueAnomalyF32(M, e_circular);
+    ASSERT_TRUE(std::isfinite(f));
+    EXPECT_NEAR(f, M, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, MeanToTrueAnomaly_Elliptical) {
+    float M = M_PI / 4.0f;
+    float f = OrbitalMotion::meanToTrueAnomalyF32(M, e_elliptical);
+    ASSERT_TRUE(std::isfinite(f));
+    float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e_elliptical);
+    float expected = OrbitalMotion::eccentricToTrueAnomalyF32(E, e_elliptical);
+    EXPECT_NEAR(f, expected, kAnomalyTol);
+}
+
+// Mean to Hyperbolic Anomaly Tests
+TEST_F(AnomalyConversionTest, MeanToHyperbolicAnomaly_HyperbolicOrbit) {
+    float N = 0.5f;
+    float H = OrbitalMotion::meanToHyperbolicAnomalyF32(N, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(H));
+    // Verify hyperbolic Kepler's equation: N = e*sinh(H) - H
+    float N_check = e_hyperbolic * std::sinh(H) - H;
+    EXPECT_NEAR(N_check, N, kAnomalyTol);
+}
+
+TEST_F(AnomalyConversionTest, MeanToHyperbolicAnomaly_RoundTrip) {
+    float H_original = 0.5f;
+    float N = OrbitalMotion::hyperbolicToMeanAnomalyF32(H_original, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(N));
+    float H_result = OrbitalMotion::meanToHyperbolicAnomalyF32(N, e_hyperbolic);
+    ASSERT_TRUE(std::isfinite(H_result));
+    EXPECT_NEAR(H_result, H_original, kAnomalyTol);
+}
+
+// =============================================================================
+// State Conversion Tests
+// =============================================================================
+
+class StateConversionTest : public ::testing::Test {
+   protected:
+    const double mu = muEarth;
+};
+
+TEST_F(StateConversionTest, CircularOrbit_Conversion) {
+    ClassicalElementsF32 elements;
+    elements.semiMajorAxis = 7000000.0;  // 7000 km
+    elements.eccentricity = 0.0f;
+    elements.inclination = 0.0f;
+    elements.rightAscensionAscendingNode = 0.0f;
+    elements.argPeriapsis = 0.0f;
+    elements.trueAnomaly = 0.0f;
+
+    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
+    for (int j = 0; j < 3; ++j) {
+        ASSERT_TRUE(std::isfinite(state.position[j]));
+        ASSERT_TRUE(std::isfinite(state.velocity[j]));
+    }
+
+    // For circular orbit at true anomaly = 0, position should be along x-axis
+    EXPECT_NEAR(state.position.x(), elements.semiMajorAxis, std::abs(elements.semiMajorAxis) * kStateRelTol);
+    EXPECT_NEAR(state.position.y(), 0.0, kAnomalyTol);
+    EXPECT_NEAR(state.position.z(), 0.0, kAnomalyTol);
+
+    // Velocity should be perpendicular to position
+    double r = state.position.norm();
+    double v = state.velocity.norm();
+    EXPECT_NEAR(state.position.dot(state.velocity), 0.0, r * v * kStateRelTol);
+}
+
+TEST_F(StateConversionTest, EllipticalOrbit_Conversion) {
+    ClassicalElementsF32 elements;
+    elements.semiMajorAxis = 8000000.0;
+    elements.eccentricity = 0.3f;
+    elements.inclination = 0.5f;
+    elements.rightAscensionAscendingNode = 0.2f;
+    elements.argPeriapsis = 0.8f;
+    elements.trueAnomaly = M_PI / 4.0f;
+
+    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
+    for (int j = 0; j < 3; ++j) {
+        ASSERT_TRUE(std::isfinite(state.position[j]));
+        ASSERT_TRUE(std::isfinite(state.velocity[j]));
+    }
+
+    // Check that position and velocity magnitudes make sense
+    double r_mag = state.position.norm();
+    double v_mag = state.velocity.norm();
+
+    EXPECT_GT(r_mag, 0.0);
+    EXPECT_GT(v_mag, 0.0);
+
+    // Check vis-viva equation: v^2 = mu*(2/r - 1/a)
+    double v_squared_expected = mu * (2.0 / r_mag - 1.0 / elements.semiMajorAxis);
+    EXPECT_NEAR(v_mag * v_mag, v_squared_expected, std::abs(v_squared_expected) * kStateRelTol);
+}
+
+TEST_F(StateConversionTest, CartesianToElements_RoundTrip) {
+    ClassicalElementsF32 original;
+    original.semiMajorAxis = 7500000.0;
+    original.eccentricity = 0.2f;
+    original.inclination = 0.3f;
+    original.rightAscensionAscendingNode = 0.5f;
+    original.argPeriapsis = 1.0f;
+    original.trueAnomaly = M_PI / 3.0f;
+
+    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, original);
+    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(mu, state.position, state.velocity);
+
+    EXPECT_NEAR(result.semiMajorAxis, original.semiMajorAxis, std::abs(original.semiMajorAxis) * kStateRelTol);
+    EXPECT_NEAR(result.eccentricity, original.eccentricity, kStateRelTol);
+    EXPECT_NEAR(result.inclination, original.inclination, kStateRelTol);
+    EXPECT_NEAR(result.rightAscensionAscendingNode, original.rightAscensionAscendingNode, kStateRelTol);
+    EXPECT_NEAR(result.argPeriapsis, original.argPeriapsis, kStateRelTol);
+    EXPECT_NEAR(result.trueAnomaly, original.trueAnomaly, kStateRelTol);
+}
+
+TEST_F(StateConversionTest, ElementsToCartesian_RoundTrip) {
+    Eigen::Vector3d r_original(7000000.0, 1000000.0, 500000.0);
+    Eigen::Vector3d v_original(500.0, 7000.0, 100.0);
+
+    ClassicalElementsF32 elements = OrbitalMotion::cartesianStateToElementsF32(mu, r_original, v_original);
+    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
+
+    EXPECT_NEAR(state.position.x(), r_original.x(), std::abs(r_original.x()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.position.y(), r_original.y(), std::abs(r_original.y()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.position.z(), r_original.z(), std::abs(r_original.z()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.velocity.x(), v_original.x(), std::abs(v_original.x()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.velocity.y(), v_original.y(), std::abs(v_original.y()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.velocity.z(), v_original.z(), std::abs(v_original.z()) * kStateRelTol + kAnomalyTol);
+}
+
+TEST_F(StateConversionTest, EquatorialOrbit_NoRAANAmbiguity) {
+    ClassicalElementsF32 elements;
+    elements.semiMajorAxis = 7000000.0;
+    elements.eccentricity = 0.1f;
+    elements.inclination = 0.0f;  // Equatorial
+    elements.rightAscensionAscendingNode = 0.0f;
+    elements.argPeriapsis = M_PI / 4.0f;
+    elements.trueAnomaly = M_PI / 6.0f;
+
+    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
+    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(mu, state.position, state.velocity);
+
+    EXPECT_NEAR(result.inclination, 0.0f, kAnomalyTol);
+}
+
+TEST_F(StateConversionTest, CircularOrbit_NoArgPeriapsisAmbiguity) {
+    ClassicalElementsF32 elements;
+    elements.semiMajorAxis = 7000000.0;
+    elements.eccentricity = 0.0f;  // Circular
+    elements.inclination = 0.5f;
+    elements.rightAscensionAscendingNode = 0.3f;
+    elements.argPeriapsis = 0.0f;
+    elements.trueAnomaly = M_PI / 4.0f;
+
+    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
+    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(mu, state.position, state.velocity);
+
+    EXPECT_NEAR(result.eccentricity, 0.0f, kAnomalyTol);
+}
+
+// =============================================================================
+// Edge Cases Tests
+// =============================================================================
+
+class EdgeCasesTest : public ::testing::Test {};
+
+TEST_F(EdgeCasesTest, NearParabolicOrbit_Eccentricity) {
+    float e = 0.9999f;
+    float f = M_PI / 6.0f;
+
+    float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e);
+    EXPECT_TRUE(std::isfinite(E));
+}
+
+TEST_F(EdgeCasesTest, VerySmallEccentricity) {
+    float e = 1e-6f;
+    float M = M_PI / 4.0f;
+
+    float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e);
+    ASSERT_TRUE(std::isfinite(E));
+    EXPECT_NEAR(E, M, kAnomalyTol);
+}
+
+TEST_F(EdgeCasesTest, LargeHyperbolicEccentricity) {
+    float e = 10.0f;
+    float f = M_PI / 12.0f;
+
+    float H = OrbitalMotion::trueToHyperbolicAnomalyF32(f, e);
+    EXPECT_TRUE(std::isfinite(H));
+}
+
+TEST_F(EdgeCasesTest, PolarOrbit) {
+    ClassicalElementsF32 elements;
+    elements.semiMajorAxis = 7000000.0;
+    elements.eccentricity = 0.0f;
+    elements.inclination = M_PI / 2.0f;  // Polar orbit
+    elements.rightAscensionAscendingNode = 0.0f;
+    elements.argPeriapsis = 0.0f;
+    elements.trueAnomaly = 0.0f;
+
+    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(muEarth, elements);
+    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(muEarth, state.position, state.velocity);
+
+    EXPECT_NEAR(result.inclination, M_PI / 2.0f, kAnomalyTol);
+}
+
+TEST_F(EdgeCasesTest, RetrogradeOrbit) {
+    ClassicalElementsF32 elements;
+    elements.semiMajorAxis = 7000000.0;
+    elements.eccentricity = 0.1f;
+    elements.inclination = 3.0f * M_PI / 4.0f;  // Retrograde
+    elements.rightAscensionAscendingNode = 1.0f;
+    elements.argPeriapsis = 0.5f;
+    elements.trueAnomaly = M_PI / 3.0f;
+
+    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(muEarth, elements);
+    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(muEarth, state.position, state.velocity);
+
+    EXPECT_GT(result.inclination, M_PI / 2.0f);
+}

--- a/algorithms/utilities/_tests/test_orbitalMotion_fuzz.cpp
+++ b/algorithms/utilities/_tests/test_orbitalMotion_fuzz.cpp
@@ -1,0 +1,450 @@
+/*
+ MIT License
+
+ Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+*/
+
+#include "../orbitalMotion.hpp"
+
+#include <fuzztest/fuzztest.h>
+#include <gtest/gtest.h>
+#include <Eigen/Geometry>
+#include <cmath>
+
+// Earth's gravitational parameter (m³/s²)
+constexpr double kMu = 3.986004418e14;
+
+// Semi-major axis used for Keplerian conserved-quantity tests (m).
+// Fixed so the fuzzer can vary the remaining orbital shape parameters freely.
+constexpr double kSemiMajorAxis = 7.0e6;
+
+inline constexpr float kAnomalyTol = 1e-5f;
+inline constexpr double kStateRelTol = 1e-3;
+
+// ============================================================================
+// Elliptic anomaly identities
+// ============================================================================
+
+// Kepler's equation holds exactly: eccentricToMean(E, e) == E − e·sin(E).
+void fuzzKeplersEquation(float E, float e) {
+    const float result = OrbitalMotion::eccentricToMeanAnomalyF32(E, e);
+    ASSERT_TRUE(std::isfinite(result));
+    EXPECT_FLOAT_EQ(result, E - e * sinf(E));
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzKeplersEquation)
+    .WithDomains(fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)),
+                 fuzztest::InRange(0.0f, 0.99f));
+
+// Mean anomaly is odd in eccentric anomaly: M(−E, e) = −M(E, e).
+void fuzzMeanAnomalyIsOdd(float E, float e) {
+    const float pos = OrbitalMotion::eccentricToMeanAnomalyF32(E, e);
+    const float neg = OrbitalMotion::eccentricToMeanAnomalyF32(-E, e);
+    ASSERT_TRUE(std::isfinite(pos));
+    ASSERT_TRUE(std::isfinite(neg));
+    EXPECT_FLOAT_EQ(neg, -pos);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanAnomalyIsOdd)
+    .WithDomains(fuzztest::InRange(0.0f, static_cast<float>(M_PI)), fuzztest::InRange(0.0f, 0.99f));
+
+// The Newton-Raphson solver must return E satisfying E − e·sin(E) = M.
+void fuzzMeanToEccentricSolvesKepler(float M, float e) {
+    const float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e);
+    ASSERT_TRUE(std::isfinite(E));
+    EXPECT_NEAR(E - e * sinf(E), M, kAnomalyTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanToEccentricSolvesKepler)
+    .WithDomains(fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)),
+                 fuzztest::InRange(0.0f, 0.99f));
+
+// E → f → E closed-form round-trip.
+void fuzzEccentricTrueRoundTrip(float E, float e) {
+    const float f = OrbitalMotion::eccentricToTrueAnomalyF32(E, e);
+    ASSERT_TRUE(std::isfinite(f));
+    const float E_back = OrbitalMotion::trueToEccentricAnomalyF32(f, e);
+    ASSERT_TRUE(std::isfinite(E_back));
+    EXPECT_NEAR(E_back, E, kAnomalyTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzEccentricTrueRoundTrip)
+    .WithDomains(fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)),
+                 fuzztest::InRange(0.0f, 0.99f));
+
+// M → E → M round-trip: meanToEccentric then eccentricToMean must recover M.
+void fuzzMeanEccentricRoundTrip(float M, float e) {
+    const float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e);
+    ASSERT_TRUE(std::isfinite(E));
+    const float M_back = OrbitalMotion::eccentricToMeanAnomalyF32(E, e);
+    ASSERT_TRUE(std::isfinite(M_back));
+    EXPECT_NEAR(M_back, M, kAnomalyTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanEccentricRoundTrip)
+    .WithDomains(fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)),
+                 fuzztest::InRange(0.0f, 0.99f));
+
+// ============================================================================
+// Hyperbolic anomaly identities
+// ============================================================================
+
+// Hyperbolic Kepler's equation: hyperbolicToMean(H, e) == e·sinh(H) − H.
+void fuzzHyperbolicKeplersEquation(float H, float e) {
+    const float result = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e);
+    ASSERT_TRUE(std::isfinite(result));
+    EXPECT_FLOAT_EQ(result, e * sinhf(H) - H);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicKeplersEquation)
+    .WithDomains(fuzztest::InRange(-3.0f, 3.0f), fuzztest::InRange(1.05f, 5.0f));
+
+// Hyperbolic mean anomaly is odd: N(−H, e) = −N(H, e).
+void fuzzHyperbolicMeanIsOdd(float H, float e) {
+    const float pos = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e);
+    const float neg = OrbitalMotion::hyperbolicToMeanAnomalyF32(-H, e);
+    ASSERT_TRUE(std::isfinite(pos));
+    ASSERT_TRUE(std::isfinite(neg));
+    EXPECT_FLOAT_EQ(neg, -pos);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicMeanIsOdd)
+    .WithDomains(fuzztest::InRange(0.0f, 3.0f), fuzztest::InRange(1.05f, 5.0f));
+
+// The Newton-Raphson solver must return H satisfying e·sinh(H) − H = N.
+void fuzzMeanToHyperbolicSolvesKepler(float N, float e) {
+    const float H = OrbitalMotion::meanToHyperbolicAnomalyF32(N, e);
+    ASSERT_TRUE(std::isfinite(H));
+    EXPECT_NEAR(e * sinhf(H) - H, N, kAnomalyTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanToHyperbolicSolvesKepler)
+    .WithDomains(fuzztest::InRange(-5.0f, 5.0f), fuzztest::InRange(1.01f, 10.0f));
+
+// H → f → H closed-form round-trip.
+void fuzzHyperbolicTrueRoundTrip(float H, float e) {
+    const float f = OrbitalMotion::hyperbolicToTrueAnomalyF32(H, e);
+    ASSERT_TRUE(std::isfinite(f));
+    const float H_back = OrbitalMotion::trueToHyperbolicAnomalyF32(f, e);
+    ASSERT_TRUE(std::isfinite(H_back));
+    EXPECT_NEAR(H_back, H, kAnomalyTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicTrueRoundTrip)
+    .WithDomains(fuzztest::InRange(-2.0f, 2.0f), fuzztest::InRange(1.01f, 10.0f));
+
+// N → H → N round-trip: meanToHyperbolic then hyperbolicToMean must recover N.
+void fuzzHyperbolicMeanRoundTrip(float N, float e) {
+    const float H = OrbitalMotion::meanToHyperbolicAnomalyF32(N, e);
+    ASSERT_TRUE(std::isfinite(H));
+    const float N_back = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e);
+    ASSERT_TRUE(std::isfinite(N_back));
+    EXPECT_NEAR(N_back, N, kAnomalyTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicMeanRoundTrip)
+    .WithDomains(fuzztest::InRange(-5.0f, 5.0f), fuzztest::InRange(1.01f, 10.0f));
+
+// ============================================================================
+// Keplerian conserved quantities
+// ============================================================================
+
+// Vis-viva equation: v² = μ (2/r − 1/a)
+void fuzzVisViva(float e, float i, float Omega, float omega, float f) {
+    ClassicalElementsF32 el;
+    el.semiMajorAxis = kSemiMajorAxis;
+    el.eccentricity = e;
+    el.inclination = i;
+    el.rightAscensionAscendingNode = Omega;
+    el.argPeriapsis = omega;
+    el.trueAnomaly = f;
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    const double r = state.position.norm();
+    const double v2 = state.velocity.squaredNorm();
+    ASSERT_TRUE(std::isfinite(r));
+    ASSERT_TRUE(std::isfinite(v2));
+    const double v2_expected = kMu * (2.0 / r - 1.0 / kSemiMajorAxis);
+    EXPECT_NEAR(v2, v2_expected, v2_expected * kStateRelTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzVisViva)
+    .WithDomains(fuzztest::InRange(0.0f, 0.9f),
+                 fuzztest::InRange(0.0f, static_cast<float>(M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+
+// Specific orbital energy: v²/2 − μ/r = −μ/(2a)
+void fuzzSpecificEnergy(float e, float i, float Omega, float omega, float f) {
+    ClassicalElementsF32 el;
+    el.semiMajorAxis = kSemiMajorAxis;
+    el.eccentricity = e;
+    el.inclination = i;
+    el.rightAscensionAscendingNode = Omega;
+    el.argPeriapsis = omega;
+    el.trueAnomaly = f;
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    const double r = state.position.norm();
+    const double energy = state.velocity.squaredNorm() / 2.0 - kMu / r;
+    const double energy_expected = -kMu / (2.0 * kSemiMajorAxis);
+    ASSERT_TRUE(std::isfinite(energy));
+    EXPECT_NEAR(energy, energy_expected, std::abs(energy_expected) * kStateRelTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzSpecificEnergy)
+    .WithDomains(fuzztest::InRange(0.0f, 0.9f),
+                 fuzztest::InRange(0.0f, static_cast<float>(M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+
+// Angular momentum magnitude: |r × v| = √(μ · a · (1 − e²))
+void fuzzAngularMomentum(float e, float i, float Omega, float omega, float f) {
+    ClassicalElementsF32 el;
+    el.semiMajorAxis = kSemiMajorAxis;
+    el.eccentricity = e;
+    el.inclination = i;
+    el.rightAscensionAscendingNode = Omega;
+    el.argPeriapsis = omega;
+    el.trueAnomaly = f;
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    const double h = state.position.cross(state.velocity).norm();
+    const double h_expected = std::sqrt(kMu * kSemiMajorAxis * (1.0 - static_cast<double>(e) * e));
+    ASSERT_TRUE(std::isfinite(h));
+    EXPECT_NEAR(h, h_expected, h_expected * kStateRelTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzAngularMomentum)
+    .WithDomains(fuzztest::InRange(0.0f, 0.9f),
+                 fuzztest::InRange(0.0f, static_cast<float>(M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+
+// Orbit equation: r = p / (1 + e·cos f)  where p = a(1 − e²).
+void fuzzOrbitEquation(float e, float i, float Omega, float omega, float f) {
+    ClassicalElementsF32 el;
+    el.semiMajorAxis = kSemiMajorAxis;
+    el.eccentricity = e;
+    el.inclination = i;
+    el.rightAscensionAscendingNode = Omega;
+    el.argPeriapsis = omega;
+    el.trueAnomaly = f;
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    const double r = state.position.norm();
+    const double p = kSemiMajorAxis * (1.0 - static_cast<double>(e) * e);
+    const double r_expected = p / (1.0 + e * cosf(f));
+    ASSERT_TRUE(std::isfinite(r));
+    EXPECT_NEAR(r, r_expected, r_expected * kStateRelTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzOrbitEquation)
+    .WithDomains(fuzztest::InRange(0.0f, 0.9f),
+                 fuzztest::InRange(0.0f, static_cast<float>(M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+
+// ============================================================================
+// Elements ↔ Cartesian round-trip
+// ============================================================================
+
+// elementsToCartesian → cartesianToElements must recover semi-major axis,
+// eccentricity, and inclination to within float precision.
+void fuzzElementsRoundTrip(float e, float i, float Omega, float omega, float f) {
+    ClassicalElementsF32 in;
+    in.semiMajorAxis = kSemiMajorAxis;
+    in.eccentricity = e;
+    in.inclination = i;
+    in.rightAscensionAscendingNode = Omega;
+    in.argPeriapsis = omega;
+    in.trueAnomaly = f;
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, in);
+    const ClassicalElementsF32 out = OrbitalMotion::cartesianStateToElementsF32(kMu, state.position, state.velocity);
+
+    EXPECT_NEAR(out.semiMajorAxis, in.semiMajorAxis, in.semiMajorAxis * kStateRelTol);
+    EXPECT_NEAR(out.eccentricity, in.eccentricity, kStateRelTol);
+    EXPECT_NEAR(out.inclination, in.inclination, kStateRelTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzElementsRoundTrip)
+    .WithDomains(fuzztest::InRange(0.01f, 0.9f),
+                 fuzztest::InRange(0.05f, static_cast<float>(M_PI) - 0.05f),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+
+// ============================================================================
+// Near-circular and equatorial round-trip singularity tests
+// ============================================================================
+
+// e ≈ 0: argPeriapsis is undefined, but a, e, i should round-trip.
+void fuzzNearCircularRoundTrip(float e, float i, float Omega, float omega, float f) {
+    ClassicalElementsF32 in;
+    in.semiMajorAxis = kSemiMajorAxis;
+    in.eccentricity = e;
+    in.inclination = i;
+    in.rightAscensionAscendingNode = Omega;
+    in.argPeriapsis = omega;
+    in.trueAnomaly = f;
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, in);
+    const ClassicalElementsF32 out = OrbitalMotion::cartesianStateToElementsF32(kMu, state.position, state.velocity);
+
+    EXPECT_NEAR(out.semiMajorAxis, in.semiMajorAxis, in.semiMajorAxis * kStateRelTol);
+    EXPECT_NEAR(out.eccentricity, in.eccentricity, kStateRelTol);
+    EXPECT_NEAR(out.inclination, in.inclination, kStateRelTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzNearCircularRoundTrip)
+    .WithDomains(fuzztest::InRange(0.0f, 0.001f),
+                 fuzztest::InRange(0.05f, static_cast<float>(M_PI) - 0.05f),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+
+// i ≈ 0: RAAN is undefined, but a, e, i should round-trip.
+void fuzzEquatorialRoundTrip(float e, float i, float Omega, float omega, float f) {
+    ClassicalElementsF32 in;
+    in.semiMajorAxis = kSemiMajorAxis;
+    in.eccentricity = e;
+    in.inclination = i;
+    in.rightAscensionAscendingNode = Omega;
+    in.argPeriapsis = omega;
+    in.trueAnomaly = f;
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, in);
+    const ClassicalElementsF32 out = OrbitalMotion::cartesianStateToElementsF32(kMu, state.position, state.velocity);
+
+    EXPECT_NEAR(out.semiMajorAxis, in.semiMajorAxis, in.semiMajorAxis * kStateRelTol);
+    EXPECT_NEAR(out.eccentricity, in.eccentricity, kStateRelTol);
+    EXPECT_NEAR(out.inclination, in.inclination, kStateRelTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzEquatorialRoundTrip)
+    .WithDomains(fuzztest::InRange(0.05f, 0.5f),
+                 fuzztest::InRange(0.0f, 0.001f),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
+                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+
+// ============================================================================
+// All-anomaly finiteness
+// ============================================================================
+
+// Every anomaly conversion function must return finite for valid inputs.
+void fuzzAllAnomalyConversionsFinite(float e, float angle) {
+    if (e < 1.0f) {
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToTrueAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToEccentricAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToMeanAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToMeanAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::meanToEccentricAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::meanToTrueAnomalyF32(angle, e)));
+    } else {
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToTrueAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToMeanAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::meanToHyperbolicAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToHyperbolicAnomalyF32(angle, e)));
+    }
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzAllAnomalyConversionsFinite)
+    .WithDomains(fuzztest::InRange(0.0f, 0.9999f),
+                 fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)));
+
+// ============================================================================
+// Near-parabolic and near-rectilinear degenerate cases
+// ============================================================================
+
+// Closed-form anomaly functions must return finite values for e → 1⁻.
+void fuzzNearParabolicEllipticAnomalyFinite(float f, float e) {
+    const float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e);
+    const float fb = OrbitalMotion::eccentricToTrueAnomalyF32(E, e);
+    const float M = OrbitalMotion::eccentricToMeanAnomalyF32(E, e);
+    const float M2 = OrbitalMotion::trueToMeanAnomalyF32(f, e);
+    EXPECT_TRUE(std::isfinite(E)) << "trueToEccentric";
+    EXPECT_TRUE(std::isfinite(fb)) << "eccentricToTrue";
+    EXPECT_TRUE(std::isfinite(M)) << "eccentricToMean";
+    EXPECT_TRUE(std::isfinite(M2)) << "trueToMean";
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicEllipticAnomalyFinite)
+    .WithDomains(fuzztest::InRange(-0.8f, 0.8f), fuzztest::InRange(0.9f, 0.9999f));
+
+// elementsToCartesianStateF32 must return a finite Cartesian state for e → 1⁻.
+void fuzzNearParabolicCartesianFinite(float e, float f) {
+    ClassicalElementsF32 el;
+    el.semiMajorAxis = 7.0e6 / (1.0 - e);
+    el.eccentricity = e;
+    el.inclination = 0.3f;
+    el.rightAscensionAscendingNode = 0.0f;
+    el.argPeriapsis = 0.0f;
+    el.trueAnomaly = f;
+
+    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_TRUE(std::isfinite(state.position[i])) << "position[" << i << ']';
+        EXPECT_TRUE(std::isfinite(state.velocity[i])) << "velocity[" << i << ']';
+    }
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicCartesianFinite)
+    .WithDomains(fuzztest::InRange(0.9f, 0.9999f), fuzztest::InRange(0.0f, 1.0f));
+
+// Hyperbolic anomaly functions must stay finite for e just above 1.
+void fuzzNearParabolicHyperbolicAnomalyFinite(float H, float e) {
+    const float N = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e);
+    const float f = OrbitalMotion::hyperbolicToTrueAnomalyF32(H, e);
+    EXPECT_TRUE(std::isfinite(N)) << "hyperbolicToMean";
+    EXPECT_TRUE(std::isfinite(f)) << "hyperbolicToTrue";
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicHyperbolicAnomalyFinite)
+    .WithDomains(fuzztest::InRange(-0.5f, 0.5f), fuzztest::InRange(1.0001f, 1.1f));
+
+// Rectilinear orbit: h=0 singularity. v_transverse = 0, all outputs must be finite.
+void fuzzRectilinearElementsFinite(double v_radial) {
+    const Eigen::Vector3d r_vec(7.0e6, 0.0, 0.0);
+    const Eigen::Vector3d v_vec(v_radial, 0.0, 0.0);
+
+    const ClassicalElementsF32 el = OrbitalMotion::cartesianStateToElementsF32(kMu, r_vec, v_vec);
+
+    EXPECT_TRUE(std::isfinite(el.semiMajorAxis)) << "sma";
+    EXPECT_TRUE(std::isfinite(el.eccentricity)) << "ecc";
+    EXPECT_TRUE(std::isfinite(el.inclination)) << "inc";
+    EXPECT_TRUE(std::isfinite(el.rightAscensionAscendingNode)) << "raan";
+    EXPECT_TRUE(std::isfinite(el.argPeriapsis)) << "aop";
+    EXPECT_TRUE(std::isfinite(el.trueAnomaly)) << "ta";
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzRectilinearElementsFinite).WithDomains(fuzztest::InRange(-8000.0, 8000.0));
+
+// Near-rectilinear orbits (tiny transverse velocity), all outputs finite.
+void fuzzNearRectilinearElementsFinite(double v_radial, double v_transverse) {
+    const Eigen::Vector3d r_vec(7.0e6, 0.0, 0.0);
+    const Eigen::Vector3d v_vec(v_radial, 0.0, v_transverse);
+
+    const ClassicalElementsF32 el = OrbitalMotion::cartesianStateToElementsF32(kMu, r_vec, v_vec);
+
+    EXPECT_TRUE(std::isfinite(el.semiMajorAxis)) << "sma";
+    EXPECT_TRUE(std::isfinite(el.eccentricity)) << "ecc";
+    EXPECT_TRUE(std::isfinite(el.inclination)) << "inc";
+    EXPECT_TRUE(std::isfinite(el.rightAscensionAscendingNode)) << "raan";
+    EXPECT_TRUE(std::isfinite(el.argPeriapsis)) << "aop";
+    EXPECT_TRUE(std::isfinite(el.trueAnomaly)) << "ta";
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzNearRectilinearElementsFinite)
+    .WithDomains(fuzztest::InRange(-8000.0, 8000.0), fuzztest::InRange(0.01, 100.0));
+
+// Parabolic boundary: e = 1.0 exactly. All closed-form anomaly functions finite.
+void fuzzParabolicAnomalyFinite(float angle) {
+    const float E = OrbitalMotion::trueToEccentricAnomalyF32(angle, 1.0f);
+    const float f = OrbitalMotion::eccentricToTrueAnomalyF32(angle, 1.0f);
+    const float M = OrbitalMotion::eccentricToMeanAnomalyF32(angle, 1.0f);
+    const float M2 = OrbitalMotion::trueToMeanAnomalyF32(angle, 1.0f);
+    EXPECT_TRUE(std::isfinite(E)) << "trueToEccentric";
+    EXPECT_TRUE(std::isfinite(f)) << "eccentricToTrue";
+    EXPECT_TRUE(std::isfinite(M)) << "eccentricToMean";
+    EXPECT_TRUE(std::isfinite(M2)) << "trueToMean";
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzParabolicAnomalyFinite).WithDomains(fuzztest::InRange(-0.8f, 0.8f));
+
+// Straddles the elliptic/hyperbolic boundary: e in [0.999, 1.001].
+void fuzzParabolicHyperbolicBoundary(float e, float angle) {
+    if (e < 1.0f) {
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToEccentricAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToTrueAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToMeanAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToMeanAnomalyF32(angle, e)));
+    } else if (e > 1.0f) {
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToTrueAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToMeanAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToHyperbolicAnomalyF32(angle, e)));
+    }
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzParabolicHyperbolicBoundary)
+    .WithDomains(fuzztest::InRange(0.999f, 1.001f), fuzztest::InRange(-0.8f, 0.8f));

--- a/algorithms/utilities/orbitalMotion.cpp
+++ b/algorithms/utilities/orbitalMotion.cpp
@@ -117,7 +117,7 @@ float OrbitalMotion::meanToEccentricAnomalyF32(float M, float e) {
     for (int i = 0; i < kMaxNumberOfIterations; ++i) {
         float const dE = (E - e * std::sin(E) - M) / (1 - e * std::cos(E));
         E -= fmaxf(-0.5F, fminf(0.5F, dE));  // Clamp step size in case of near parabolic orbits
-        if (fabsf(dE) < kToleranceF32) {
+        if (std::abs(dE) < kToleranceF32) {
             break;
         }
     }
@@ -226,7 +226,7 @@ ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
     elements.radiusMagnitude = r;
     elements.eccentricity = static_cast<float>(eVec.norm());
     if (h < kTolerance) {
-        elements.inclination = 0.0F; // rectilinear orbit
+        elements.inclination = 0.0F;  // rectilinear orbit
     } else {
         elements.inclination = static_cast<float>(std::acos(hVec(2) / h));
     }
@@ -243,8 +243,8 @@ ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
     elements.trueAnomaly = f < 0 ? static_cast<float>(f + (2 * std::numbers::pi)) : f;
 
     elements.radiusPeriapsis = h * h / mu / (1 + elements.eccentricity);
-    if (fabsf(elements.eccentricity - 1) < kTolerance) {
-        elements.radiusApoapsis = 0.0F; // parabolic orbit
+    if (std::abs(elements.eccentricity - 1) < kTolerance) {
+        elements.radiusApoapsis = 0.0F;  // parabolic orbit
     } else {
         elements.radiusApoapsis = h * h / mu / (1 - elements.eccentricity);
     }

--- a/algorithms/utilities/orbitalMotion.cpp
+++ b/algorithms/utilities/orbitalMotion.cpp
@@ -18,7 +18,9 @@
  */
 
 #include "orbitalMotion.hpp"
+#include <Eigen/Geometry>
 #include <numbers>
+#include "safeMathFloat.h"
 
 inline constexpr int kMaxNumberOfIterations = 200;
 inline constexpr float kClamp = 7;

--- a/algorithms/utilities/orbitalMotion.cpp
+++ b/algorithms/utilities/orbitalMotion.cpp
@@ -20,7 +20,10 @@
 #include "orbitalMotion.hpp"
 #include <numbers>
 
-constexpr double tolerance = 1e-8;
+inline constexpr int kMaxNumberOfIterations = 200;
+inline constexpr float kClamp = 7;
+inline constexpr float kToleranceF32 = 1e-6;
+inline constexpr double kTolerance = 1e-9;
 
 /**
  * @brief Converts eccentric anomaly to true anomaly.
@@ -109,10 +112,12 @@ float OrbitalMotion::hyperbolicToMeanAnomalyF32(float const H, float const e) {
 float OrbitalMotion::meanToEccentricAnomalyF32(float M, float e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
     float E = M;
-    for (int i = 0; i < 200; ++i) {
+    for (int i = 0; i < kMaxNumberOfIterations; ++i) {
         float const dE = (E - e * std::sin(E) - M) / (1 - e * std::cos(E));
-        E -= dE;
-        if (std::abs(dE) < tolerance) break;
+        E -= fmaxf(-0.5F, fminf(0.5F, dE));  // Clamp step size in case of near parabolic orbits
+        if (fabsf(dE) < kToleranceF32) {
+            break;
+        }
     }
     return E;
 }
@@ -137,11 +142,14 @@ float OrbitalMotion::meanToTrueAnomalyF32(float const M, float const e) {
  */
 float OrbitalMotion::meanToHyperbolicAnomalyF32(const float N, const float e) {
     assert(e > 1.0 && "Eccentricity must be > 1");
-    float H = std::abs(N) > 7 ? 7 * (N > 0 ? 1 : -1) : N;
-    for (int i = 0; i < 200; ++i) {
+    const int signN = (N > 0 ? 1 : -1);
+    float H = std::abs(N) > kClamp ? kClamp * static_cast<float>(signN) : N;
+    for (int i = 0; i < kMaxNumberOfIterations; ++i) {
         const float dH = (e * std::sinh(H) - H - N) / (e * std::cosh(H) - 1);
         H -= dH;
-        if (std::abs(dH) < tolerance) break;
+        if (std::abs(dH) < kToleranceF32) {
+            break;
+        }
     }
     return H;
 }
@@ -217,7 +225,7 @@ ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
     elements.eccentricity = static_cast<float>(eVec.norm());
     elements.inclination = static_cast<float>(std::acos(hVec(2) / h));
     elements.alpha = (2 / r) - (v * v / mu);
-    elements.semiMajorAxis = std::abs(elements.alpha) > tolerance ? 1 / elements.alpha : 0.0;
+    elements.semiMajorAxis = fabs(elements.alpha) > kTolerance ? 1 / elements.alpha : 0.0;
 
     auto Omega = static_cast<float>(std::atan2(nVec(1), nVec(0)));
     elements.rightAscensionAscendingNode = Omega < 0 ? static_cast<float>(Omega + (2 * std::numbers::pi)) : Omega;

--- a/algorithms/utilities/orbitalMotion.cpp
+++ b/algorithms/utilities/orbitalMotion.cpp
@@ -18,9 +18,10 @@
  */
 
 #include "orbitalMotion.hpp"
+#include "safeMath.h"
+#include <math.h>
 #include <Eigen/Geometry>
 #include <numbers>
-#include "safeMathFloat.h"
 
 inline constexpr int kMaxNumberOfIterations = 200;
 inline constexpr float kClamp = 7;
@@ -35,7 +36,7 @@ inline constexpr double kTolerance = 1e-9;
  */
 float OrbitalMotion::eccentricToTrueAnomalyF32(float const E, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    return 2 * std::atan2(std::sqrt(1 + e) * std::sin(E / 2), std::sqrt(1 - e) * std::cos(E / 2));
+    return 2 * safeAtan2f(safeSqrtf(1 + e) * safeSinf(E / 2), safeSqrtf(1 - e) * safeCosf(E / 2));
 }
 
 /**
@@ -46,7 +47,7 @@ float OrbitalMotion::eccentricToTrueAnomalyF32(float const E, float const e) {
  */
 float OrbitalMotion::eccentricToMeanAnomalyF32(float const E, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    return E - (e * std::sin(E));
+    return E - (e * safeSinf(E));
 }
 
 /**
@@ -57,7 +58,7 @@ float OrbitalMotion::eccentricToMeanAnomalyF32(float const E, float const e) {
  */
 float OrbitalMotion::trueToEccentricAnomalyF32(float const f, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    return 2 * std::atan2(std::sqrt(1 - e) * std::sin(f / 2), std::sqrt(1 + e) * std::cos(f / 2));
+    return 2 * safeAtan2f(safeSqrtf(1 - e) * safeSinf(f / 2), safeSqrtf(1 + e) * safeCosf(f / 2));
 }
 
 /**
@@ -80,7 +81,7 @@ float OrbitalMotion::trueToMeanAnomalyF32(float const f, float const e) {
  */
 float OrbitalMotion::trueToHyperbolicAnomalyF32(float const f, float const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
-    return 2 * std::atanh(std::sqrt((e - 1) / (e + 1)) * std::tan(f / 2));
+    return 2 * safeAtanHf(safeSqrtf((e - 1) / (e + 1)) * safeTanf(f / 2));
 }
 
 /**
@@ -91,7 +92,7 @@ float OrbitalMotion::trueToHyperbolicAnomalyF32(float const f, float const e) {
  */
 float OrbitalMotion::hyperbolicToTrueAnomalyF32(float const H, float const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
-    return 2 * std::atan(std::sqrt((e + 1) / (e - 1)) * std::tanh(H / 2));
+    return 2 * safeAtanf(safeSqrtf((e + 1) / (e - 1)) * safeTanHf(H / 2));
 }
 
 /**
@@ -102,7 +103,7 @@ float OrbitalMotion::hyperbolicToTrueAnomalyF32(float const H, float const e) {
  */
 float OrbitalMotion::hyperbolicToMeanAnomalyF32(float const H, float const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
-    return (e * std::sinh(H)) - H;
+    return (e * safeSinHf(H)) - H;
 }
 
 /**
@@ -115,9 +116,9 @@ float OrbitalMotion::meanToEccentricAnomalyF32(float M, float e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
     float E = M;
     for (int i = 0; i < kMaxNumberOfIterations; ++i) {
-        float const dE = (E - e * std::sin(E) - M) / (1 - e * std::cos(E));
+        float const dE = (E - e * safeSinf(E) - M) / (1 - e * safeCosf(E));
         E -= fmaxf(-0.5F, fminf(0.5F, dE));  // Clamp step size in case of near parabolic orbits
-        if (std::abs(dE) < kToleranceF32) {
+        if (fabsf(dE) < kToleranceF32) {
             break;
         }
     }
@@ -145,11 +146,11 @@ float OrbitalMotion::meanToTrueAnomalyF32(float const M, float const e) {
 float OrbitalMotion::meanToHyperbolicAnomalyF32(const float N, const float e) {
     assert(e > 1.0 && "Eccentricity must be > 1");
     const int signN = (N > 0 ? 1 : -1);
-    float H = std::abs(N) > kClamp ? kClamp * static_cast<float>(signN) : N;
+    float H = fabsf(N) > kClamp ? kClamp * static_cast<float>(signN) : N;
     for (int i = 0; i < kMaxNumberOfIterations; ++i) {
-        const float dH = (e * std::sinh(H) - H - N) / (e * std::cosh(H) - 1);
+        const float dH = (e * safeSinHf(H) - H - N) / (e * safeCosHf(H) - 1);
         H -= dH;
-        if (std::abs(dH) < kToleranceF32) {
+        if (fabsf(dH) < kToleranceF32) {
             break;
         }
     }
@@ -171,17 +172,17 @@ CartesianState OrbitalMotion::elementsToCartesianStateF32(double const mu, const
     float const f = elements.trueAnomaly;
 
     double const p = a * (1 - e * e);
-    double const r = p / (1 + e * std::cos(f));
-    double const h = std::sqrt(mu * p);
+    double const r = p / (1 + e * safeCosf(f));
+    double const h = safeSqrt(mu * p);
 
-    float const cos_O = std::cos(Omega);
-    float const sin_O = std::sin(Omega);
-    float const cos_o = std::cos(omega);
-    float const sin_o = std::sin(omega);
-    float const cos_i = std::cos(i);
-    float const sin_i = std::sin(i);
-    float const cos_f = std::cos(f);
-    float const sin_f = std::sin(f);
+    float const cos_O = safeCosf(Omega);
+    float const sin_O = safeSinf(Omega);
+    float const cos_o = safeCosf(omega);
+    float const sin_o = safeSinf(omega);
+    float const cos_i = safeCosf(i);
+    float const sin_i = safeSinf(i);
+    float const cos_f = safeCosf(f);
+    float const sin_f = safeSinf(f);
 
     float const cos_theta = (cos_o * cos_f) - (sin_o * sin_f);
     float const sin_theta = (sin_o * cos_f) + (cos_o * sin_f);
@@ -233,17 +234,17 @@ ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
     elements.alpha = (2 / r) - (v * v / mu);
     elements.semiMajorAxis = fabs(elements.alpha) > kTolerance ? 1 / elements.alpha : 0.0;
 
-    auto Omega = static_cast<float>(std::atan2(nVec(1), nVec(0)));
+    auto Omega = static_cast<float>(safeAtan2(nVec(1), nVec(0)));
     elements.rightAscensionAscendingNode = Omega < 0 ? static_cast<float>(Omega + (2 * std::numbers::pi)) : Omega;
 
-    auto omega = static_cast<float>(std::atan2(nVec.cross(eVec).dot(hVec.normalized()), nVec.dot(eVec)));
+    auto omega = static_cast<float>(safeAtan2(nVec.cross(eVec).dot(hVec.normalized()), nVec.dot(eVec)));
     elements.argPeriapsis = omega < 0 ? static_cast<float>(omega + (2 * std::numbers::pi)) : omega;
 
-    auto f = static_cast<float>(std::atan2(eVec.cross(rVec).dot(hVec.normalized()), eVec.dot(rVec)));
+    auto f = static_cast<float>(safeAtan2(eVec.cross(rVec).dot(hVec.normalized()), eVec.dot(rVec)));
     elements.trueAnomaly = f < 0 ? static_cast<float>(f + (2 * std::numbers::pi)) : f;
 
     elements.radiusPeriapsis = h * h / mu / (1 + elements.eccentricity);
-    if (std::abs(elements.eccentricity - 1) < kTolerance) {
+    if (fabsf(elements.eccentricity - 1) < kTolerance) {
         elements.radiusApoapsis = 0.0F;  // parabolic orbit
     } else {
         elements.radiusApoapsis = h * h / mu / (1 - elements.eccentricity);

--- a/algorithms/utilities/orbitalMotion.cpp
+++ b/algorithms/utilities/orbitalMotion.cpp
@@ -28,7 +28,7 @@ constexpr double tolerance = 1e-8;
  * @param e Orbital eccentricity.
  * @return True anomaly in radians.
  */
-float OrbitalMotion::eccentricToTrueAnomalyF32(float E, float e) {
+float OrbitalMotion::eccentricToTrueAnomalyF32(float const E, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
     return 2.0 * std::atan2(std::sqrt(1 + e) * std::sin(E / 2), std::sqrt(1 - e) * std::cos(E / 2));
 }
@@ -39,7 +39,7 @@ float OrbitalMotion::eccentricToTrueAnomalyF32(float E, float e) {
  * @param e Orbital eccentricity.
  * @return Mean anomaly in radians.
  */
-float OrbitalMotion::eccentricToMeanAnomalyF32(float E, float e) {
+float OrbitalMotion::eccentricToMeanAnomalyF32(float const E, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
     return E - e * std::sin(E);
 }
@@ -50,7 +50,7 @@ float OrbitalMotion::eccentricToMeanAnomalyF32(float E, float e) {
  * @param e Orbital eccentricity.
  * @return Eccentric anomaly in radians.
  */
-float OrbitalMotion::trueToEccentricAnomalyF32(float f, float e) {
+float OrbitalMotion::trueToEccentricAnomalyF32(float const f, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
     return 2.0 * std::atan2(std::sqrt(1 - e) * std::sin(f / 2), std::sqrt(1 + e) * std::cos(f / 2));
 }
@@ -61,9 +61,9 @@ float OrbitalMotion::trueToEccentricAnomalyF32(float f, float e) {
  * @param e Orbital eccentricity (0 <= e < 1).
  * @return Mean anomaly in radians.
  */
-float OrbitalMotion::trueToMeanAnomalyF32(float f, float e) {
+float OrbitalMotion::trueToMeanAnomalyF32(float const f, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    float eccentric = trueToEccentricAnomalyF32(f, e);
+    float const eccentric = trueToEccentricAnomalyF32(f, e);
     return eccentricToMeanAnomalyF32(eccentric, e);
 }
 
@@ -73,7 +73,7 @@ float OrbitalMotion::trueToMeanAnomalyF32(float f, float e) {
  * @param e Orbital eccentricity (> 1).
  * @return Hyperbolic anomaly in radians.
  */
-float OrbitalMotion::trueToHyperbolicAnomalyF32(float f, float e) {
+float OrbitalMotion::trueToHyperbolicAnomalyF32(float const f, float const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
     return 2.0 * std::atanh(std::sqrt((e - 1) / (e + 1)) * std::tan(f / 2));
 }
@@ -84,7 +84,7 @@ float OrbitalMotion::trueToHyperbolicAnomalyF32(float f, float e) {
  * @param e Orbital eccentricity (> 1).
  * @return True anomaly in radians.
  */
-float OrbitalMotion::hyperbolicToTrueAnomalyF32(float H, float e) {
+float OrbitalMotion::hyperbolicToTrueAnomalyF32(float const H, float const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
     return 2.0 * std::atan(std::sqrt((e + 1) / (e - 1)) * std::tanh(H / 2));
 }
@@ -95,7 +95,7 @@ float OrbitalMotion::hyperbolicToTrueAnomalyF32(float H, float e) {
  * @param e Orbital eccentricity (> 1).
  * @return Mean hyperbolic anomaly in radians.
  */
-float OrbitalMotion::hyperbolicToMeanAnomalyF32(float H, float e) {
+float OrbitalMotion::hyperbolicToMeanAnomalyF32(float const H, float const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
     return e * std::sinh(H) - H;
 }
@@ -123,9 +123,9 @@ float OrbitalMotion::meanToEccentricAnomalyF32(float M, float e) {
  * @param e Orbital eccentricity (0 <= e < 1).
  * @return True anomaly in radians.
  */
-float OrbitalMotion::meanToTrueAnomalyF32(float M, float e) {
+float OrbitalMotion::meanToTrueAnomalyF32(float const M, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    float eccentric = meanToEccentricAnomalyF32(M, e);
+    float const eccentric = meanToEccentricAnomalyF32(M, e);
     return eccentricToTrueAnomalyF32(eccentric, e);
 }
 
@@ -135,11 +135,11 @@ float OrbitalMotion::meanToTrueAnomalyF32(float M, float e) {
  * @param e Orbital eccentricity (> 1).
  * @return Hyperbolic anomaly in radians.
  */
-float OrbitalMotion::meanToHyperbolicAnomalyF32(float N, float e) {
+float OrbitalMotion::meanToHyperbolicAnomalyF32(const float N, const float e) {
     assert(e > 1.0 && "Eccentricity must be > 1");
     float H = std::abs(N) > 7.0 ? 7.0 * (N > 0 ? 1 : -1) : N;
     for (int i = 0; i < 200; ++i) {
-        float dH = (e * std::sinh(H) - H - N) / (e * std::cosh(H) - 1);
+        const float dH = (e * std::sinh(H) - H - N) / (e * std::cosh(H) - 1);
         H -= dH;
         if (std::abs(dH) < tolerance) break;
     }
@@ -152,38 +152,38 @@ float OrbitalMotion::meanToHyperbolicAnomalyF32(float N, float e) {
  * @param elements Classical orbital elements (a, e, i, Omega, omega, f).
  * @param CartesianState Output: position and velocity vectors in km and km/s.
  */
-CartesianState OrbitalMotion::elementsToCartesianStateF32(double mu, const ClassicalElementsF32& elements) {
-    double a = elements.semiMajorAxis;
-    float e = elements.eccentricity;
-    float i = elements.inclination;
-    float Omega = elements.rightAscensionAscendingNode;
-    float omega = elements.argPeriapsis;
-    float f = elements.trueAnomaly;
+CartesianState OrbitalMotion::elementsToCartesianStateF32(double const mu, const ClassicalElementsF32& elements) {
+    double const a = elements.semiMajorAxis;
+    float const e = elements.eccentricity;
+    float const i = elements.inclination;
+    float const Omega = elements.rightAscensionAscendingNode;
+    float const omega = elements.argPeriapsis;
+    float const f = elements.trueAnomaly;
 
-    double p = a * (1 - e * e);
-    double r = p / (1 + e * std::cos(f));
-    double h = std::sqrt(mu * p);
+    double const p = a * (1 - e * e);
+    double const r = p / (1 + e * std::cos(f));
+    double const h = std::sqrt(mu * p);
 
-    float cos_O = std::cos(Omega);
-    float sin_O = std::sin(Omega);
-    float cos_o = std::cos(omega);
-    float sin_o = std::sin(omega);
-    float cos_i = std::cos(i);
-    float sin_i = std::sin(i);
-    float cos_f = std::cos(f);
-    float sin_f = std::sin(f);
+    float const cos_O = std::cos(Omega);
+    float const sin_O = std::sin(Omega);
+    float const cos_o = std::cos(omega);
+    float const sin_o = std::sin(omega);
+    float const cos_i = std::cos(i);
+    float const sin_i = std::sin(i);
+    float const cos_f = std::cos(f);
+    float const sin_f = std::sin(f);
 
-    float cos_theta = cos_o * cos_f - sin_o * sin_f;
-    float sin_theta = sin_o * cos_f + cos_o * sin_f;
+    float const cos_theta = (cos_o * cos_f) - (sin_o * sin_f);
+    float const sin_theta = (sin_o * cos_f) + (cos_o * sin_f);
 
     Eigen::Vector3d rVec{};
     rVec(0) = r * (cos_O * cos_theta - sin_O * sin_theta * cos_i);
     rVec(1) = r * (sin_O * cos_theta + cos_O * sin_theta * cos_i);
     rVec(2) = r * (sin_theta * sin_i);
 
-    double vx = -mu / h * (cos_O * (sin_theta + e * sin_o) + sin_O * (cos_theta + e * cos_o) * cos_i);
-    double vy = -mu / h * (sin_O * (sin_theta + e * sin_o) - cos_O * (cos_theta + e * cos_o) * cos_i);
-    double vz = mu / h * (cos_theta + e * cos_o) * sin_i;
+    double const vx = -mu / h * (cos_O * (sin_theta + e * sin_o) + sin_O * (cos_theta + e * cos_o) * cos_i);
+    double const vy = -mu / h * (sin_O * (sin_theta + e * sin_o) - cos_O * (cos_theta + e * cos_o) * cos_i);
+    double const vz = mu / h * (cos_theta + e * cos_o) * sin_i;
 
     const Eigen::Vector3d vVec = Eigen::Vector3d(vx, vy, vz);
 
@@ -201,13 +201,13 @@ CartesianState OrbitalMotion::elementsToCartesianStateF32(double mu, const Class
  * @param vVec Velocity vector in km/s.
  * @return elements : classical orbital elements (a, e, i, Omega, omega, f).
  */
-ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(double mu,
+ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
                                                                 const Eigen::Vector3d& rVec,
                                                                 const Eigen::Vector3d& vVec) {
-    double r = rVec.norm();
-    double v = vVec.norm();
+    const double r = rVec.norm();
+    const double v = vVec.norm();
     const Eigen::Vector3d hVec = rVec.cross(vVec);
-    double h = hVec.norm();
+    const double h = hVec.norm();
     const Eigen::Vector3d nVec = Eigen::Vector3d::UnitZ().cross(hVec);
     const Eigen::Vector3d eVec = ((v * v - mu / r) * rVec - (rVec.dot(vVec)) * vVec) / mu;
 

--- a/algorithms/utilities/orbitalMotion.cpp
+++ b/algorithms/utilities/orbitalMotion.cpp
@@ -223,7 +223,11 @@ ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
 
     elements.radiusMagnitude = r;
     elements.eccentricity = static_cast<float>(eVec.norm());
-    elements.inclination = static_cast<float>(std::acos(hVec(2) / h));
+    if (h < kTolerance) {
+        elements.inclination = 0.0F; // rectilinear orbit
+    } else {
+        elements.inclination = static_cast<float>(std::acos(hVec(2) / h));
+    }
     elements.alpha = (2 / r) - (v * v / mu);
     elements.semiMajorAxis = fabs(elements.alpha) > kTolerance ? 1 / elements.alpha : 0.0;
 
@@ -237,7 +241,10 @@ ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
     elements.trueAnomaly = f < 0 ? static_cast<float>(f + (2 * std::numbers::pi)) : f;
 
     elements.radiusPeriapsis = h * h / mu / (1 + elements.eccentricity);
-    elements.radiusApoapsis = h * h / mu / (1 - elements.eccentricity);
-
+    if (fabsf(elements.eccentricity - 1) < kTolerance) {
+        elements.radiusApoapsis = 0.0F; // parabolic orbit
+    } else {
+        elements.radiusApoapsis = h * h / mu / (1 - elements.eccentricity);
+    }
     return elements;
 }

--- a/algorithms/utilities/orbitalMotion.cpp
+++ b/algorithms/utilities/orbitalMotion.cpp
@@ -30,7 +30,7 @@ constexpr double tolerance = 1e-8;
  */
 float OrbitalMotion::eccentricToTrueAnomalyF32(float const E, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    return 2.0 * std::atan2(std::sqrt(1 + e) * std::sin(E / 2), std::sqrt(1 - e) * std::cos(E / 2));
+    return 2 * std::atan2(std::sqrt(1 + e) * std::sin(E / 2), std::sqrt(1 - e) * std::cos(E / 2));
 }
 
 /**
@@ -41,7 +41,7 @@ float OrbitalMotion::eccentricToTrueAnomalyF32(float const E, float const e) {
  */
 float OrbitalMotion::eccentricToMeanAnomalyF32(float const E, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    return E - e * std::sin(E);
+    return E - (e * std::sin(E));
 }
 
 /**
@@ -52,7 +52,7 @@ float OrbitalMotion::eccentricToMeanAnomalyF32(float const E, float const e) {
  */
 float OrbitalMotion::trueToEccentricAnomalyF32(float const f, float const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    return 2.0 * std::atan2(std::sqrt(1 - e) * std::sin(f / 2), std::sqrt(1 + e) * std::cos(f / 2));
+    return 2 * std::atan2(std::sqrt(1 - e) * std::sin(f / 2), std::sqrt(1 + e) * std::cos(f / 2));
 }
 
 /**
@@ -75,7 +75,7 @@ float OrbitalMotion::trueToMeanAnomalyF32(float const f, float const e) {
  */
 float OrbitalMotion::trueToHyperbolicAnomalyF32(float const f, float const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
-    return 2.0 * std::atanh(std::sqrt((e - 1) / (e + 1)) * std::tan(f / 2));
+    return 2 * std::atanh(std::sqrt((e - 1) / (e + 1)) * std::tan(f / 2));
 }
 
 /**
@@ -86,7 +86,7 @@ float OrbitalMotion::trueToHyperbolicAnomalyF32(float const f, float const e) {
  */
 float OrbitalMotion::hyperbolicToTrueAnomalyF32(float const H, float const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
-    return 2.0 * std::atan(std::sqrt((e + 1) / (e - 1)) * std::tanh(H / 2));
+    return 2 * std::atan(std::sqrt((e + 1) / (e - 1)) * std::tanh(H / 2));
 }
 
 /**
@@ -97,7 +97,7 @@ float OrbitalMotion::hyperbolicToTrueAnomalyF32(float const H, float const e) {
  */
 float OrbitalMotion::hyperbolicToMeanAnomalyF32(float const H, float const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
-    return e * std::sinh(H) - H;
+    return (e * std::sinh(H)) - H;
 }
 
 /**
@@ -110,7 +110,7 @@ float OrbitalMotion::meanToEccentricAnomalyF32(float M, float e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
     float E = M;
     for (int i = 0; i < 200; ++i) {
-        float dE = (E - e * std::sin(E) - M) / (1 - e * std::cos(E));
+        float const dE = (E - e * std::sin(E) - M) / (1 - e * std::cos(E));
         E -= dE;
         if (std::abs(dE) < tolerance) break;
     }
@@ -137,7 +137,7 @@ float OrbitalMotion::meanToTrueAnomalyF32(float const M, float const e) {
  */
 float OrbitalMotion::meanToHyperbolicAnomalyF32(const float N, const float e) {
     assert(e > 1.0 && "Eccentricity must be > 1");
-    float H = std::abs(N) > 7.0 ? 7.0 * (N > 0 ? 1 : -1) : N;
+    float H = std::abs(N) > 7 ? 7 * (N > 0 ? 1 : -1) : N;
     for (int i = 0; i < 200; ++i) {
         const float dH = (e * std::sinh(H) - H - N) / (e * std::cosh(H) - 1);
         H -= dH;
@@ -209,24 +209,24 @@ ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
     const Eigen::Vector3d hVec = rVec.cross(vVec);
     const double h = hVec.norm();
     const Eigen::Vector3d nVec = Eigen::Vector3d::UnitZ().cross(hVec);
-    const Eigen::Vector3d eVec = ((v * v - mu / r) * rVec - (rVec.dot(vVec)) * vVec) / mu;
+    const Eigen::Vector3d eVec = (((v * v) - (mu / r)) * rVec - (rVec.dot(vVec)) * vVec) / mu;
 
     ClassicalElementsF32 elements{};
 
     elements.radiusMagnitude = r;
-    elements.alpha = 2.0 / r - v * v / mu;
-    elements.semiMajorAxis = std::abs(elements.alpha) > 1e-10 ? 1.0 / elements.alpha : 0.0;
     elements.eccentricity = static_cast<float>(eVec.norm());
     elements.inclination = static_cast<float>(std::acos(hVec(2) / h));
+    elements.alpha = (2 / r) - (v * v / mu);
+    elements.semiMajorAxis = std::abs(elements.alpha) > tolerance ? 1 / elements.alpha : 0.0;
 
     auto Omega = static_cast<float>(std::atan2(nVec(1), nVec(0)));
-    elements.rightAscensionAscendingNode = Omega < 0 ? static_cast<float>(Omega + 2 * std::numbers::pi) : Omega;
+    elements.rightAscensionAscendingNode = Omega < 0 ? static_cast<float>(Omega + (2 * std::numbers::pi)) : Omega;
 
     auto omega = static_cast<float>(std::atan2(nVec.cross(eVec).dot(hVec.normalized()), nVec.dot(eVec)));
-    elements.argPeriapsis = omega < 0 ? static_cast<float>(omega + 2 * std::numbers::pi) : omega;
+    elements.argPeriapsis = omega < 0 ? static_cast<float>(omega + (2 * std::numbers::pi)) : omega;
 
     auto f = static_cast<float>(std::atan2(eVec.cross(rVec).dot(hVec.normalized()), eVec.dot(rVec)));
-    elements.trueAnomaly = f < 0 ? static_cast<float>(f + 2 * std::numbers::pi) : f;
+    elements.trueAnomaly = f < 0 ? static_cast<float>(f + (2 * std::numbers::pi)) : f;
 
     elements.radiusPeriapsis = h * h / mu / (1 + elements.eccentricity);
     elements.radiusApoapsis = h * h / mu / (1 - elements.eccentricity);

--- a/algorithms/utilities/orbitalMotion.hpp
+++ b/algorithms/utilities/orbitalMotion.hpp
@@ -17,8 +17,8 @@
 
  */
 
-#ifndef ORBITAL_MOTION_HPP
-#define ORBITAL_MOTION_HPP
+#ifndef ORBITAL_MOTION_FP32_HPP
+#define ORBITAL_MOTION_FP32_HPP
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/algorithms/utilities/orbitalMotion.hpp
+++ b/algorithms/utilities/orbitalMotion.hpp
@@ -21,7 +21,6 @@
 #define ORBITAL_MOTION_FP32_HPP
 
 #include <Eigen/Core>
-#include <Eigen/Geometry>
 
 struct CartesianState {
     Eigen::Vector3d position;


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2040
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
New version of orbital motion. Previous reviews were taken into account (tolerances were fixed in the tests).

## Verification
Unit tests test poorly defined orbits as well as the functions in orbital motion, the fuzz test covers a large range of inputs 

## Documentation
None

## Future work
None
