### PR TITLE
Add condition number to generateValidInertia

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: "Pull Request"
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,6 +2,7 @@ name: "Static Analysis"
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/algorithms/utilities/_tests/utilitiesHelpers.hpp
+++ b/algorithms/utilities/_tests/utilitiesHelpers.hpp
@@ -26,11 +26,17 @@ inline Eigen::Matrix3f GenerateValidInertiaMatrix(float const ev1,
                                                   float const sigma1,
                                                   float const sigma2,
                                                   float const sigma3) {
-    /* Sort the first two eigenvalues so ev_min <= ev_max */
-    const float ev_min = std::min(ev1, ev2);
+    /* Sort the first two eigenvalues so ev_min <= ev_max,
+       and clamp the ratio to avoid float32 precision loss
+       in the R^T * D * R round-trip. */
+    constexpr float maxConditionNumber = 1e4f;
     const float ev_max = std::max(ev1, ev2);
-    const float ev3_min = (ev_max - ev_min > 1e-5f) ? ev_max - ev_min + 1e-5f : 1e-5f;
-    const float ev3_max = ev_max + ev_min - 1e-5f;
+    const float ev_min = std::max(std::min(ev1, ev2), ev_max / maxConditionNumber);
+    constexpr float triangleInequalityTolerance = 1e-5f;
+    const float ev3_min = (ev_max - ev_min > triangleInequalityTolerance)
+                              ? ev_max - ev_min + triangleInequalityTolerance
+                              : triangleInequalityTolerance;
+    const float ev3_max = ev_max + ev_min - triangleInequalityTolerance;
 
     const float ev3 = ev3_min + (0.5 * (ev3_max - ev3_min));
     const std::array<float, 3> eigenvalues = {ev_min, ev3, ev_max};

--- a/algorithms/utilities/_tests/utilitiesHelpers.hpp
+++ b/algorithms/utilities/_tests/utilitiesHelpers.hpp
@@ -21,7 +21,7 @@ inline Eigen::Matrix3f mrpToDcm(const Eigen::Vector3f& mrp) {
 }
 
 /* Function to generate a general inertia matrix */
-inline Eigen::Matrix3f GenerateValidInertiaMatrix(float const ev1,
+inline Eigen::Matrix3f generateValidInertiaMatrix(float const ev1,
                                                   float const ev2,
                                                   float const sigma1,
                                                   float const sigma2,
@@ -58,7 +58,7 @@ inline Eigen::Matrix3f GenerateValidInertiaMatrix(float const ev1,
 
 /* Test validity against generated inertia matrix */
 inline void testInertiaValidity(float eigen1, float eigen2, float sigma1, float sigma2, float sigma3) {
-    const Eigen::Matrix3f inertia = GenerateValidInertiaMatrix(eigen1, eigen2, sigma1, sigma2, sigma3);
+    const Eigen::Matrix3f inertia = generateValidInertiaMatrix(eigen1, eigen2, sigma1, sigma2, sigma3);
 
     EXPECT_TRUE(inertiaIsValid(inertia));
 }


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The test_validateInertia_fuzz is failing when eigenvalues with a very large difference are passed to the `generateValidInertia()` function. E.g. ev_min = 1.0, ev_max = 834534.125. With ev3_min = 834533.125 + 1e-5 — but at magnitude ~800K, the float32 ULP is ~0.095, so the 1e-5 margin vanishes entirely and ev3_min = 834533.125. 

As a fix, a condition number variable is added to keep the two eigenvalues within range that is representable by single precision float. The resulting inertia are also physically realistic.

The second commit makes a formatting edit. The final commit updates the workflow toggles from this branch to ensure the CI is triggered upon transitioning a PR from draft to in-review.

## Verification
Fuzz tests run for 2 mins. Ci runs successfully.

## Documentation
NA

## Future work
None
