### PR TITLE
Add double precision generate of valid inertia matrix

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: "Pull Request"
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,6 +2,7 @@ name: "Static Analysis"
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/algorithms/utilities/_tests/test_validDcm_fuzz.cpp
+++ b/algorithms/utilities/_tests/test_validDcm_fuzz.cpp
@@ -1,5 +1,11 @@
 #include "utilitiesHelpers.hpp"
 #include <fuzztest/fuzztest.h>
 
-FUZZ_TEST(DcmFuzz, testDcmValidity)
-    .WithDomains(fuzztest::InRange(1e-6F, 1.0F), fuzztest::InRange(1e-6F, 1.0F), fuzztest::InRange(1e-6F, 1.0F));
+inline void testFloatDcmValidity(double const sigma1, double const sigma2, double const sigma3) {
+    const Eigen::Matrix3f dcm = generateValidDCM(sigma1, sigma2, sigma3).cast<float>();
+
+    EXPECT_TRUE(isValidDcm(dcm));
+}
+
+FUZZ_TEST(DcmFuzz, testFloatDcmValidity)
+    .WithDomains(fuzztest::InRange(1e-6, 1.0), fuzztest::InRange(1e-6, 1.0), fuzztest::InRange(1e-6, 1.0));

--- a/algorithms/utilities/_tests/test_validateInertia_fuzz.cpp
+++ b/algorithms/utilities/_tests/test_validateInertia_fuzz.cpp
@@ -1,9 +1,20 @@
 #include "utilitiesHelpers.hpp"
 #include <fuzztest/fuzztest.h>
 
+/* Test validity against generated inertia matrix */
+inline void testInertiaValidity(const double eigen1,
+                                const double eigen2,
+                                const double sigma1,
+                                const double sigma2,
+                                const double sigma3) {
+    const Eigen::Matrix3f inertia = generateValidInertiaMatrix(eigen1, eigen2, sigma1, sigma2, sigma3).cast<float>();
+
+    EXPECT_TRUE(inertiaIsValid(inertia));
+}
+
 FUZZ_TEST(InertiaFuzz, testInertiaValidity)
-    .WithDomains(fuzztest::InRange(1.0F, 1e6F),
-                 fuzztest::InRange(1.0F, 1e6F),
-                 fuzztest::InRange(1e-6F, 1.0F),
-                 fuzztest::InRange(1e-6F, 1.0F),
-                 fuzztest::InRange(1e-6F, 1.0F));
+    .WithDomains(fuzztest::InRange(1.0, 1e6),
+                 fuzztest::InRange(1.0, 1e6),
+                 fuzztest::InRange(1e-6, 1.0),
+                 fuzztest::InRange(1e-6, 1.0),
+                 fuzztest::InRange(1e-6, 1.0));

--- a/algorithms/utilities/_tests/utilitiesHelpers.hpp
+++ b/algorithms/utilities/_tests/utilitiesHelpers.hpp
@@ -59,9 +59,3 @@ inline Eigen::Matrix3d generateValidDCM(double const sigma1, double const sigma2
 
     return dcm;
 }
-
-inline void testDcmValidity(float const sigma1, float const sigma2, float const sigma3) {
-    const Eigen::Matrix3f dcm = generateValidDCM(sigma1, sigma2, sigma3);
-
-    EXPECT_TRUE(isValidDcm(dcm));
-}

--- a/algorithms/utilities/_tests/utilitiesHelpers.hpp
+++ b/algorithms/utilities/_tests/utilitiesHelpers.hpp
@@ -49,13 +49,6 @@ inline Eigen::Matrix3d generateValidInertiaMatrix(double const ev1,
     return R.transpose() * D * R;
 }
 
-/* Test validity against generated inertia matrix */
-inline void testInertiaValidity(float eigen1, float eigen2, float sigma1, float sigma2, float sigma3) {
-    const Eigen::Matrix3f inertia = GenerateValidInertiaMatrix(eigen1, eigen2, sigma1, sigma2, sigma3);
-
-    EXPECT_TRUE(inertiaIsValid(inertia));
-}
-
 /* Function to generate a general inertia matrix */
 inline Eigen::Matrix3f generateValidDCM(float const sigma1, float const sigma2, float const sigma3) {
     Eigen::Vector3f mrp(sigma1, sigma2, sigma3);

--- a/algorithms/utilities/_tests/utilitiesHelpers.hpp
+++ b/algorithms/utilities/_tests/utilitiesHelpers.hpp
@@ -4,49 +4,48 @@
 #include <gtest/gtest.h>
 #include <Eigen/Core>
 
-/* Function to generate a cross product operator from a vector */
-inline Eigen::Matrix3f tildeMatrix(const Eigen::Vector3f& vector) {
-    Eigen::Matrix3f tilde;
-    tilde << 0.0F, -vector(2), vector(1), vector(2), 0.0F, -vector(0), -vector(1), vector(0), 0.0F;
+/* Function to generate a cross product operator from a vector (double precision) */
+inline Eigen::Matrix3d tildeMatrix(const Eigen::Vector3d& vector) {
+    Eigen::Matrix3d tilde;
+    tilde << 0.0, -vector(2), vector(1), vector(2), 0.0, -vector(0), -vector(1), vector(0), 0.0;
     return tilde;
 }
 
-/* Function to generate a dcm from an mrp */
-inline Eigen::Matrix3f mrpToDcm(const Eigen::Vector3f& mrp) {
-    const Eigen::Matrix3f t = tildeMatrix(mrp);
-    const float denom = (1.0 + mrp.dot(mrp));
-    const Eigen::Matrix3f dcm = (8.0 * t * t - 4.0 * (1.0 - mrp.dot(mrp)) * t) / (denom * denom);
+/* Function to generate a dcm from an mrp (double precision) */
+inline Eigen::Matrix3d mrpToDcm(const Eigen::Vector3d& mrp) {
+    const Eigen::Matrix3d t = tildeMatrix(mrp);
+    const double denom = (1.0 + mrp.dot(mrp));
+    const Eigen::Matrix3d dcm = (8.0 * t * t - 4.0 * (1.0 - mrp.dot(mrp)) * t) / (denom * denom);
 
-    return dcm + Eigen::Matrix3f::Identity();
+    return dcm + Eigen::Matrix3d::Identity();
 }
 
-/* Function to generate a general inertia matrix */
-inline Eigen::Matrix3f GenerateValidInertiaMatrix(float const ev1,
-                                                  float const ev2,
-                                                  float const sigma1,
-                                                  float const sigma2,
-                                                  float const sigma3) {
+/* Function to generate a general inertia matrix using double precision internally */
+inline Eigen::Matrix3d generateValidInertiaMatrix(double const ev1,
+                                                  double const ev2,
+                                                  double const sigma1,
+                                                  double const sigma2,
+                                                  double const sigma3) {
     /* Sort the first two eigenvalues so ev_min <= ev_max */
-    const float ev_min = std::min(ev1, ev2);
-    const float ev_max = std::max(ev1, ev2);
-    const float ev3_min = (ev_max - ev_min > 1e-5f) ? ev_max - ev_min + 1e-5f : 1e-5f;
-    const float ev3_max = ev_max + ev_min - 1e-5f;
+    const double ev_min = std::min(ev1, ev2);
+    const double ev_max = std::max(ev1, ev2);
+    const double ev3_min = (ev_max - ev_min > 1e-5) ? ev_max - ev_min + 1e-5 : 1e-5;
+    const double ev3_max = ev_max + ev_min - 1e-5;
 
-    const float ev3 = ev3_min + (0.5 * (ev3_max - ev3_min));
-    const std::array<float, 3> eigenvalues = {ev_min, ev3, ev_max};
+    const double ev3 = ev3_min + (0.5 * (ev3_max - ev3_min));
 
-    /* Create a rotation matrix with provided mrp */
-    Eigen::Vector3f mrp(sigma1, sigma2, sigma3);
+    /* Create a rotation matrix with provided mrp (double precision) */
+    Eigen::Vector3d mrp(static_cast<double>(sigma1), static_cast<double>(sigma2), static_cast<double>(sigma3));
     if (mrp.squaredNorm() > 1) {
         mrp = -mrp / mrp.squaredNorm();
     }
-    Eigen::Matrix3f R = mrpToDcm(mrp);
+    Eigen::Matrix3d R = mrpToDcm(mrp);
 
     /* Create diagonal matrix D with eigenvalues */
-    Eigen::Matrix3f D;
-    D << eigenvalues[0], 0, 0, 0, eigenvalues[1], 0, 0, 0, eigenvalues[2];
+    Eigen::Matrix3d D;
+    D << ev_min, 0, 0, 0, ev3, 0, 0, 0, ev_max;
 
-    /* Return rotated diagonal matrix */
+    /* Return rotated diagonal matrix, cast to float */
     return R.transpose() * D * R;
 }
 

--- a/algorithms/utilities/_tests/utilitiesHelpers.hpp
+++ b/algorithms/utilities/_tests/utilitiesHelpers.hpp
@@ -50,12 +50,12 @@ inline Eigen::Matrix3d generateValidInertiaMatrix(double const ev1,
 }
 
 /* Function to generate a general inertia matrix */
-inline Eigen::Matrix3f generateValidDCM(float const sigma1, float const sigma2, float const sigma3) {
-    Eigen::Vector3f mrp(sigma1, sigma2, sigma3);
+inline Eigen::Matrix3d generateValidDCM(double const sigma1, double const sigma2, double const sigma3) {
+    Eigen::Vector3d mrp(sigma1, sigma2, sigma3);
     if (mrp.squaredNorm() > 1) {
         mrp = -mrp / mrp.squaredNorm();
     }
-    Eigen::Matrix3f dcm = mrpToDcm(mrp);
+    Eigen::Matrix3d dcm = mrpToDcm(mrp);
 
     return dcm;
 }


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2088
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The functions that generate a valid inertia matrix and a valid direction cosine matrix are refactored to use doubles. This is done to achieve high numerical precision. The usage of the generated double precision inertia or DCM can be downcast to float when comparing to a float inertia or DCM.

## Verification
CI runs successfully.

## Documentation
None invalidated. None new needed.

## Future work
None
