### PR TITLE
Remove ephemNavConverter from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,6 @@ set(algorithms
     "bodyRateMiscompare"
     "celestialTwoBodyPoint"
     "ephemeridesRecenter"
-    "ephemNavConverter"
     "inertial3D"
     "inertialUKF"
     "mimuMajorityVote"


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The ephemNavConverter algorithm was removed. This PR removes it from the list of algs to build.

## Verification
NA

## Documentation
NA

## Future work
None
