### PR TITLE
rateControl V&V feedback

### DIFF
--- a/algorithms/rateControl/CMakeLists.txt
+++ b/algorithms/rateControl/CMakeLists.txt
@@ -14,3 +14,5 @@ target_sources("${module}" PRIVATE
 target_include_directories("${module}" PUBLIC "..")
 
 target_link_libraries("${module}" PRIVATE Eigen3::Eigen)
+
+add_subdirectory(_tests)

--- a/algorithms/rateControl/_tests/CMakeLists.txt
+++ b/algorithms/rateControl/_tests/CMakeLists.txt
@@ -1,0 +1,41 @@
+add_executable(test_rateControl
+  ../rateControlAlgorithm.cpp
+  rateControlTestHelpers.hpp
+  test_rateControl.cpp
+)
+
+target_include_directories(test_rateControl PRIVATE "../..")
+target_include_directories(test_rateControl PRIVATE "..")
+target_include_directories(test_rateControl PRIVATE "${CMAKE_SOURCE_DIR}")
+
+target_link_libraries(test_rateControl PRIVATE
+    Eigen3::Eigen
+    GTest::gtest_main
+  )
+
+gtest_discover_tests(test_rateControl)
+
+if(XMERA_ENABLE_FUZZTESTS)
+  fuzztest_setup_fuzzing_flags()
+
+  add_executable(test_rateControl_fuzz
+    ../rateControlAlgorithm.cpp
+    rateControlTestHelpers.hpp
+    test_rateControl_fuzz.cpp
+  )
+
+  target_include_directories(test_rateControl_fuzz PRIVATE "../..")
+  target_include_directories(test_rateControl_fuzz PRIVATE "..")
+  target_include_directories(test_rateControl_fuzz PRIVATE "${CMAKE_SOURCE_DIR}")
+
+  target_link_libraries(test_rateControl_fuzz PRIVATE
+    Eigen3::Eigen
+    fuzztest::fuzztest
+    fuzztest::fuzztest_gtest_main
+  )
+
+  gtest_discover_tests(test_rateControl_fuzz
+    PROPERTIES
+      LABELS "fuzz\;fuzz-smoke"
+  )
+endif()

--- a/algorithms/rateControl/_tests/rateControlTestHelpers.hpp
+++ b/algorithms/rateControl/_tests/rateControlTestHelpers.hpp
@@ -8,29 +8,49 @@
 #include <architecture/utilities/macroDefinitions.h>
 #include <gtest/gtest.h>
 
-Eigen::Vector3f referenceUpdate(const Eigen::Matrix3f& spacecraftInertia,
-                                const float derivativeGainP,
-                                const Eigen::Vector3f& knownTorquePntB_B,
-                                const Eigen::Vector3f omega_BR_B,
-                                const Eigen::Vector3f domega_RN_B) {
+Eigen::Vector3d referenceUpdate(const Eigen::Matrix3d& spacecraftInertia,
+                                const double derivativeGainP,
+                                const Eigen::Vector3d& knownTorquePntB_B,
+                                const Eigen::Vector3d omega_BR_B,
+                                const Eigen::Vector3d domega_RN_B) {
     const auto ISCPntB_B = spacecraftInertia;
-    const Eigen::Vector3f Lr = -derivativeGainP * omega_BR_B + ISCPntB_B * domega_RN_B - knownTorquePntB_B;  // [Nm]
+    const Eigen::Vector3d Lr = -derivativeGainP * omega_BR_B + ISCPntB_B * domega_RN_B - knownTorquePntB_B;  // [Nm]
     return Lr;
 }
 
-inline void regressionTestRateControl(const Eigen::Matrix3f& spacecraftInertia,
-                                      const float derivativeGainP,
-                                      const Eigen::Vector3f& knownTorquePntB_B,
-                                      const Eigen::Vector3f& omega_BR_B,
-                                      const Eigen::Vector3f& domega_RN_B) {
+inline void regressionTestRateControl(const Eigen::Matrix3f& spacecraftInertia_f,
+                                      const float derivativeGainP_f,
+                                      const Eigen::Vector3f& knownTorquePntB_B_f,
+                                      const Eigen::Vector3f& omega_BR_B_f,
+                                      const Eigen::Vector3f& domega_RN_B_f) {
+    // Run algorithm in float.
     RateControlAlgorithm alg;
-    alg.setSpacecraftInertia(spacecraftInertia);
-    alg.setDerivativeGainP(derivativeGainP);
-    alg.setKnownTorquePntB_B(knownTorquePntB_B);
-    const Eigen::Vector3f out_alg = alg.update(omega_BR_B, domega_RN_B);
-    const Eigen::Vector3f out_ref =
-        referenceUpdate(spacecraftInertia, derivativeGainP, knownTorquePntB_B, omega_BR_B, domega_RN_B);
-    EXPECT_EQ(out_alg, out_ref);
+    alg.setSpacecraftInertia(spacecraftInertia_f);
+    alg.setDerivativeGainP(derivativeGainP_f);
+    alg.setKnownTorquePntB_B(knownTorquePntB_B_f);
+    const Eigen::Vector3f out_alg = alg.update(omega_BR_B_f, domega_RN_B_f);
+
+    // Run reference in double on the exact same float-quantized inputs.
+    const Eigen::Matrix3d spacecraftInertia_d = spacecraftInertia_f.cast<double>();
+    const double derivativeGainP_d = static_cast<double>(derivativeGainP_f);
+    const Eigen::Vector3d knownTorquePntB_B_d = knownTorquePntB_B_f.cast<double>();
+    const Eigen::Vector3d omega_BR_B_d = omega_BR_B_f.cast<double>();
+    const Eigen::Vector3d domega_RN_B_d = domega_RN_B_f.cast<double>();
+
+    const Eigen::Vector3d out_ref_d =
+        referenceUpdate(spacecraftInertia_d, derivativeGainP_d, knownTorquePntB_B_d, omega_BR_B_d, domega_RN_B_d);
+
+    for (int i = 0; i < 3; i++) {
+        const float sum_abs_terms =
+            std::abs(derivativeGainP_f * omega_BR_B_f[i]) + std::abs(spacecraftInertia_f(i, 0) * domega_RN_B_f[0]) +
+            std::abs(spacecraftInertia_f(i, 1) * domega_RN_B_f[1]) +
+            std::abs(spacecraftInertia_f(i, 2) * domega_RN_B_f[2]) + std::abs(knownTorquePntB_B_f[i]);
+
+        const float tol =
+            8.0f * sum_abs_terms * std::numeric_limits<float>::epsilon() + std::numeric_limits<float>::min();
+
+        EXPECT_NEAR(out_alg[i], static_cast<float>(out_ref_d[i]), tol);
+    }
 }
 
 #endif

--- a/algorithms/rateControl/_tests/rateControlTestHelpers.hpp
+++ b/algorithms/rateControl/_tests/rateControlTestHelpers.hpp
@@ -1,0 +1,36 @@
+#ifndef TEST_RATECONTROL_H
+#define TEST_RATECONTROL_H
+
+#include "../freestandingInvalidArgument.h"
+#include "../utilities/_tests/utilitiesHelpers.hpp"
+#include "architecture/utilities/eigenSupport.h"
+#include "rateControlAlgorithm.h"
+#include <architecture/utilities/macroDefinitions.h>
+#include <gtest/gtest.h>
+
+Eigen::Vector3f referenceUpdate(const Eigen::Matrix3f& spacecraftInertia,
+                                const float derivativeGainP,
+                                const Eigen::Vector3f& knownTorquePntB_B,
+                                const Eigen::Vector3f omega_BR_B,
+                                const Eigen::Vector3f domega_RN_B) {
+    const auto ISCPntB_B = spacecraftInertia;
+    const Eigen::Vector3f Lr = -derivativeGainP * omega_BR_B + ISCPntB_B * domega_RN_B - knownTorquePntB_B;  // [Nm]
+    return Lr;
+}
+
+inline void regressionTestRateControl(const Eigen::Matrix3f& spacecraftInertia,
+                                      const float derivativeGainP,
+                                      const Eigen::Vector3f& knownTorquePntB_B,
+                                      const Eigen::Vector3f& omega_BR_B,
+                                      const Eigen::Vector3f& domega_RN_B) {
+    RateControlAlgorithm alg;
+    alg.setSpacecraftInertia(spacecraftInertia);
+    alg.setDerivativeGainP(derivativeGainP);
+    alg.setKnownTorquePntB_B(knownTorquePntB_B);
+    const Eigen::Vector3f out_alg = alg.update(omega_BR_B, domega_RN_B);
+    const Eigen::Vector3f out_ref =
+        referenceUpdate(spacecraftInertia, derivativeGainP, knownTorquePntB_B, omega_BR_B, domega_RN_B);
+    EXPECT_EQ(out_alg, out_ref);
+}
+
+#endif

--- a/algorithms/rateControl/_tests/test_rateControl.cpp
+++ b/algorithms/rateControl/_tests/test_rateControl.cpp
@@ -1,0 +1,37 @@
+#include "rateControlTestHelpers.hpp"
+#include <gtest/gtest.h>
+
+TEST(rateControlTest, RegressionTest) {
+    const Eigen::Matrix3f spacecraftInertia = Eigen::Matrix3f::Identity();
+    const float derivativeGainP = 1.0F;
+    const Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Ones();
+    const Eigen::Vector3f omega_BR_B{1.0f, 2.0f, -3.0f};
+    const Eigen::Vector3f domega_RN_B{11.0f, -2.6f, 0.9f};
+    regressionTestRateControl(spacecraftInertia, derivativeGainP, knownTorquePntB_B, omega_BR_B, domega_RN_B);
+}
+
+TEST(rateControlTest, SetupTest) {
+    RateControlAlgorithm alg;
+
+    // 1) Set spacecraft inertia
+    const Eigen::Matrix3f I_invalid = Eigen::Matrix3f{{2.0f, 0.0f, 0.0f}, {0.1f, 3.0f, 0.2f}, {0.0f, 0.2f, 4.0f}};
+    EXPECT_THROW(alg.setSpacecraftInertia(I_invalid), fs::invalid_argument);  // invalid inertia due to not symmetry
+    const Eigen::Matrix3f I = Eigen::Matrix3f{{2.0f, 0.1f, 0.0f}, {0.1f, 3.0f, 0.2f}, {0.0f, 0.2f, 4.0f}};
+    EXPECT_NO_THROW(alg.setSpacecraftInertia(I));
+
+    // 2) Derivative gain P: allow zero and positive, reject negative
+    EXPECT_NO_THROW(alg.setDerivativeGainP(0.0f));
+    EXPECT_EQ(alg.getDerivativeGainP(), 0.0f);
+    EXPECT_THROW(alg.setDerivativeGainP(-1.0f), fs::invalid_argument);
+    EXPECT_NO_THROW(alg.setDerivativeGainP(1.25f));
+    EXPECT_EQ(alg.getDerivativeGainP(), 1.25f);
+
+    // 3) Known external torque: set + getter correctness
+    const Eigen::Vector3f tau = Eigen::Vector3f(0.4f, -0.2f, 0.1f);
+    EXPECT_NO_THROW(alg.setKnownTorquePntB_B(tau));
+
+    const Eigen::Vector3f& got = alg.getKnownTorquePntB_B();
+    EXPECT_EQ(got.x(), tau.x());
+    EXPECT_EQ(got.y(), tau.y());
+    EXPECT_EQ(got.z(), tau.z());
+}

--- a/algorithms/rateControl/_tests/test_rateControl.cpp
+++ b/algorithms/rateControl/_tests/test_rateControl.cpp
@@ -5,8 +5,8 @@ TEST(rateControlTest, RegressionTest) {
     const Eigen::Matrix3f spacecraftInertia = Eigen::Matrix3f::Identity();
     const float derivativeGainP = 1.0F;
     const Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Ones();
-    const Eigen::Vector3f omega_BR_B{1.0f, 2.0f, -3.0f};
-    const Eigen::Vector3f domega_RN_B{11.0f, -2.6f, 0.9f};
+    const Eigen::Vector3f omega_BR_B{1.0F, 2.0F, -3.0F};
+    const Eigen::Vector3f domega_RN_B{11.0F, -2.6F, 0.9F};
     regressionTestRateControl(spacecraftInertia, derivativeGainP, knownTorquePntB_B, omega_BR_B, domega_RN_B);
 }
 

--- a/algorithms/rateControl/_tests/test_rateControl.py
+++ b/algorithms/rateControl/_tests/test_rateControl.py
@@ -93,10 +93,9 @@ def test_rateControl(setExtTorque):
 
 def findTrueTorques(rateCntrl, attGuidanceMessageData, vehicleConfigOut, knownTorquePntB_B):
     P = rateCntrl.getDerivativeGainP()
-    sigma_BR = np.array(attGuidanceMessageData.sigma_BR)
-    omega_BR_B = np.array(attGuidanceMessageData.omega_BR_B)
-    omega_RN_B = np.array(attGuidanceMessageData.omega_RN_B)
-    domega_RN_B = np.array(attGuidanceMessageData.domega_RN_B)
+    omega_BR_B = np.array(attGuidanceMessageData.omega_BR_B, dtype=np.float32)
+    omega_RN_B = np.array(attGuidanceMessageData.omega_RN_B, dtype=np.float32)
+    domega_RN_B = np.array(attGuidanceMessageData.domega_RN_B, dtype=np.float32)
     omega_BN_B = omega_BR_B + omega_RN_B
 
     ISCPntB_B = np.identity(3)

--- a/algorithms/rateControl/_tests/test_rateControl.py
+++ b/algorithms/rateControl/_tests/test_rateControl.py
@@ -10,9 +10,9 @@ from xmera.fp32 import rateControlF32
 from xmera.utilities import macros
 from xmera.architecture import messaging
 
-@pytest.mark.parametrize("setExtTorque", [False, True])
+@pytest.mark.parametrize("set_ext_torque", [False, True])
 
-def test_rateControl(setExtTorque):
+def test_rateControl(set_ext_torque):
     r"""
     **Validation Test Description**
 
@@ -25,88 +25,85 @@ def test_rateControl(setExtTorque):
     The unit test verifies that the module output torque message vector matches expected values. The test
     method parameters include the following.
 
-    :param setExtTorque: flag to set the knownTorquePntB_B variable
+    :param set_ext_torque: flag to set the known_torque_PntB_N variable
     :return: void
     """
 
-    unitTaskName = "unitTask"
-    unitProcessName = "TestProcess"
+    unit_task_name = "unitTask"
+    unit_process_name = "test_process"
 
     # Create a sim module as an empty container
-    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unit_test_sim = SimulationBaseClass.SimBaseClass()
 
     # Create test thread
-    testProcessRate = macros.sec2nano(0.5)
-    testProc = unitTestSim.CreateNewProcess(unitProcessName)
-    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+    test_process_rate = macros.sec2nano(0.5)
+    test_proc = unit_test_sim.CreateNewProcess(unit_process_name)
+    test_proc.addTask(unit_test_sim.CreateNewTask(unit_task_name, test_process_rate))
 
     # Create an instance of the rateControl module
-    rateCntrl = rateControlF32.RateControl()
-    rateCntrl.setDerivativeGainP(150.0)
-    rateCntrl.modelTag = "rateControl"
-    unitTestSim.AddModelToTask(unitTaskName, rateCntrl)
+    rate_cntrl = rateControlF32.RateControl()
+    rate_cntrl.setDerivativeGainP(150.0)
+    rate_cntrl.modelTag = "rateControl"
+    unit_test_sim.AddModelToTask(unit_task_name, rate_cntrl)
 
     # Set the external torque
-    knownTorquePntB_B = np.array([0.0, 0.0, 0.0])
-    if setExtTorque:
-        knownTorquePntB_B = np.array([0.1, 0.2, 0.3])
-        rateCntrl.setKnownTorquePntB_B(knownTorquePntB_B)
+    known_torque_PntB_N = np.array([0.0, 0.0, 0.0], dtype=np.float32)
+    if set_ext_torque:
+        known_torque_PntB_N = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        rate_cntrl.setKnownTorquePntB_B(known_torque_PntB_N)
 
     # Create the attitude guidance input message
-    attGuidanceMessageData = messaging.AttGuidMsgF32Payload()
-    attGuidanceMessageData.sigma_BR = np.array([0.3, -0.5, 0.7])
-    attGuidanceMessageData.omega_BR_B = np.array([0.010, -0.020, 0.015])
-    attGuidanceMessageData.omega_RN_B = np.array([-0.02, -0.01, 0.005])
-    attGuidanceMessageData.domega_RN_B = np.array([0.0002, 0.0003, 0.0001])
-    attGuidanceMessage = messaging.AttGuidMsgF32().write(attGuidanceMessageData)
+    att_guidance_message_data = messaging.AttGuidMsgF32Payload()
+    att_guidance_message_data.sigma_BR = np.array([0.3, -0.5, 0.7], dtype=np.float32)
+    att_guidance_message_data.omega_BR_B = np.array([0.010, -0.020, 0.015], dtype=np.float32)
+    att_guidance_message_data.omega_RN_B = np.array([-0.02, -0.01, 0.005], dtype=np.float32)
+    att_guidance_message_data.domega_RN_B = np.array([0.0002, 0.0003, 0.0001], dtype=np.float32)
+    att_guidance_message = messaging.AttGuidMsgF32().write(att_guidance_message_data)
 
     # Create the vehicleConfig fsw message
-    vehicleConfigIn = messaging.VehicleConfigMsgF32Payload()
-    vehicleConfigIn.ISCPntB_B = [1000., 0., 0.,
+    vehicle_config_in = messaging.VehicleConfigMsgF32Payload()
+    vehicle_config_in.ISCPntB_B = [1000., 0., 0.,
                                   0., 800., 0.,
                                   0., 0., 800.]
-    vcInMsg = messaging.VehicleConfigMsgF32().write(vehicleConfigIn)
+    vc_in_msg = messaging.VehicleConfigMsgF32().write(vehicle_config_in)
 
     # Set up data logging
-    cmdTorqueOutMsgDataLog = rateCntrl.cmdTorqueOutMsg.recorder()
-    unitTestSim.AddModelToTask(unitTaskName, cmdTorqueOutMsgDataLog)
+    cmd_torque_outmsg_datalog = rate_cntrl.cmdTorqueOutMsg.recorder()
+    unit_test_sim.AddModelToTask(unit_task_name, cmd_torque_outmsg_datalog)
 
     # Connect messages
-    rateCntrl.vehConfigInMsg.subscribeTo(vcInMsg)
-    rateCntrl.guidInMsg.subscribeTo(attGuidanceMessage)
+    rate_cntrl.vehConfigInMsg.subscribeTo(vc_in_msg)
+    rate_cntrl.guidInMsg.subscribeTo(att_guidance_message)
 
     # Execute the simulation
-    unitTestSim.InitializeSimulation()
-    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
-    unitTestSim.ExecuteSimulation()
+    unit_test_sim.InitializeSimulation()
+    unit_test_sim.ConfigureStopTime(macros.sec2nano(1.0))
+    unit_test_sim.ExecuteSimulation()
 
     # Extract logged data for test check
-    cmdTorqueTruth = np.array([findTrueTorques(rateCntrl, attGuidanceMessageData, vehicleConfigIn, knownTorquePntB_B)]*3)
+    cmd_torque_truth = np.array([findTrueTorques(rate_cntrl, att_guidance_message_data, vehicle_config_in, known_torque_PntB_N)]*3
+                              , dtype=np.float32)
 
     # Compare the module results to the computed truth value
     accuracy = 1e-7
-    np.testing.assert_allclose(cmdTorqueTruth,
-                               cmdTorqueOutMsgDataLog.torqueRequestBody,
+    np.testing.assert_allclose(cmd_torque_truth,
+                               cmd_torque_outmsg_datalog.torqueRequestBody,
                                atol=accuracy,
                                rtol=0,
                                verbose=True)
 
-def findTrueTorques(rateCntrl, attGuidanceMessageData, vehicleConfigOut, knownTorquePntB_B):
-    P = rateCntrl.getDerivativeGainP()
-    omega_BR_B = np.array(attGuidanceMessageData.omega_BR_B, dtype=np.float32)
-    omega_RN_B = np.array(attGuidanceMessageData.omega_RN_B, dtype=np.float32)
-    domega_RN_B = np.array(attGuidanceMessageData.domega_RN_B, dtype=np.float32)
-    omega_BN_B = omega_BR_B + omega_RN_B
+def findTrueTorques(rate_cntrl, att_guidance_message_data, vehicle_config_out, known_torque_PntB_N):
+    P = rate_cntrl.getDerivativeGainP()
+    omega_BR_B = np.array(att_guidance_message_data.omega_BR_B, dtype=np.float32)
+    domega_RN_B = np.array(att_guidance_message_data.domega_RN_B, dtype=np.float32)
 
-    ISCPntB_B = np.identity(3)
-    ISCPntB_B[0][0] = vehicleConfigOut.ISCPntB_B[0]
-    ISCPntB_B[1][1] = vehicleConfigOut.ISCPntB_B[4]
-    ISCPntB_B[2][2] = vehicleConfigOut.ISCPntB_B[8]
-
+    ISCPntB_B = np.identity(3, dtype=np.float32)
+    ISCPntB_B[0][0] = vehicle_config_out.ISCPntB_B[0]
+    ISCPntB_B[1][1] = vehicle_config_out.ISCPntB_B[4]
+    ISCPntB_B[2][2] = vehicle_config_out.ISCPntB_B[8]
     return (- P * omega_BR_B
-            + np.cross(omega_RN_B, np.dot(ISCPntB_B, omega_BN_B))
-            + np.dot(ISCPntB_B, domega_RN_B - np.cross(omega_BN_B, omega_RN_B))
-            - knownTorquePntB_B)
+            + np.dot(ISCPntB_B, domega_RN_B)
+            - known_torque_PntB_N)
 
 if __name__ == "__main__":
     test_rateControl(False)

--- a/algorithms/rateControl/_tests/test_rateControl_fuzz.cpp
+++ b/algorithms/rateControl/_tests/test_rateControl_fuzz.cpp
@@ -1,0 +1,32 @@
+#include "rateControlTestHelpers.hpp"
+#include <fuzztest/fuzztest.h>
+
+static auto Vec3(float lo, float hi) { return fuzztest::ArrayOf<3>(fuzztest::InRange(lo, hi)); }
+
+inline void fuzzAdapterRateControl(const float ev1,
+                                   const float ev2,
+                                   const float sigma1,
+                                   const float sigma2,
+                                   const float sigma3,
+                                   const float DerivativeGainP,
+                                   const std::array<float, 3>& knownTorque_a,
+                                   const std::array<float, 3>& omega_BR_a,
+                                   const std::array<float, 3>& domega_RN_a) {
+    const Eigen::Matrix3f spacecraftInertia = generateValidInertiaMatrix(ev1, ev2, sigma1, sigma2, sigma3);
+    const Eigen::Vector3f knownTorquePntB_B(knownTorque_a[0], knownTorque_a[1], knownTorque_a[2]);
+    const Eigen::Vector3f omega_BR_B(omega_BR_a[0], omega_BR_a[1], omega_BR_a[2]);
+    const Eigen::Vector3f domega_RN_B(domega_RN_a[0], domega_RN_a[1], domega_RN_a[2]);
+    regressionTestRateControl(spacecraftInertia, DerivativeGainP, knownTorquePntB_B, omega_BR_B, domega_RN_B);
+}
+
+FUZZ_TEST(rateControlFuzz, fuzzAdapterRateControl)
+    .WithDomains(fuzztest::InRange(1.0F, 1e6F),
+                 fuzztest::InRange(1.0F, 1e6F),
+                 fuzztest::InRange(1e-6F, 1.0F),
+                 fuzztest::InRange(1e-6F, 1.0F),
+                 fuzztest::InRange(1e-6F, 1.0F),
+                 fuzztest::InRange(0.0f, 1E6f),  // P must be >= 0
+                 Vec3(-1E6f, 1E6f),              // known torque
+                 Vec3(-1E6f, 1E6f),              // omega_BR
+                 Vec3(-1E6f, 1E6f)               // domega_RN
+    );

--- a/algorithms/rateControl/_tests/test_rateControl_fuzz.cpp
+++ b/algorithms/rateControl/_tests/test_rateControl_fuzz.cpp
@@ -1,22 +1,32 @@
 #include "rateControlTestHelpers.hpp"
 #include <fuzztest/fuzztest.h>
 
-static auto Vec3(float lo, float hi) { return fuzztest::ArrayOf<3>(fuzztest::InRange(lo, hi)); }
+static auto Vec3(double lo, double hi) { return fuzztest::ArrayOf<3>(fuzztest::InRange(lo, hi)); }
 
 inline void fuzzAdapterRateControl(const float ev1,
                                    const float ev2,
                                    const float sigma1,
                                    const float sigma2,
                                    const float sigma3,
-                                   const float DerivativeGainP,
-                                   const std::array<float, 3>& knownTorque_a,
-                                   const std::array<float, 3>& omega_BR_a,
-                                   const std::array<float, 3>& domega_RN_a) {
-    const Eigen::Matrix3f spacecraftInertia = generateValidInertiaMatrix(ev1, ev2, sigma1, sigma2, sigma3);
-    const Eigen::Vector3f knownTorquePntB_B(knownTorque_a[0], knownTorque_a[1], knownTorque_a[2]);
-    const Eigen::Vector3f omega_BR_B(omega_BR_a[0], omega_BR_a[1], omega_BR_a[2]);
-    const Eigen::Vector3f domega_RN_B(domega_RN_a[0], domega_RN_a[1], domega_RN_a[2]);
-    regressionTestRateControl(spacecraftInertia, DerivativeGainP, knownTorquePntB_B, omega_BR_B, domega_RN_B);
+                                   const double DerivativeGainP,
+                                   const std::array<double, 3>& knownTorque_a,
+                                   const std::array<double, 3>& omega_BR_a,
+                                   const std::array<double, 3>& domega_RN_a) {
+    const Eigen::Matrix3f spacecraftInertia_f = generateValidInertiaMatrix(ev1, ev2, sigma1, sigma2, sigma3);
+
+    const float derivativeGainP_f = static_cast<float>(DerivativeGainP);
+
+    const Eigen::Vector3f knownTorquePntB_B_f(static_cast<float>(knownTorque_a[0]),
+                                              static_cast<float>(knownTorque_a[1]),
+                                              static_cast<float>(knownTorque_a[2]));
+
+    const Eigen::Vector3f omega_BR_B_f(
+        static_cast<float>(omega_BR_a[0]), static_cast<float>(omega_BR_a[1]), static_cast<float>(omega_BR_a[2]));
+
+    const Eigen::Vector3f domega_RN_B_f(
+        static_cast<float>(domega_RN_a[0]), static_cast<float>(domega_RN_a[1]), static_cast<float>(domega_RN_a[2]));
+
+    regressionTestRateControl(spacecraftInertia_f, derivativeGainP_f, knownTorquePntB_B_f, omega_BR_B_f, domega_RN_B_f);
 }
 
 FUZZ_TEST(rateControlFuzz, fuzzAdapterRateControl)
@@ -25,8 +35,7 @@ FUZZ_TEST(rateControlFuzz, fuzzAdapterRateControl)
                  fuzztest::InRange(1e-6F, 1.0F),
                  fuzztest::InRange(1e-6F, 1.0F),
                  fuzztest::InRange(1e-6F, 1.0F),
-                 fuzztest::InRange(0.0f, 1E6f),  // P must be >= 0
-                 Vec3(-1E6f, 1E6f),              // known torque
-                 Vec3(-1E6f, 1E6f),              // omega_BR
-                 Vec3(-1E6f, 1E6f)               // domega_RN
-    );
+                 fuzztest::InRange(0.0, 1.0E6),
+                 Vec3(-1.0E6, 1.0E6),
+                 Vec3(-1.0E6, 1.0E6),
+                 Vec3(-1.0E6, 1.0E6));

--- a/algorithms/rateControl/_tests/test_rateControl_fuzz.cpp
+++ b/algorithms/rateControl/_tests/test_rateControl_fuzz.cpp
@@ -1,3 +1,4 @@
+#include "fp32-fsw-xmera/architecture/testUtilities/eigenFuzzDomains.hpp"
 #include "rateControlTestHelpers.hpp"
 #include <fuzztest/fuzztest.h>
 
@@ -9,22 +10,18 @@ inline void fuzzAdapterRateControl(const float ev1,
                                    const float sigma2,
                                    const float sigma3,
                                    const double DerivativeGainP,
-                                   const std::array<double, 3>& knownTorque_a,
-                                   const std::array<double, 3>& omega_BR_a,
-                                   const std::array<double, 3>& domega_RN_a) {
+                                   const Eigen::Vector3d knownTorque_a,
+                                   const Eigen::Vector3d omega_BR_a,
+                                   const Eigen::Vector3d domega_RN_a) {
     const Eigen::Matrix3f spacecraftInertia_f = generateValidInertiaMatrix(ev1, ev2, sigma1, sigma2, sigma3);
 
     const float derivativeGainP_f = static_cast<float>(DerivativeGainP);
 
-    const Eigen::Vector3f knownTorquePntB_B_f(static_cast<float>(knownTorque_a[0]),
-                                              static_cast<float>(knownTorque_a[1]),
-                                              static_cast<float>(knownTorque_a[2]));
+    const Eigen::Vector3f knownTorquePntB_B_f = knownTorque_a.cast<float>();
 
-    const Eigen::Vector3f omega_BR_B_f(
-        static_cast<float>(omega_BR_a[0]), static_cast<float>(omega_BR_a[1]), static_cast<float>(omega_BR_a[2]));
+    const Eigen::Vector3f omega_BR_B_f = omega_BR_a.cast<float>();
 
-    const Eigen::Vector3f domega_RN_B_f(
-        static_cast<float>(domega_RN_a[0]), static_cast<float>(domega_RN_a[1]), static_cast<float>(domega_RN_a[2]));
+    const Eigen::Vector3f domega_RN_B_f = domega_RN_a.cast<float>();
 
     regressionTestRateControl(spacecraftInertia_f, derivativeGainP_f, knownTorquePntB_B_f, omega_BR_B_f, domega_RN_B_f);
 }
@@ -36,6 +33,6 @@ FUZZ_TEST(rateControlFuzz, fuzzAdapterRateControl)
                  fuzztest::InRange(1e-6F, 1.0F),
                  fuzztest::InRange(1e-6F, 1.0F),
                  fuzztest::InRange(0.0, 1.0E6),
-                 Vec3(-1.0E6, 1.0E6),
-                 Vec3(-1.0E6, 1.0E6),
-                 Vec3(-1.0E6, 1.0E6));
+                 xmera::fuzz::Vector3dInRange(-1.0E6, 1.0E6),
+                 xmera::fuzz::Vector3dInRange(-1.0E6, 1.0E6),
+                 xmera::fuzz::Vector3dInRange(-1.0E6, 1.0E6));

--- a/algorithms/rateControl/rateControl.cpp
+++ b/algorithms/rateControl/rateControl.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "rateControl.h"
-
+#include "architecture/utilities/eigenSupport.h"
 #include <stdint.h>
 #include <stdexcept>
 
@@ -23,7 +23,9 @@ void RateControl::reset(uint64_t callTime) {
     }
 
     if (this->vehConfigInMsg.isWritten()) {
-        this->algorithm.setSpacecraftInertia(this->vehConfigInMsg());
+        auto vehicleConfigPayload = this->vehConfigInMsg();
+        const Eigen::Matrix3f spacecraftInertia = cArrayToEigenMatrix3(vehicleConfigPayload.ISCPntB_B);
+        this->algorithm.setSpacecraftInertia(spacecraftInertia);
     }
 }
 
@@ -34,8 +36,13 @@ the reference frame angular rates and acceleration, and computes the required co
 */
 void RateControl::updateState(uint64_t callTime) {
     CmdTorqueBodyMsgF32Payload torqueCmdOut{};
+    auto inMsg = this->guidInMsg();
+    const Eigen::Vector3f omega_BR_B = cArrayToEigenVector3(inMsg.omega_BR_B);
+    const Eigen::Vector3f omega_RN_B = cArrayToEigenVector3(inMsg.omega_RN_B);
+    const Eigen::Vector3f domega_RN_B = cArrayToEigenVector3(inMsg.domega_RN_B);
     if (this->guidInMsg.isWritten()) {
-        torqueCmdOut = this->algorithm.update(this->guidInMsg());
+        Eigen::Vector3f const out = this->algorithm.update(omega_BR_B, omega_RN_B, domega_RN_B);
+        eigenVectorToCArray(out, torqueCmdOut.torqueRequestBody);
     }
 
     this->cmdTorqueOutMsg.write(&torqueCmdOut, moduleID, callTime);

--- a/algorithms/rateControl/rateControl.cpp
+++ b/algorithms/rateControl/rateControl.cpp
@@ -38,10 +38,9 @@ void RateControl::updateState(uint64_t callTime) {
     CmdTorqueBodyMsgF32Payload torqueCmdOut{};
     auto inMsg = this->guidInMsg();
     const Eigen::Vector3f omega_BR_B = cArrayToEigenVector3(inMsg.omega_BR_B);
-    const Eigen::Vector3f omega_RN_B = cArrayToEigenVector3(inMsg.omega_RN_B);
     const Eigen::Vector3f domega_RN_B = cArrayToEigenVector3(inMsg.domega_RN_B);
     if (this->guidInMsg.isWritten()) {
-        Eigen::Vector3f const out = this->algorithm.update(omega_BR_B, omega_RN_B, domega_RN_B);
+        Eigen::Vector3f const out = this->algorithm.update(omega_BR_B, domega_RN_B);
         eigenVectorToCArray(out, torqueCmdOut.torqueRequestBody);
     }
 

--- a/algorithms/rateControl/rateControl.cpp
+++ b/algorithms/rateControl/rateControl.cpp
@@ -11,7 +11,6 @@
 
 /*! This method performs a complete reset of the module.  Local module variables that retain
  time varying states between function calls are reset to their default values.
- @return void
  @param callTime [ns] Time the method is called
 */
 void RateControl::reset(uint64_t callTime) {
@@ -31,7 +30,6 @@ void RateControl::reset(uint64_t callTime) {
 
 /*! This method takes the attitude and rate errors relative to the reference frame, as well as
 the reference frame angular rates and acceleration, and computes the required control torque Lr.
- @return void
  @param callTime [ns] Time the method is called
 */
 void RateControl::updateState(uint64_t callTime) {
@@ -48,25 +46,23 @@ void RateControl::updateState(uint64_t callTime) {
 }
 
 /*! Setter method for the derivative gain P.
- @return void
- @param P [N*m*s] Rate error feedback gain applied
+ @param P the derivative gain P
 */
 void RateControl::setDerivativeGainP(const float P) { this->algorithm.setDerivativeGainP(P); }
 
 /*! Getter method for the derivative gain P.
- @return const float
+ @return the derivative gain P
 */
 float RateControl::getDerivativeGainP() const { return this->algorithm.getDerivativeGainP(); }
 
-/*! Setter method for the known external torque about point B.
- @return void
- @param knownTorquePntB_B [N*m] Known external torque expressed in body frame components
+/*! Setter method for the known external torque.
+ @param knownTorquePntB_B the known external torque [N*m] expressed in body frame coordinates
 */
 void RateControl::setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B) {
     this->algorithm.setKnownTorquePntB_B(knownTorquePntB_B);
 }
 
-/*! Getter method for the known torque about point B.
- @return const Eigen::Vector3f
+/*! Getter method for the known torque.
+ @return the known external torque [N*m] expressed in body frame coordinates
 */
 const Eigen::Vector3f& RateControl::getKnownTorquePntB_B() const { return this->algorithm.getKnownTorquePntB_B(); }

--- a/algorithms/rateControl/rateControl.cpp
+++ b/algorithms/rateControl/rateControl.cpp
@@ -36,10 +36,10 @@ the reference frame angular rates and acceleration, and computes the required co
 */
 void RateControl::updateState(uint64_t callTime) {
     CmdTorqueBodyMsgF32Payload torqueCmdOut{};
-    auto inMsg = this->guidInMsg();
-    const Eigen::Vector3f omega_BR_B = cArrayToEigenVector3(inMsg.omega_BR_B);
-    const Eigen::Vector3f domega_RN_B = cArrayToEigenVector3(inMsg.domega_RN_B);
     if (this->guidInMsg.isWritten()) {
+        auto inMsg = this->guidInMsg();
+        const Eigen::Vector3f omega_BR_B = cArrayToEigenVector3(inMsg.omega_BR_B);
+        const Eigen::Vector3f domega_RN_B = cArrayToEigenVector3(inMsg.domega_RN_B);
         Eigen::Vector3f const out = this->algorithm.update(omega_BR_B, domega_RN_B);
         eigenVectorToCArray(out, torqueCmdOut.torqueRequestBody);
     }

--- a/algorithms/rateControl/rateControl.rst
+++ b/algorithms/rateControl/rateControl.rst
@@ -169,3 +169,62 @@ Since each rounded float operation contributes error on the order of machine eps
 
 The fuzz test passes when every output component from the single-precision algorithm agrees with the
 double-precision reference within this tolerance.
+
+Analysis of Gyroscopic Terms
+============================
+The control law omits two gyroscopic coupling terms that appear in the full Euler equation:
+
+.. math::
+
+    \boldsymbol{\tau}_{\text{gyro,1}} = \boldsymbol{\omega}_{RN,B} \times [I]\,\boldsymbol{\omega}_{BN,B}
+
+    \boldsymbol{\tau}_{\text{gyro,2}} = [I]\bigl(-\boldsymbol{\omega}_{BN,B} \times \boldsymbol{\omega}_{RN,B}\bigr)
+
+This section bounds their magnitude against the per-axis torque authority limits (25 N·m about X,
+14 N·m about Y and Z) to justify that omission.
+
+Inertia
+-------
+The spacecraft inertia about the centre of mass in the body frame is assembled from
+``spacecraft_props.yaml`` (deployed configuration, BOL propellant loading) by
+``dynamics.py::set_spacecraft_hub()``:
+
+.. list-table::
+   :widths: 20 20 20
+   :header-rows: 0
+
+   * - 2261.0
+     - −85.0
+     - 29.9
+   * - −85.0
+     - 4898.6
+     - 86.1
+   * - 29.9
+     - 86.1
+     - 4077.9
+
+Units: kg·m²
+
+The largest principal moment of inertia is :math:`I_{\max} = 4899` kg·m².
+
+Magnitude Bound
+---------------
+During rate damping, both :math:`\boldsymbol{\omega}_{BN,B}` and :math:`\boldsymbol{\omega}_{RN,B}`
+are assumed bounded by :math:`\omega_{\max} = 1` deg/s = 0.01745 rad/s.
+
+Using the vector-norm inequality :math:`\|\mathbf{a} \times \mathbf{b}\| \le \|\mathbf{a}\|\,\|\mathbf{b}\|`:
+
+.. math::
+
+    \|\boldsymbol{\tau}_{\text{gyro,1}}\| \le \|\boldsymbol{\omega}_{RN,B}\|\,\|[I]\,\boldsymbol{\omega}_{BN,B}\|
+    \le \omega_{\max} \cdot I_{\max} \cdot \omega_{\max}
+    = (0.01745)^2 \times 4899 \approx 1.49 \text{ N·m}
+
+    \|\boldsymbol{\tau}_{\text{gyro,2}}\| \le I_{\max}\,\|\boldsymbol{\omega}_{BN,B} \times \boldsymbol{\omega}_{RN,B}\|
+    \le I_{\max} \cdot \omega_{\max}^2
+    \approx 1.49 \text{ N·m}
+
+The combined worst-case magnitude is therefore **2.98 N·m**, which is:
+
+- 11.9 % of the 25 N·m X-axis torque limit
+- 21.3 % of the 14 N·m Y/Z-axis torque limit

--- a/algorithms/rateControl/rateControl.rst
+++ b/algorithms/rateControl/rateControl.rst
@@ -85,3 +85,87 @@ In both cases, the computed control torque is compared with the analytical contr
 
 The test runs for :math:`1` second with :math:`0.5` second time step. All the attitude guidance and spacecraft configuration parameters are defined and connected to the messages.
 The success criteria for this test is to have the commanded control torque match the analytical value with a tolerance of :math:`10^{-7}` [N·m] for both test cases.
+
+Fuzz Test Description
+=====================
+The fuzz test is located in ``algorithms/rateControl/_tests/test_rateControl_fuzz.cpp``. It uses
+`FuzzTest <https://github.com/google/fuzztest>`_ to generate a wide range of valid inputs and check
+that the single-precision algorithm output agrees with a double-precision reference computation
+evaluated on the same float-valued test case.
+
+Input Domains
+-------------
+The fuzzer drives ``fuzzAdapterRateControl`` with the following parameter ranges:
+
+.. list-table:: Fuzz Input Domains
+   :widths: 30 20 50
+   :header-rows: 1
+
+   * - **Parameter**
+     - **Type / Range**
+     - **Description**
+   * - ``ev1``, ``ev2``
+     - ``float`` [1, 1×10\ :sup:`6`]
+     - Eigenvalue magnitudes used to construct a valid positive-definite inertia matrix with ``generateValidInertiaMatrix``.
+   * - ``sigma1``, ``sigma2``, ``sigma3``
+     - ``float`` [1×10\ :sup:`-6`, 1]
+     - Off-diagonal shaping parameters for the inertia matrix.
+   * - ``DerivativeGainP``
+     - ``double`` [0, 1×10\ :sup:`6`]
+     - Derivative feedback gain :math:`P`.
+   * - ``knownTorque_a``
+     - ``double[3]`` [−1×10\ :sup:`6`, 1×10\ :sup:`6`]
+     - Known external disturbance torque :math:`\boldsymbol{L}_{\text{known}}` [N·m].
+   * - ``omega_BR_a``
+     - ``double[3]`` [−1×10\ :sup:`6`, 1×10\ :sup:`6`]
+     - Angular rate error :math:`\boldsymbol{\omega}_{BR,B}` [rad/s].
+   * - ``domega_RN_a``
+     - ``double[3]`` [−1×10\ :sup:`6`, 1×10\ :sup:`6`]
+     - Reference angular acceleration :math:`\dot{\boldsymbol{\omega}}_{RN,B}` [rad/s\ :sup:`2`].
+
+Test Method
+-----------
+The algorithm operates in single precision, so the fuzzed inputs are first converted to ``float`` to
+form the actual test case. The test then performs two computations:
+
+#. Run ``RateControlAlgorithm::update()`` in ``float``.
+#. Convert those same float values to ``double`` and evaluate the same formula with the independent
+   helper ``referenceUpdate()``.
+
+This checks whether the flight software implementation matches a higher-precision evaluation of the
+same float-valued inputs.
+
+.. code-block:: cpp
+
+    const Eigen::Vector3f out_alg = alg.update(omega_BR_B_f, domega_RN_B_f);
+
+    const Eigen::Vector3d out_ref_d =
+        referenceUpdate(spacecraftInertia_f.cast<double>(),
+                        static_cast<double>(derivativeGainP_f),
+                        knownTorquePntB_B_f.cast<double>(),
+                        omega_BR_B_f.cast<double>(),
+                        domega_RN_B_f.cast<double>());
+
+Comparison Tolerance
+--------------------
+The comparison uses ``EXPECT_NEAR`` with a small absolute tolerance based on the magnitudes of the
+terms in each torque component:
+
+.. math::
+
+    \text{tol}_i = 8 \, \varepsilon_{\text{float}}
+    \Bigl(
+    |P \omega_i|
+    + \sum_j |I_{ij}\dot{\omega}_j|
+    + |L_i|
+    \Bigr)
+    + \text{float\_min}
+
+This tolerance is used instead of ``EXPECT_FLOAT_EQ`` because large terms can nearly cancel, making
+the final result much smaller than the intermediate products. In that case, a fixed ULP-based check
+can be too strict, while the bound above correctly scales with the size of the contributing terms.
+Each torque component is formed from 4 float multiplications and about 4 float add/subtract operations.
+Since each rounded float operation contributes error on the order of machine epsilon times the magnitude of the terms involved, a factor of 8 is a simple conservative bound for the total accumulated roundoff.
+
+The fuzz test passes when every output component from the single-precision algorithm agrees with the
+double-precision reference within this tolerance.

--- a/algorithms/rateControl/rateControl.rst
+++ b/algorithms/rateControl/rateControl.rst
@@ -4,10 +4,10 @@ Rate Control Algorithm
 
 Introduction
 ============
-The rate control flight software module computes the required body frame control torque to achieve a desired angular velocity. Each time a new guidance message is written to the module,
+The rate control flight software module computes the required body frame control torque to achieve a desired angular velocity. Each time a new guidance data is written to the module,
 the torque vector is computed, taking into consideration the reference frame rotation, angular acceleration, and any known external disturbances.
-The module has a feedback term to stabilize the spacecraft by applying an opposite torque to damp the rotational rate error. It also has a coupling and feedforward terms to account for
-the gyroscopic effects and the natural motion of the rotating reference frame, respectively. The output torque is written in the body frame where it can be sent to the downstream actuator's module.
+The module has a feedback term to stabilize the spacecraft by applying an opposite torque to damp the rotational rate error and a reference angular-acceleration feedforward term.
+The output torque is written in the body frame where it can be sent to the downstream actuator's module.
 
 
 Module Input/Output Messages
@@ -22,19 +22,19 @@ structure definition, while the description provides information on what this me
    * - **Msg Variable Name**
      - **Msg Type**
      - **Description**
-   * - ``guidInMsg``
-     - :ref:`AttGuidMsgF32Payload`
-     - Input message containing the attitude guidance message, including Modified Rodrigues Parameters (MRP), rate error, reference angular rate, and angular acceleration.
-   * - ``vehConfigInMsg``
-     - :ref:`VehicleConfigMsgF32Payload`
-     - Input message containing the spacecraft configuration, including its inertia tensor, mass and Center Of Mass (COM).
-   * - ``cmdTorqueOutMsg``
-     - :ref:`CmdTorqueBodyMsgF32Payload`
-     - Output message containing the commanded torque expressed in the body frame components.
+   * - ``omega_BR_B``
+     - Eigen::Vector3f
+     - Input rate error in the body frame components [rad/s].
+   * - ``domega_RN_B``
+     - Eigen::Vector3f
+     - Input reference angular acceleration in the body frame components [rad/(s^2)].
+   * - ``L_r``
+     - Eigen::Vector3f
+     - Output commanded torque expressed in the body frame components [Nm].
 
 Algorithm Flow
 ==============
-Each time a new attitude guidance message is read, the module computes the control torque
+Each time a new attitude guidance data is read, the module computes the control torque
 vector :math:`\mathbf{L}_r` expressed in the body frame. The control is similar to :ref:`mrpPD`,
 but it does not feed back on the orientation error, instead, it  purely damps the rate error and take
 into account the reference motion and any external torques.
@@ -44,29 +44,19 @@ The control torque is calculated as
 .. math::
 
     \mathbf{L}_r = - P \, \boldsymbol{\omega}_{BR,B}
-      + \boldsymbol{\omega}_{RN,B} \times [I] \boldsymbol{\omega}_{BN,B}
-      + [I] (\dot{\boldsymbol{\omega}_{RN,B}} - \boldsymbol{\omega}_{BN,B} \times \boldsymbol{\omega}_{RN,B})
+      + [I] (\dot{\boldsymbol{\omega}_{RN,B}})
       - \boldsymbol{L}_{known}
 
 where:
 
 - :math:`P` is a positive, user-defined scalar feedback gain [N.m.s].
 - :math:`\boldsymbol{\omega}_{BR,B}` is the angular velocity of the body frame relative to the reference frame expressed in the body frame components [rad/s].
-- :math:`\boldsymbol{\omega}_{RN,B}` is the angular velocity of the reference frame relative to the inertial frame expressed in the body frame components [rad/s].
 - :math:`[I]` is the spacecraft inertia about point B expressed in the body frame components [kg.m^2].
-- :math:`\boldsymbol{\omega}_{BN,B}` is the total angular velocity of the body frame relative to the inertial frame expressed in the body frame components, and its defined as:
-
-
-  .. math::
-      \boldsymbol{\omega}_{BN,B} =
-      \boldsymbol{\omega}_{BR,B} + \boldsymbol{\omega}_{RN,B} \quad [\text{rad/s}]
-
 - :math:`\dot{\boldsymbol{\omega}_{RN,B}}` is the angular acceleration of the reference frame relative to the inertial frame, expressed in the body frame [rad/s^2].
 - :math:`\boldsymbol{\tau}_{\text{known}}` represents any known external disturbance torques expressed in the body frame [N.m].
 
 The first term is the feedback law, that applies a negative torque to damp the rate error.
-The second and third terms are the coupling and feedforward components where they capture the gyroscopic effects, and ensures the controller is taking into account the motion of the rotating
-reference frame, respectively.
+The second term is a feedforward component taking into account the motion of the rotating reference frame.
 The last term subtracts any external torques that might act on the spacecraft.
 
 
@@ -74,10 +64,9 @@ Controller Functions
 ====================
 Below is a list of functions that this flight software module performs:
 
-- Reads the incoming attitude guidance message that contains the rate error, reference angular rate, and angular acceleration.
+- Reads the incoming attitude guidance message that contains the rate error and reference angular acceleration.
 - Reads the vehicle configuration message that includes the spaceraft inertia tensor and mass properties.
 - Computes the control torque required to compensate for the rate error.
-- Writes the computed body frame control torque to the output message.
 
 
 Controller Assumptions and Limitations

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -8,18 +8,16 @@
 #include "../freestandingInvalidArgument.h"
 #include "../utilities/validInertiaCheck.h"
 
-/*! This method takes the attitude and rate errors relative to the reference frame, as well as
-the reference frame angular rates and acceleration, and computes the required control torque Lr.
- @return Eigen::Vector3d control torque
- @param InputGuidanceData Attitude guidance input
+/*! Computes the required control torque Lr from the attitude rate error and the reference frame angular acceleration.
+ @param omega_BR_B   Angular velocity of the body frame relative to the reference frame, expressed in body frame
+ coordinates [rad/s]
+ @param domega_RN_B  Time derivative of the reference frame angular velocity, expressed in body frame coordinates
+ [rad/s^2]
+ @return             Required control torque about point B [Nm]
 */
 Eigen::Vector3f RateControlAlgorithm::update(const Eigen::Vector3f& omega_BR_B,
-                                             const Eigen::Vector3f& omega_RN_B,
                                              const Eigen::Vector3f& domega_RN_B) const {
-    const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
-    const Eigen::Vector3f Lr = -this->P * omega_BR_B + omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
-                               this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
-                               this->knownTorquePntB_B;  // [Nm]
+    const Eigen::Vector3f Lr = -this->P * omega_BR_B + this->ISCPntB_B * domega_RN_B - this->knownTorquePntB_B;  // [Nm]
     return Lr;
 }
 

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -5,37 +5,27 @@
 */
 
 #include "rateControlAlgorithm.h"
-
 #include "../freestandingInvalidArgument.h"
-#include "architecture/utilities/eigenSupport.h"
-
-#include <Eigen/Geometry>
+#include "../utilities/validInertiaCheck.h"
 
 /*! This method takes the attitude and rate errors relative to the reference frame, as well as
 the reference frame angular rates and acceleration, and computes the required control torque Lr.
- @return torqueCmdOut
- @param attGuidIn Attitude guidance input
+ @return Eigen::Vector3d control torque
+ @param InputGuidanceData Attitude guidance input
 */
-CmdTorqueBodyMsgF32Payload RateControlAlgorithm::update(AttGuidMsgF32Payload attGuidIn) const {
-    CmdTorqueBodyMsgF32Payload torqueCmdOut{};
-
-    // Compute required attitude control torque vector
-    const Eigen::Vector3f omega_BR_B = cArrayToEigenVector(attGuidIn.omega_BR_B);
-    const Eigen::Vector3f omega_RN_B = cArrayToEigenVector(attGuidIn.omega_RN_B);
+Eigen::Vector3f RateControlAlgorithm::update(const Eigen::Vector3f& omega_BR_B,
+                                             const Eigen::Vector3f& omega_RN_B,
+                                             const Eigen::Vector3f& domega_RN_B) const {
     const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
-    const Eigen::Vector3f domega_RN_B = cArrayToEigenVector(attGuidIn.domega_RN_B);
     const Eigen::Vector3f Lr = -this->P * omega_BR_B + omega_RN_B.cross(this->ISCPntB_B * omega_BN_B) +
                                this->ISCPntB_B * (domega_RN_B - omega_BN_B.cross(omega_RN_B)) -
                                this->knownTorquePntB_B;  // [Nm]
-
-    eigenVectorToCArray(Lr, torqueCmdOut.torqueRequestBody);
-
-    return torqueCmdOut;
+    return Lr;
 }
 
 /*! This method sets the spacecraft inertia according to the vehicle configuration input message
  @return void
- @param vehicleConfigIn Vehicle config input
+ @param spacecraftInertia spacecraft inertia
 */
 void RateControlAlgorithm::setSpacecraftInertia(VehicleConfigMsgF32Payload vehicleConfigIn) {
     this->ISCPntB_B = cArrayToEigenMatrix3(vehicleConfigIn.ISCPntB_B);
@@ -43,13 +33,13 @@ void RateControlAlgorithm::setSpacecraftInertia(VehicleConfigMsgF32Payload vehic
 
 /*! Setter method for the derivative gain P.
  @return void
- @param P [N*m*s] Rate error feedback gain applied
+ @param derivativeGainP [N*m*s] Rate error feedback gain applied
 */
-void RateControlAlgorithm::setDerivativeGainP(const float P) {
-    if (P < 0.0) {
+void RateControlAlgorithm::setDerivativeGainP(const float derivativeGainP) {
+    if (derivativeGainP < 0.0) {
         FS_THROW_INVALID_ARGUMENT("Feedback gain P must not be negative");
     }
-    this->P = P;
+    this->P = derivativeGainP;
 }
 
 /*! Getter method for the derivative gain P.
@@ -59,10 +49,10 @@ float RateControlAlgorithm::getDerivativeGainP() const { return this->P; }
 
 /*! Setter method for the known external torque about point B.
  @return void
- @param knownTorquePntB_B [N*m] Known external torque expressed in body frame components
+ @param torquePntB_B [N*m] Known external torque expressed in body frame components
 */
-void RateControlAlgorithm::setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B) {
-    this->knownTorquePntB_B = knownTorquePntB_B;
+void RateControlAlgorithm::setKnownTorquePntB_B(const Eigen::Vector3f& torquePntB_B) {
+    this->knownTorquePntB_B = torquePntB_B;
 }
 
 /*! Getter method for the known torque about point B.

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -27,8 +27,12 @@ Eigen::Vector3f RateControlAlgorithm::update(const Eigen::Vector3f& omega_BR_B,
  @return void
  @param spacecraftInertia spacecraft inertia
 */
-void RateControlAlgorithm::setSpacecraftInertia(VehicleConfigMsgF32Payload vehicleConfigIn) {
-    this->ISCPntB_B = cArrayToEigenMatrix3(vehicleConfigIn.ISCPntB_B);
+void RateControlAlgorithm::setSpacecraftInertia(const Eigen::Matrix3f& spacecraftInertia) {
+    if (inertiaIsValid(spacecraftInertia)) {
+        this->ISCPntB_B = spacecraftInertia;
+    } else {
+        FS_THROW_INVALID_ARGUMENT("Invalid spacecraft inertia");
+    }
 }
 
 /*! Setter method for the derivative gain P.

--- a/algorithms/rateControl/rateControlAlgorithm.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm.cpp
@@ -9,11 +9,11 @@
 #include "../utilities/validInertiaCheck.h"
 
 /*! Computes the required control torque Lr from the attitude rate error and the reference frame angular acceleration.
- @param omega_BR_B   Angular velocity of the body frame relative to the reference frame, expressed in body frame
- coordinates [rad/s]
- @param domega_RN_B  Time derivative of the reference frame angular velocity, expressed in body frame coordinates
- [rad/s^2]
- @return             Required control torque about point B [Nm]
+ @param omega_BR_B the angular velocity of the body frame relative to the reference frame,
+ expressed in body frame coordinates [rad/s]
+ @param domega_RN_B the time derivative of the reference frame angular velocity, expressed in body
+ frame coordinates [rad/s^2]
+ @return the required control torque, expressed in body frame coordinates [Nm]
 */
 Eigen::Vector3f RateControlAlgorithm::update(const Eigen::Vector3f& omega_BR_B,
                                              const Eigen::Vector3f& domega_RN_B) const {
@@ -22,8 +22,7 @@ Eigen::Vector3f RateControlAlgorithm::update(const Eigen::Vector3f& omega_BR_B,
 }
 
 /*! This method sets the spacecraft inertia according to the vehicle configuration input message
- @return void
- @param spacecraftInertia spacecraft inertia
+ @param spacecraftInertia the spacecraft inertia to set
 */
 void RateControlAlgorithm::setSpacecraftInertia(const Eigen::Matrix3f& spacecraftInertia) {
     if (inertiaIsValid(spacecraftInertia)) {
@@ -34,8 +33,7 @@ void RateControlAlgorithm::setSpacecraftInertia(const Eigen::Matrix3f& spacecraf
 }
 
 /*! Setter method for the derivative gain P.
- @return void
- @param derivativeGainP [N*m*s] Rate error feedback gain applied
+ @param derivativeGainP the derivative gain P
 */
 void RateControlAlgorithm::setDerivativeGainP(const float derivativeGainP) {
     if (derivativeGainP < 0.0) {
@@ -45,19 +43,18 @@ void RateControlAlgorithm::setDerivativeGainP(const float derivativeGainP) {
 }
 
 /*! Getter method for the derivative gain P.
- @return const float
+ @return the derivative gain P
 */
 float RateControlAlgorithm::getDerivativeGainP() const { return this->P; }
 
-/*! Setter method for the known external torque about point B.
- @return void
- @param torquePntB_B [N*m] Known external torque expressed in body frame components
+/*! Setter method for the known external torque.
+ @param torquePntB_B the known external torque [N*m] expressed in body frame coordinates
 */
 void RateControlAlgorithm::setKnownTorquePntB_B(const Eigen::Vector3f& torquePntB_B) {
     this->knownTorquePntB_B = torquePntB_B;
 }
 
 /*! Getter method for the known torque about point B.
- @return const Eigen::Vector3f
+ @return the known external torque [N*m] expressed in body frame coordinates
 */
 const Eigen::Vector3f& RateControlAlgorithm::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }

--- a/algorithms/rateControl/rateControlAlgorithm.h
+++ b/algorithms/rateControl/rateControlAlgorithm.h
@@ -4,22 +4,21 @@
  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 */
 
-#ifndef F32XIMERA_RATE_CONTROL_ALGORITHM_H
-#define F32XIMERA_RATE_CONTROL_ALGORITHM_H
-
-#include "msgPayloadDef/AttGuidMsgF32Payload.h"
-#include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
-#include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
+#ifndef F32XMERA_RATE_CONTROL_ALGORITHM_H
+#define F32XMERA_RATE_CONTROL_ALGORITHM_H
 
 #include <Eigen/Core>
 
 class RateControlAlgorithm {
    public:
-    CmdTorqueBodyMsgF32Payload update(AttGuidMsgF32Payload attGuidIn) const;
-    void setSpacecraftInertia(VehicleConfigMsgF32Payload vehicleConfigIn);
-    void setDerivativeGainP(float P);
+    Eigen::Vector3f update(const Eigen::Vector3f& omega_BR_B,
+                           const Eigen::Vector3f& omega_RN_B,
+                           const Eigen::Vector3f& domega_RN_B) const;
+    void setSpacecraftInertia(const Eigen::Matrix3f& spacecraftInertia);
+    void setDerivativeGainP(float derivativeGainP);  //!< [-] non-negative derivative gain
     float getDerivativeGainP() const;
-    void setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B);
+    void setKnownTorquePntB_B(
+        const Eigen::Vector3f& torquePntB_B);  //!< [N*m] Known external torque expressed in body frame components
     const Eigen::Vector3f& getKnownTorquePntB_B() const;
 
    private:

--- a/algorithms/rateControl/rateControlAlgorithm.h
+++ b/algorithms/rateControl/rateControlAlgorithm.h
@@ -11,9 +11,7 @@
 
 class RateControlAlgorithm {
    public:
-    Eigen::Vector3f update(const Eigen::Vector3f& omega_BR_B,
-                           const Eigen::Vector3f& omega_RN_B,
-                           const Eigen::Vector3f& domega_RN_B) const;
+    Eigen::Vector3f update(const Eigen::Vector3f& omega_BR_B, const Eigen::Vector3f& domega_RN_B) const;
     void setSpacecraftInertia(const Eigen::Matrix3f& spacecraftInertia);
     void setDerivativeGainP(float derivativeGainP);  //!< [-] non-negative derivative gain
     float getDerivativeGainP() const;

--- a/algorithms/rateControl/rateControlAlgorithm_c.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm_c.cpp
@@ -18,14 +18,14 @@ void RateControlAlgorithm_destroy(RateControlAlgorithm* self) {
     delete reinterpret_cast<::RateControlAlgorithm*>(self);
 }
 
-CmdTorqueBodyMsgF32Payload RateControlAlgorithm_update(const RateControlAlgorithm* self,
-                                                       const AttGuidMsgF32Payload* attGuidIn) {
-    return reinterpret_cast<const ::RateControlAlgorithm*>(self)->update(*attGuidIn);
+Eigen::Vector3f RateControlAlgorithm_update(const RateControlAlgorithm* self,
+                                            const Eigen::Vector3f& omega_BR_B,
+                                            const Eigen::Vector3f& domega_RN_B) {
+    return reinterpret_cast<const ::RateControlAlgorithm*>(self)->update(omega_BR_B, domega_RN_B);
 }
 
-void RateControlAlgorithm_setSpacecraftInertia(RateControlAlgorithm* self,
-                                               const VehicleConfigMsgF32Payload* vehicleConfigIn) {
-    reinterpret_cast<::RateControlAlgorithm*>(self)->setSpacecraftInertia(*vehicleConfigIn);
+void RateControlAlgorithm_setSpacecraftInertia(RateControlAlgorithm* self, const Eigen::Matrix3f& spacecraftInertia) {
+    reinterpret_cast<::RateControlAlgorithm*>(self)->setSpacecraftInertia(spacecraftInertia);
 }
 
 void RateControlAlgorithm_setDerivativeGainP(RateControlAlgorithm* self, float P) {

--- a/algorithms/rateControl/rateControlAlgorithm_c.h
+++ b/algorithms/rateControl/rateControlAlgorithm_c.h
@@ -7,9 +7,7 @@
 #ifndef F32XIMERA_RATE_CONTROL_ALGORITHM_C_H
 #define F32XIMERA_RATE_CONTROL_ALGORITHM_C_H
 
-#include "msgPayloadDef/AttGuidMsgF32Payload.h"
-#include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
-#include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
+#include <Eigen/Core>
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,20 +39,21 @@ void RateControlAlgorithm_destroy(RateControlAlgorithm* self);
 
 /**
  * @brief Run the rate control update step.
- * @param self     Pointer to the instance.
- * @param attGuidIn Pointer to the attitude guidance input.
- * @return CmdTorqueBodyMsgF32Payload The computed torque command.
+ * @param self         Pointer to the instance.
+ * @param omega_BR_B   Angular velocity of body relative to reference frame in body frame components [rad/s].
+ * @param domega_RN_B  Time derivative of reference frame angular velocity in body frame components [rad/s^2].
+ * @return Eigen::Vector3f Required control torque about point B [Nm].
  */
-CmdTorqueBodyMsgF32Payload RateControlAlgorithm_update(const RateControlAlgorithm* self,
-                                                       const AttGuidMsgF32Payload* attGuidIn);
+Eigen::Vector3f RateControlAlgorithm_update(const RateControlAlgorithm* self,
+                                            const Eigen::Vector3f& omega_BR_B,
+                                            const Eigen::Vector3f& domega_RN_B);
 
 /**
  * @brief Set the spacecraft inertia configuration.
  * @param self Pointer to the instance.
  * @param vehicleConfigIn Pointer to the vehicle configuration payload.
  */
-void RateControlAlgorithm_setSpacecraftInertia(RateControlAlgorithm* self,
-                                               const VehicleConfigMsgF32Payload* vehicleConfigIn);
+void RateControlAlgorithm_setSpacecraftInertia(RateControlAlgorithm* self, const Eigen::Matrix3f& spacecraftInertia);
 
 /**
  * @brief Set the derivative gain P.


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2052
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  
* 
## Description
Implement action items after V&V

- drop the cross terms in the algorithm update (as discussed)
- use utilities generateValidInertiaMatrix for fuzz tests
- update python test to using np.float32 only
- Note: the last commit tries to convert the regression output to double. However, this makes the fuzz test fails because the inertia matrix is generated (using floats), but all the other variables are doubles.

## Verification
pass python g- and fuzz-tests

## Documentation
See .rst

## Future work
N/A
