### PR TITLE
Update orbital motion and ephemeris to use double precision

### DIFF
--- a/algorithms/cssComm/_tests/cssCommTestHelpers.hpp
+++ b/algorithms/cssComm/_tests/cssCommTestHelpers.hpp
@@ -74,30 +74,26 @@ inline void regressionTestCssComm(uint32_t numSensors,
     alg.setChebyCount(chebyCount);
 
     std::array<double, kMaxNumChebyPolys> polynomials{};
-    std::array<float, kMaxNumChebyPolys> polynomialsF32{};
     for (std::size_t i = 0; i < chebyCoeffs.size() && i < kMaxNumChebyPolys; ++i) {
         polynomials[i] = chebyCoeffs[i];
-        polynomialsF32[i] = static_cast<float>(chebyCoeffs[i]);
     }
-    alg.setChebyPolynomials(polynomialsF32);
+    alg.setChebyPolynomials(polynomials);
 
     std::array<double, MAX_NUM_CSS_SENSORS> inputValues{};
-    std::array<float, MAX_NUM_CSS_SENSORS> inputValuesF32{};
     for (std::size_t i = 0; i < sensorInputRatios.size() && i < MAX_NUM_CSS_SENSORS; ++i) {
         inputValues[i] = sensorInputRatios[i] * maxSensorValue;
-        inputValuesF32[i] = static_cast<float>(sensorInputRatios[i] * maxSensorValue);
     }
 
-    std::array<float, MAX_NUM_CSS_SENSORS> output{};
-    EXPECT_NO_THROW(output = alg.update(inputValuesF32));
+    std::array<double, MAX_NUM_CSS_SENSORS> output{};
+    EXPECT_NO_THROW(output = alg.update(inputValues));
 
     auto reference = referenceUpdate(numSensors, maxSensorValue, chebyCount, polynomials, inputValues);
 
     for (uint32_t i = 0; i < MAX_NUM_CSS_SENSORS; ++i) {
-        EXPECT_NEAR(output[i], reference[i], 1e-3F);
+        EXPECT_NEAR(output[i], reference[i], 1e-12);
         EXPECT_TRUE(std::isfinite(output[i]));
-        EXPECT_GE(output[i], 0.0F);
-        EXPECT_LE(output[i], 1.0F);
+        EXPECT_GE(output[i], 0.0);
+        EXPECT_LE(output[i], 1.0);
     }
 }
 

--- a/algorithms/cssComm/_tests/test_cssComm.cpp
+++ b/algorithms/cssComm/_tests/test_cssComm.cpp
@@ -2,7 +2,7 @@
 
 TEST(CssCommTest, RegressionTest) {
     uint32_t numSensors = 4;
-    float maxSensorValue = 500e-6;
+    double maxSensorValue = 500e-6;
     uint32_t chebyCount = 3;
 
     std::vector chebyCoeffs = {0.1, -0.2, 0.05};
@@ -21,8 +21,8 @@ TEST(CssCommTest, SetupTest) {
     EXPECT_THROW(alg.setNumSensors(MAX_NUM_CSS_SENSORS + 1), fs::invalid_argument);
 
     // maxSensorValue: 0 and negative should throw
-    EXPECT_THROW(alg.setMaxSensorValue(0.0F), fs::invalid_argument);
-    EXPECT_THROW(alg.setMaxSensorValue(-1.0F), fs::invalid_argument);
+    EXPECT_THROW(alg.setMaxSensorValue(0.0), fs::invalid_argument);
+    EXPECT_THROW(alg.setMaxSensorValue(-1.0), fs::invalid_argument);
 
     // chebyCount: 0 and above-max should throw
     EXPECT_THROW(alg.setChebyCount(0), fs::invalid_argument);
@@ -32,19 +32,19 @@ TEST(CssCommTest, SetupTest) {
     alg.setNumSensors(4);
     EXPECT_EQ(alg.getNumSensors(), 4u);
 
-    alg.setMaxSensorValue(500e-6F);
-    EXPECT_FLOAT_EQ(alg.getMaxSensorValue(), 500e-6F);
+    alg.setMaxSensorValue(500e-6);
+    EXPECT_DOUBLE_EQ(alg.getMaxSensorValue(), 500e-6);
 
     alg.setChebyCount(3);
     EXPECT_EQ(alg.getChebyCount(), 3u);
 
-    std::array<float, kMaxNumChebyPolys> polys{};
-    polys[0] = 0.1F;
-    polys[1] = -0.2F;
+    std::array<double, kMaxNumChebyPolys> polys{};
+    polys[0] = 0.1;
+    polys[1] = -0.2;
     alg.setChebyPolynomials(polys);
     auto retrieved = alg.getChebyPolynomials();
     for (std::size_t i = 0; i < kMaxNumChebyPolys; ++i) {
-        EXPECT_FLOAT_EQ(retrieved[i], polys[i]);
+        EXPECT_DOUBLE_EQ(retrieved[i], polys[i]);
     }
 }
 
@@ -56,45 +56,45 @@ TEST(CssCommTest, SetupTest) {
 TEST(CssCommTest, SaturationClampingToOne) {
     CssCommAlgorithm alg{};
     alg.setNumSensors(1);
-    alg.setMaxSensorValue(1.0F);
+    alg.setMaxSensorValue(1.0);
     alg.setChebyCount(1);
 
     // With chebyPolynomials[0] = 2.0 and input = 1.0:
     // scaled = 1.0, correction = 2.0, corrected = 3.0 → clamped to 1.0
-    std::array<float, kMaxNumChebyPolys> polys{};
-    polys[0] = 2.0F;
+    std::array<double, kMaxNumChebyPolys> polys{};
+    polys[0] = 2.0;
     alg.setChebyPolynomials(polys);
 
-    std::array<float, MAX_NUM_CSS_SENSORS> input{};
-    input[0] = 1.0F;
+    std::array<double, MAX_NUM_CSS_SENSORS> input{};
+    input[0] = 1.0;
     auto output = alg.update(input);
 
-    EXPECT_FLOAT_EQ(output[0], 1.0F);
+    EXPECT_DOUBLE_EQ(output[0], 1.0);
 }
 
 // For any valid configuration and inputs, every output is in [0.0, 1.0].
 TEST(CssCommTest, OutputAlwaysInUnitRange) {
     CssCommAlgorithm alg{};
     alg.setNumSensors(MAX_NUM_CSS_SENSORS);
-    alg.setMaxSensorValue(100.0F);
+    alg.setMaxSensorValue(100.0);
     alg.setChebyCount(4);
 
-    std::array<float, kMaxNumChebyPolys> polys{};
-    polys[0] = 1e4F;
-    polys[1] = -5e3F;
-    polys[2] = 2e3F;
-    polys[3] = -1e3F;
+    std::array<double, kMaxNumChebyPolys> polys{};
+    polys[0] = 1e4;
+    polys[1] = -5e3;
+    polys[2] = 2e3;
+    polys[3] = -1e3;
     alg.setChebyPolynomials(polys);
 
-    std::array<float, MAX_NUM_CSS_SENSORS> input{};
+    std::array<double, MAX_NUM_CSS_SENSORS> input{};
     for (uint32_t i = 0; i < MAX_NUM_CSS_SENSORS; ++i) {
-        input[i] = static_cast<float>(i) * 20.0F - 200.0F;  // range of values including negatives
+        input[i] = static_cast<double>(i) * 20.0 - 200.0;  // range of values including negatives
     }
     auto output = alg.update(input);
 
     for (uint32_t i = 0; i < MAX_NUM_CSS_SENSORS; ++i) {
-        EXPECT_GE(output[i], 0.0F);
-        EXPECT_LE(output[i], 1.0F);
+        EXPECT_GE(output[i], 0.0);
+        EXPECT_LE(output[i], 1.0);
         EXPECT_TRUE(std::isfinite(output[i]));
     }
 }
@@ -103,26 +103,26 @@ TEST(CssCommTest, OutputAlwaysInUnitRange) {
 TEST(CssCommTest, UnusedSensorsRemainZero) {
     CssCommAlgorithm alg{};
     alg.setNumSensors(2);
-    alg.setMaxSensorValue(1.0F);
+    alg.setMaxSensorValue(1.0);
     alg.setChebyCount(1);
 
-    std::array<float, kMaxNumChebyPolys> polys{};
-    polys[0] = 0.5F;
+    std::array<double, kMaxNumChebyPolys> polys{};
+    polys[0] = 0.5;
     alg.setChebyPolynomials(polys);
 
-    std::array<float, MAX_NUM_CSS_SENSORS> input{};
+    std::array<double, MAX_NUM_CSS_SENSORS> input{};
     for (auto& v : input) {
-        v = 0.5F;  // fill all entries
+        v = 0.5;  // fill all entries
     }
     auto output = alg.update(input);
 
     // First 2 sensors should have non-trivial output
-    EXPECT_GT(output[0], 0.0F);
-    EXPECT_GT(output[1], 0.0F);
+    EXPECT_GT(output[0], 0.0);
+    EXPECT_GT(output[1], 0.0);
 
     // Remaining sensors must be zero
     for (uint32_t i = 2; i < MAX_NUM_CSS_SENSORS; ++i) {
-        EXPECT_FLOAT_EQ(output[i], 0.0F);
+        EXPECT_DOUBLE_EQ(output[i], 0.0);
     }
 }
 
@@ -131,23 +131,23 @@ TEST(CssCommTest, UnusedSensorsRemainZero) {
 TEST(CssCommTest, ZeroInputIsChebyCorrection) {
     CssCommAlgorithm alg{};
     alg.setNumSensors(4);
-    alg.setMaxSensorValue(1.0F);
+    alg.setMaxSensorValue(1.0);
     alg.setChebyCount(3);
 
-    std::array<float, kMaxNumChebyPolys> polys{};
-    polys[0] = 0.3F;
-    polys[1] = 0.1F;
-    polys[2] = 0.05F;
+    std::array<double, kMaxNumChebyPolys> polys{};
+    polys[0] = 0.3;
+    polys[1] = 0.1;
+    polys[2] = 0.05;
     alg.setChebyPolynomials(polys);
 
-    std::array<float, MAX_NUM_CSS_SENSORS> input{};  // all zeros
+    std::array<double, MAX_NUM_CSS_SENSORS> input{};  // all zeros
     auto output = alg.update(input);
 
-    float expectedCorrection = calculateChebyValue(polys, 3, 0.0F);
-    float expected = std::clamp(expectedCorrection, 0.0F, 1.0F);
+    double expectedCorrection = calculateChebyValue(polys, 3, 0.0);
+    double expected = std::clamp(expectedCorrection, 0.0, 1.0);
 
     for (uint32_t i = 0; i < 4; ++i) {
-        EXPECT_NEAR(output[i], expected, 1e-6F);
+        EXPECT_NEAR(output[i], expected, 1e-14);
     }
 }
 
@@ -156,25 +156,25 @@ TEST(CssCommTest, ZeroInputIsChebyCorrection) {
 TEST(CssCommTest, ZeroChebyIsIdentity) {
     CssCommAlgorithm alg{};
     alg.setNumSensors(5);
-    alg.setMaxSensorValue(100.0F);
+    alg.setMaxSensorValue(100.0);
     alg.setChebyCount(3);
 
-    std::array<float, kMaxNumChebyPolys> polys{};  // all zeros
+    std::array<double, kMaxNumChebyPolys> polys{};  // all zeros
     alg.setChebyPolynomials(polys);
 
-    std::array<float, MAX_NUM_CSS_SENSORS> input{};
-    input[0] = 50.0F;   // scaled = 0.5
-    input[1] = 0.0F;    // scaled = 0.0
-    input[2] = 100.0F;  // scaled = 1.0
-    input[3] = -10.0F;  // scaled = -0.1 → clamped to 0.0
-    input[4] = 110.0F;  // scaled = 1.1 → clamped to 1.0
+    std::array<double, MAX_NUM_CSS_SENSORS> input{};
+    input[0] = 50.0;   // scaled = 0.5
+    input[1] = 0.0;    // scaled = 0.0
+    input[2] = 100.0;  // scaled = 1.0
+    input[3] = -10.0;  // scaled = -0.1 → clamped to 0.0
+    input[4] = 110.0;  // scaled = 1.1 → clamped to 1.0
     auto output = alg.update(input);
 
-    EXPECT_NEAR(output[0], 0.5F, 1e-6F);
-    EXPECT_NEAR(output[1], 0.0F, 1e-6F);
-    EXPECT_NEAR(output[2], 1.0F, 1e-6F);
-    EXPECT_NEAR(output[3], 0.0F, 1e-6F);
-    EXPECT_NEAR(output[4], 1.0F, 1e-6F);
+    EXPECT_NEAR(output[0], 0.5, 1e-14);
+    EXPECT_NEAR(output[1], 0.0, 1e-14);
+    EXPECT_NEAR(output[2], 1.0, 1e-14);
+    EXPECT_NEAR(output[3], 0.0, 1e-14);
+    EXPECT_NEAR(output[4], 1.0, 1e-14);
 }
 
 // ---------------------------------------------------------------------------
@@ -186,66 +186,66 @@ TEST(CssCommTest, ZeroChebyIsIdentity) {
 TEST(CssCommTest, SingleChebyCoefficient) {
     CssCommAlgorithm alg{};
     alg.setNumSensors(3);
-    alg.setMaxSensorValue(1.0F);
+    alg.setMaxSensorValue(1.0);
     alg.setChebyCount(1);
 
-    std::array<float, kMaxNumChebyPolys> polys{};
-    polys[0] = 0.2F;
+    std::array<double, kMaxNumChebyPolys> polys{};
+    polys[0] = 0.2;
     alg.setChebyPolynomials(polys);
 
-    std::array<float, MAX_NUM_CSS_SENSORS> input{};
-    input[0] = 0.0F;
-    input[1] = 0.5F;
-    input[2] = 0.8F;
+    std::array<double, MAX_NUM_CSS_SENSORS> input{};
+    input[0] = 0.0;
+    input[1] = 0.5;
+    input[2] = 0.8;
     auto output = alg.update(input);
 
     // correction = 0.2 for all inputs, so output = clamp(scaled + 0.2, 0, 1)
-    EXPECT_NEAR(output[0], 0.2F, 1e-6F);  // 0.0 + 0.2
-    EXPECT_NEAR(output[1], 0.7F, 1e-6F);  // 0.5 + 0.2
-    EXPECT_NEAR(output[2], 1.0F, 1e-6F);  // 0.8 + 0.2 = 1.0
+    EXPECT_NEAR(output[0], 0.2, 1e-14);  // 0.0 + 0.2
+    EXPECT_NEAR(output[1], 0.7, 1e-14);  // 0.5 + 0.2
+    EXPECT_NEAR(output[2], 1.0, 1e-14);  // 0.8 + 0.2 = 1.0
 }
 
 // When input exactly equals maxSensorValue, scaled = 1.0.
 TEST(CssCommTest, InputEqualsMaxSensorValue) {
     CssCommAlgorithm alg{};
     alg.setNumSensors(1);
-    alg.setMaxSensorValue(500e-6F);
+    alg.setMaxSensorValue(500e-6);
     alg.setChebyCount(2);
 
-    std::array<float, kMaxNumChebyPolys> polys{};
-    polys[0] = -0.1F;
-    polys[1] = 0.05F;
+    std::array<double, kMaxNumChebyPolys> polys{};
+    polys[0] = -0.1;
+    polys[1] = 0.05;
     alg.setChebyPolynomials(polys);
 
-    std::array<float, MAX_NUM_CSS_SENSORS> input{};
-    input[0] = 500e-6F;  // scaled = 1.0 exactly
+    std::array<double, MAX_NUM_CSS_SENSORS> input{};
+    input[0] = 500e-6;  // scaled = 1.0 exactly
     auto output = alg.update(input);
 
-    float correction = calculateChebyValue(polys, 2, 1.0F);
-    float expected = std::clamp(1.0F + correction, 0.0F, 1.0F);
-    EXPECT_NEAR(output[0], expected, 1e-6F);
+    double correction = calculateChebyValue(polys, 2, 1.0);
+    double expected = std::clamp(1.0 + correction, 0.0, 1.0);
+    EXPECT_NEAR(output[0], expected, 1e-14);
 }
 
 // All active sensors with identical input should produce identical output.
 TEST(CssCommTest, IdenticalSensorsIdenticalOutput) {
     CssCommAlgorithm alg{};
     alg.setNumSensors(MAX_NUM_CSS_SENSORS);
-    alg.setMaxSensorValue(1.0F);
+    alg.setMaxSensorValue(1.0);
     alg.setChebyCount(3);
 
-    std::array<float, kMaxNumChebyPolys> polys{};
-    polys[0] = 0.1F;
-    polys[1] = -0.05F;
-    polys[2] = 0.02F;
+    std::array<double, kMaxNumChebyPolys> polys{};
+    polys[0] = 0.1;
+    polys[1] = -0.05;
+    polys[2] = 0.02;
     alg.setChebyPolynomials(polys);
 
-    std::array<float, MAX_NUM_CSS_SENSORS> input{};
+    std::array<double, MAX_NUM_CSS_SENSORS> input{};
     for (auto& v : input) {
-        v = 0.4F;
+        v = 0.4;
     }
     auto output = alg.update(input);
 
     for (uint32_t i = 1; i < MAX_NUM_CSS_SENSORS; ++i) {
-        EXPECT_FLOAT_EQ(output[i], output[0]);
+        EXPECT_DOUBLE_EQ(output[i], output[0]);
     }
 }

--- a/algorithms/cssComm/cssComm.cpp
+++ b/algorithms/cssComm/cssComm.cpp
@@ -20,7 +20,7 @@ void CssComm::reset(uint64_t callTime) {
  @param callTime The clock time at which the function was called (nanoseconds)
  */
 void CssComm::updateState(uint64_t callTime) {
-    std::array<float, MAX_NUM_CSS_SENSORS>
+    std::array<double, MAX_NUM_CSS_SENSORS>
         inputValues{}; /* [-] Current measured CSS value for the constellation of CSS sensors */
 
     // read sensor list input msg
@@ -28,10 +28,10 @@ void CssComm::updateState(uint64_t callTime) {
     std::ranges::copy(
         std::ranges::begin(inMsgBuffer.CosValue), std::ranges::end(inMsgBuffer.CosValue), inputValues.begin());
 
-    std::array<float, MAX_NUM_CSS_SENSORS> outputValues = this->algorithm.update(inputValues);
+    std::array<double, MAX_NUM_CSS_SENSORS> outputValues = this->algorithm.update(inputValues);
 
     CSSArraySensorMsgF32Payload outputBuffer{};
-    std::ranges::copy(outputValues, outputBuffer.CosValue);
+    std::ranges::copy(outputValues.begin(), outputValues.end(), std::ranges::begin(outputBuffer.CosValue));
 
     /*! - Write aggregate output into output message */
     this->cssArrayOutMsg.write(&outputBuffer, this->moduleID, callTime);
@@ -52,12 +52,12 @@ uint32_t CssComm::getNumSensors() const { return this->algorithm.getNumSensors()
  @return void
  @param maxValue [-] maximum sensor value
 */
-void CssComm::setMaxSensorValue(const float maxValue) { this->algorithm.setMaxSensorValue(maxValue); }
+void CssComm::setMaxSensorValue(const double maxValue) { this->algorithm.setMaxSensorValue(maxValue); }
 
 /*! Get the maximum sensor value
- @return float
+ @return double
 */
-float CssComm::getMaxSensorValue() const { return this->algorithm.getMaxSensorValue(); }
+double CssComm::getMaxSensorValue() const { return this->algorithm.getMaxSensorValue(); }
 
 /*! Set the cheby polynomial count
  @return void
@@ -74,13 +74,13 @@ uint32_t CssComm::getChebyCount() const { return this->algorithm.getChebyCount()
  @return void
  @param polynomials [-] cheby polynomials
 */
-void CssComm::setChebyPolynomials(const std::array<float, kMaxNumChebyPolys>& polynomials) {
+void CssComm::setChebyPolynomials(const std::array<double, kMaxNumChebyPolys>& polynomials) {
     this->algorithm.setChebyPolynomials(polynomials);
 }
 
 /*! Get the cheby polynomials
- @return std::array<float, kMaxNumChebyPolys>
+ @return std::array<double, kMaxNumChebyPolys>
 */
-std::array<float, kMaxNumChebyPolys> CssComm::getChebyPolynomials() const {
+std::array<double, kMaxNumChebyPolys> CssComm::getChebyPolynomials() const {
     return this->algorithm.getChebyPolynomials();
 }

--- a/algorithms/cssComm/cssComm.h
+++ b/algorithms/cssComm/cssComm.h
@@ -18,12 +18,12 @@ class CssComm : public SysModel {
 
     void setNumSensors(uint32_t numberOfSensors);
     uint32_t getNumSensors() const;
-    void setMaxSensorValue(float maxValue);
-    float getMaxSensorValue() const;
+    void setMaxSensorValue(double maxValue);
+    double getMaxSensorValue() const;
     void setChebyCount(uint32_t count);
     uint32_t getChebyCount() const;
-    void setChebyPolynomials(const std::array<float, kMaxNumChebyPolys>& polynomials);
-    std::array<float, kMaxNumChebyPolys> getChebyPolynomials() const;
+    void setChebyPolynomials(const std::array<double, kMaxNumChebyPolys>& polynomials);
+    std::array<double, kMaxNumChebyPolys> getChebyPolynomials() const;
 
     ReadFunctor<CSSArraySensorMsgF32Payload> sensorListInMsg;  //!< input message that contains CSS data
     Message<CSSArraySensorMsgF32Payload> cssArrayOutMsg;       //!< output message of corrected CSS data

--- a/algorithms/cssComm/cssCommAlgorithm.cpp
+++ b/algorithms/cssComm/cssCommAlgorithm.cpp
@@ -8,17 +8,17 @@
  @return void
  @param inputValues [-] Current measured CSS value for the constellation of CSS sensors
  */
-std::array<float, MAX_NUM_CSS_SENSORS> CssCommAlgorithm::update(
-    const std::array<float, MAX_NUM_CSS_SENSORS>& inputValues) const {
-    std::array<float, MAX_NUM_CSS_SENSORS> outputValues{};
+std::array<double, MAX_NUM_CSS_SENSORS> CssCommAlgorithm::update(
+    const std::array<double, MAX_NUM_CSS_SENSORS>& inputValues) const {
+    std::array<double, MAX_NUM_CSS_SENSORS> outputValues{};
 
     for (uint32_t i = 0; i < this->numSensors; ++i) {
-        float const measuredValue = inputValues.at(i) / this->maxSensorValue; /* Scale Sensor Data */
+        double const measuredValue = inputValues.at(i) / this->maxSensorValue; /* Scale Sensor Data */
 
         /* Calculate correction using Chebyshev polynomial */
-        float const correction = calculateChebyValue(this->chebyPolynomials, this->chebyCount, measuredValue);
+        double const correction = calculateChebyValue(this->chebyPolynomials, this->chebyCount, measuredValue);
 
-        float correctedValue = measuredValue + correction;
+        double correctedValue = measuredValue + correction;
 
         if (correctedValue > 1.0) {
             correctedValue = 1.0;
@@ -54,7 +54,7 @@ uint32_t CssCommAlgorithm::getNumSensors() const { return this->numSensors; }
  @return void
  @param maxValue [-] maximum sensor value
 */
-void CssCommAlgorithm::setMaxSensorValue(const float maxValue) {
+void CssCommAlgorithm::setMaxSensorValue(const double maxValue) {
     if (maxValue <= 0) {
         FS_THROW_INVALID_ARGUMENT(
             "The maximum CSS sensor value must be positive. Otherwise, CSS sensor values "
@@ -64,9 +64,9 @@ void CssCommAlgorithm::setMaxSensorValue(const float maxValue) {
 }
 
 /*! Get the maximum sensor value
- @return float
+ @return double
 */
-float CssCommAlgorithm::getMaxSensorValue() const { return this->maxSensorValue; }
+double CssCommAlgorithm::getMaxSensorValue() const { return this->maxSensorValue; }
 
 /*! Set the cheby polynomial count
  @return void
@@ -91,11 +91,11 @@ uint32_t CssCommAlgorithm::getChebyCount() const { return this->chebyCount; }
  @return void
  @param polynomials [-] cheby polynomials
 */
-void CssCommAlgorithm::setChebyPolynomials(const std::array<float, kMaxNumChebyPolys>& polynomials) {
+void CssCommAlgorithm::setChebyPolynomials(const std::array<double, kMaxNumChebyPolys>& polynomials) {
     this->chebyPolynomials = polynomials;
 }
 
 /*! Get the cheby polynomials
- @return std::array<float, kMaxNumChebyPolys>
+ @return std::array<double, kMaxNumChebyPolys>
 */
-std::array<float, kMaxNumChebyPolys> CssCommAlgorithm::getChebyPolynomials() const { return this->chebyPolynomials; }
+std::array<double, kMaxNumChebyPolys> CssCommAlgorithm::getChebyPolynomials() const { return this->chebyPolynomials; }

--- a/algorithms/cssComm/cssCommAlgorithm.h
+++ b/algorithms/cssComm/cssCommAlgorithm.h
@@ -12,22 +12,22 @@ inline constexpr std::size_t kMaxNumChebyPolys = 10;
  CSS interface*/
 class CssCommAlgorithm final {
    public:
-    std::array<float, MAX_NUM_CSS_SENSORS> update(const std::array<float, MAX_NUM_CSS_SENSORS>& inputValues) const;
+    std::array<double, MAX_NUM_CSS_SENSORS> update(const std::array<double, MAX_NUM_CSS_SENSORS>& inputValues) const;
 
     void setNumSensors(uint32_t numberOfSensors);
     uint32_t getNumSensors() const;
-    void setMaxSensorValue(float maxValue);
-    float getMaxSensorValue() const;
+    void setMaxSensorValue(double maxValue);
+    double getMaxSensorValue() const;
     void setChebyCount(uint32_t count);
     uint32_t getChebyCount() const;
-    void setChebyPolynomials(const std::array<float, kMaxNumChebyPolys>& polynomials);
-    std::array<float, kMaxNumChebyPolys> getChebyPolynomials() const;
+    void setChebyPolynomials(const std::array<double, kMaxNumChebyPolys>& polynomials);
+    std::array<double, kMaxNumChebyPolys> getChebyPolynomials() const;
 
    private:
-    uint32_t numSensors{};                                    //!< The number of sensors we are processing
-    float maxSensorValue{};                                   //!< Scale factor to go from sensor values to cosine
-    uint32_t chebyCount{};                                    //!< Count on the number of chebyshev polynomials we have
-    std::array<float, kMaxNumChebyPolys> chebyPolynomials{};  //!< Chebyshev polynomials to fit output to cosine
+    uint32_t numSensors{};                                     //!< The number of sensors we are processing
+    double maxSensorValue{};                                   //!< Scale factor to go from sensor values to cosine
+    uint32_t chebyCount{};                                     //!< Count on the number of chebyshev polynomials we have
+    std::array<double, kMaxNumChebyPolys> chebyPolynomials{};  //!< Chebyshev polynomials to fit output to cosine
 };
 
 #endif

--- a/algorithms/cssComm/cssCommF32.i
+++ b/algorithms/cssComm/cssCommF32.i
@@ -1,17 +1,17 @@
 %module cssCommF32
 %{
    #include "cssComm.h"
-   typedef std::array<float, kMaxNumChebyPolys> FloatArray10;
+   typedef std::array<double, kMaxNumChebyPolys> DoubleArray10;
 %}
 
 %include <architecture/_GeneralModuleFiles/sys_model.i>
 %include <std_array.i>
 
-%template(FloatArray10) std::array<float, 10>;
+%template(DoubleArray10) std::array<double, 10>;
 
 %include <attribute.i>
 %attribute(CssComm, uint32_t, numSensors, getNumSensors, setNumSensors)
-%attribute(CssComm, float, maxSensorValue, getMaxSensorValue, setMaxSensorValue)
+%attribute(CssComm, double, maxSensorValue, getMaxSensorValue, setMaxSensorValue)
 %attribute(CssComm, uint32_t, chebyCount, getChebyCount, setChebyCount)
 
 %include "cssComm.h"

--- a/algorithms/oeStateEphem/_tests/test_oeStateEphem.cpp
+++ b/algorithms/oeStateEphem/_tests/test_oeStateEphem.cpp
@@ -93,7 +93,7 @@ TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcRadiusPeriapsisCoefficients) {
 
 TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcEccentricityCoefficients) {
     const unsigned int arcNum = 0;
-    std::array<float, kMaxOeCoeff> coeffs{};
+    std::array<double, kMaxOeCoeff> coeffs{};
     coeffs[0] = 0.1f;
     coeffs[1] = 0.01f;
     algorithm.setArcEccentricityCoefficients(arcNum, coeffs);
@@ -104,7 +104,7 @@ TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcEccentricityCoefficients) {
 
 TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcInclinationCoefficients) {
     const unsigned int arcNum = 0;
-    std::array<float, kMaxOeCoeff> coeffs{};
+    std::array<double, kMaxOeCoeff> coeffs{};
     coeffs[0] = 0.5f;
     algorithm.setArcInclinationCoefficients(arcNum, coeffs);
     auto retrieved = algorithm.getArcInclinationCoefficients(arcNum);
@@ -113,7 +113,7 @@ TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcInclinationCoefficients) {
 
 TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcArgPeriapsisCoefficients) {
     const unsigned int arcNum = 0;
-    std::array<float, kMaxOeCoeff> coeffs{};
+    std::array<double, kMaxOeCoeff> coeffs{};
     coeffs[0] = 1.0f;
     algorithm.setArcArgPeriapsisCoefficients(arcNum, coeffs);
     auto retrieved = algorithm.getArcArgPeriapsisCoefficients(arcNum);
@@ -122,7 +122,7 @@ TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcArgPeriapsisCoefficients) {
 
 TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcRaanCoefficients) {
     const unsigned int arcNum = 0;
-    std::array<float, kMaxOeCoeff> coeffs{};
+    std::array<double, kMaxOeCoeff> coeffs{};
     coeffs[0] = 0.5f;
     algorithm.setArcRaanCoefficients(arcNum, coeffs);
     auto retrieved = algorithm.getArcRaanCoefficients(arcNum);
@@ -131,7 +131,7 @@ TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcRaanCoefficients) {
 
 TEST_F(OEStateEphemAlgorithmTest, SetAndGetArcTrueAnomalyCoefficients) {
     const unsigned int arcNum = 0;
-    std::array<float, kMaxOeCoeff> coeffs{};
+    std::array<double, kMaxOeCoeff> coeffs{};
     coeffs[0] = 0.0f;
     algorithm.setArcTrueAnomalyCoefficients(arcNum, coeffs);
     auto retrieved = algorithm.getArcTrueAnomalyCoefficients(arcNum);
@@ -173,7 +173,7 @@ TEST_F(OEStateEphemAlgorithmTest, CircularOrbitAtOrigin_ConstantCoefficients) {
     rpCoeffs[0] = radius_m;  // r_p = a for circular orbit (e=0)
     algorithm.setArcRadiusPeriapsisCoefficients(0, rpCoeffs);
 
-    std::array<float, kMaxOeCoeff> zeroCoeffs{};
+    std::array<double, kMaxOeCoeff> zeroCoeffs{};
     zeroCoeffs[0] = 0.0f;
 
     algorithm.setArcEccentricityCoefficients(0, zeroCoeffs);
@@ -217,15 +217,15 @@ TEST_F(OEStateEphemAlgorithmTest, CircularOrbitAt90Degrees_ConstantCoefficients)
     rpCoeffs[0] = radius_m;
     algorithm.setArcRadiusPeriapsisCoefficients(0, rpCoeffs);
 
-    std::array<float, kMaxOeCoeff> zeroCoeffs{};
+    std::array<double, kMaxOeCoeff> zeroCoeffs{};
     zeroCoeffs[0] = 0.0f;
     algorithm.setArcEccentricityCoefficients(0, zeroCoeffs);
     algorithm.setArcInclinationCoefficients(0, zeroCoeffs);
     algorithm.setArcArgPeriapsisCoefficients(0, zeroCoeffs);
     algorithm.setArcRaanCoefficients(0, zeroCoeffs);
 
-    std::array<float, kMaxOeCoeff> nuCoeffs{};
-    nuCoeffs[0] = static_cast<float>(M_PI / 2.0);
+    std::array<double, kMaxOeCoeff> nuCoeffs{};
+    nuCoeffs[0] = M_PI / 2.0;
     algorithm.setArcTrueAnomalyCoefficients(0, nuCoeffs);
 
     CartesianState state = algorithm.update(0);
@@ -261,11 +261,11 @@ TEST_F(OEStateEphemAlgorithmTest, EllipticalOrbitAtPeriapsis_ConstantCoefficient
     rpCoeffs[0] = r_p_m;
     algorithm.setArcRadiusPeriapsisCoefficients(0, rpCoeffs);
 
-    std::array<float, kMaxOeCoeff> eCoeffs{};
-    eCoeffs[0] = static_cast<float>(eccentricity);
+    std::array<double, kMaxOeCoeff> eCoeffs{};
+    eCoeffs[0] = eccentricity;
     algorithm.setArcEccentricityCoefficients(0, eCoeffs);
 
-    std::array<float, kMaxOeCoeff> zeroCoeffs{};
+    std::array<double, kMaxOeCoeff> zeroCoeffs{};
     zeroCoeffs[0] = 0.0f;
     algorithm.setArcInclinationCoefficients(0, zeroCoeffs);
     algorithm.setArcArgPeriapsisCoefficients(0, zeroCoeffs);

--- a/algorithms/oeStateEphem/_tests/test_oeStateEphem_helpers.h
+++ b/algorithms/oeStateEphem/_tests/test_oeStateEphem_helpers.h
@@ -11,6 +11,7 @@
 
 #include "oeStateEphemAlgorithm.h"
 #include "utilities/orbitalMotion.hpp"
+#include "utilities/safeMath.h"
 #include "utilities/timeConstants.h"
 #include <gtest/gtest.h>
 #include <cmath>
@@ -157,24 +158,24 @@ inline void testOEStateEphemUpdate(double mu,
         rpCoeffs[0] = r_p_m;
         algorithm.setArcRadiusPeriapsisCoefficients(arcIdx, rpCoeffs);
 
-        std::array<float, kMaxOeCoeff> eCoeffs{};
-        eCoeffs[0] = static_cast<float>(eccentricity);
+        std::array<double, kMaxOeCoeff> eCoeffs{};
+        eCoeffs[0] = eccentricity;
         algorithm.setArcEccentricityCoefficients(arcIdx, eCoeffs);
 
-        std::array<float, kMaxOeCoeff> iCoeffs{};
-        iCoeffs[0] = static_cast<float>(inclination);
+        std::array<double, kMaxOeCoeff> iCoeffs{};
+        iCoeffs[0] = inclination;
         algorithm.setArcInclinationCoefficients(arcIdx, iCoeffs);
 
-        std::array<float, kMaxOeCoeff> omegaCoeffs{};
-        omegaCoeffs[0] = static_cast<float>(arg_periapsis);
+        std::array<double, kMaxOeCoeff> omegaCoeffs{};
+        omegaCoeffs[0] = arg_periapsis;
         algorithm.setArcArgPeriapsisCoefficients(arcIdx, omegaCoeffs);
 
-        std::array<float, kMaxOeCoeff> raanCoeffs{};
-        raanCoeffs[0] = static_cast<float>(raan);
+        std::array<double, kMaxOeCoeff> raanCoeffs{};
+        raanCoeffs[0] = raan;
         algorithm.setArcRaanCoefficients(arcIdx, raanCoeffs);
 
-        std::array<float, kMaxOeCoeff> nuCoeffs{};
-        nuCoeffs[0] = static_cast<float>(anomaly_angle);
+        std::array<double, kMaxOeCoeff> nuCoeffs{};
+        nuCoeffs[0] = anomaly_angle;
         algorithm.setArcTrueAnomalyCoefficients(arcIdx, nuCoeffs);
     }
     // Call the update function
@@ -199,8 +200,8 @@ inline void testOEStateEphemUpdate(double mu,
         elementsToCartesianStateDouble(mu, a_d, eccentricity, inclination, raan, arg_periapsis, f_d);
 
     // Compare to 6 significant digits (relative tolerance 1e-6)
-    constexpr double relTol = 1e-4;
-    constexpr double absFloor = 1e-6;
+    constexpr double relTol = 1e-14;
+    constexpr double absFloor = 1e-14;
     constexpr double angleTol = 1e-6;
 
     double posTol = std::max(absFloor, expected_state.position.norm() * relTol);
@@ -212,7 +213,7 @@ inline void testOEStateEphemUpdate(double mu,
         EXPECT_NEAR(computed_state.position[idx], expected_state.position[idx], posTol);
         EXPECT_NEAR(computed_state.velocity[idx], expected_state.velocity[idx], velTol);
     }
-    EXPECT_GT(computed_state.position.normalized().dot(expected_state.position.normalized()), std::cos(angleTol));
+    EXPECT_LT(safeAcos(computed_state.position.normalized().dot(expected_state.position.normalized())), angleTol);
 }
 
 #endif  // TEST_OE_STATE_EPHEM_HELPERS_H

--- a/algorithms/oeStateEphem/oeStateEphem.cpp
+++ b/algorithms/oeStateEphem/oeStateEphem.cpp
@@ -43,11 +43,11 @@ void OEStateEphem::updateState(const uint64_t callTime) {
     this->stateFitOutMsg.write(&ephmerisMessageOutput, moduleID, callTime);
 }
 
-void OEStateEphem::setCentralBodyGravitationalParameter(const float mu) {
+void OEStateEphem::setCentralBodyGravitationalParameter(const double mu) {
     this->algorithm.setCentralBodyGravitationalParameter(mu);
 };
 
-float OEStateEphem::getCentralBodyGravitationalParameter() const {
+double OEStateEphem::getCentralBodyGravitationalParameter() const {
     return this->algorithm.getCentralBodyGravitationalParameter();
 };
 
@@ -106,46 +106,46 @@ std::array<double, kMaxOeCoeff> OEStateEphem::getArcRadiusPeriapsisCoefficients(
 };
 
 void OEStateEphem::setArcEccentricityCoefficients(const unsigned int arcNumber,
-                                                  const std::array<float, kMaxOeCoeff> &eccentricityCoefficients) {
+                                                  const std::array<double, kMaxOeCoeff> &eccentricityCoefficients) {
     this->algorithm.setArcEccentricityCoefficients(arcNumber, eccentricityCoefficients);
 };
 
-std::array<float, kMaxOeCoeff> OEStateEphem::getArcEccentricityCoefficients(const unsigned int arcNumber) {
+std::array<double, kMaxOeCoeff> OEStateEphem::getArcEccentricityCoefficients(const unsigned int arcNumber) {
     return this->algorithm.getArcEccentricityCoefficients(arcNumber);
 };
 
 void OEStateEphem::setArcInclinationCoefficients(const unsigned int arcNumber,
-                                                 const std::array<float, kMaxOeCoeff> &inclinationCoefficients) {
+                                                 const std::array<double, kMaxOeCoeff> &inclinationCoefficients) {
     this->algorithm.setArcInclinationCoefficients(arcNumber, inclinationCoefficients);
 };
 
-std::array<float, kMaxOeCoeff> OEStateEphem::getArcInclinationCoefficients(const unsigned int arcNumber) {
+std::array<double, kMaxOeCoeff> OEStateEphem::getArcInclinationCoefficients(const unsigned int arcNumber) {
     return this->algorithm.getArcInclinationCoefficients(arcNumber);
 };
 
 void OEStateEphem::setArcArgPeriapsisCoefficients(const unsigned int arcNumber,
-                                                  const std::array<float, kMaxOeCoeff> &argPeriapsisCoefficients) {
+                                                  const std::array<double, kMaxOeCoeff> &argPeriapsisCoefficients) {
     this->algorithm.setArcArgPeriapsisCoefficients(arcNumber, argPeriapsisCoefficients);
 };
 
-std::array<float, kMaxOeCoeff> OEStateEphem::getArcArgPeriapsisCoefficients(const unsigned int arcNumber) {
+std::array<double, kMaxOeCoeff> OEStateEphem::getArcArgPeriapsisCoefficients(const unsigned int arcNumber) {
     return this->algorithm.getArcArgPeriapsisCoefficients(arcNumber);
 };
 
 void OEStateEphem::setArcRaanCoefficients(const unsigned int arcNumber,
-                                          const std::array<float, kMaxOeCoeff> &raanCoefficients) {
+                                          const std::array<double, kMaxOeCoeff> &raanCoefficients) {
     this->algorithm.setArcRaanCoefficients(arcNumber, raanCoefficients);
 };
 
-std::array<float, kMaxOeCoeff> OEStateEphem::getArcRaanCoefficients(const unsigned int arcNumber) {
+std::array<double, kMaxOeCoeff> OEStateEphem::getArcRaanCoefficients(const unsigned int arcNumber) {
     return this->algorithm.getArcRaanCoefficients(arcNumber);
 };
 
 void OEStateEphem::setArcTrueAnomalyCoefficients(const unsigned int arcNumber,
-                                                 const std::array<float, kMaxOeCoeff> &trueAnomalyCoefficients) {
+                                                 const std::array<double, kMaxOeCoeff> &trueAnomalyCoefficients) {
     this->algorithm.setArcTrueAnomalyCoefficients(arcNumber, trueAnomalyCoefficients);
 };
 
-std::array<float, kMaxOeCoeff> OEStateEphem::getArcTrueAnomalyCoefficients(const unsigned int arcNumber) {
+std::array<double, kMaxOeCoeff> OEStateEphem::getArcTrueAnomalyCoefficients(const unsigned int arcNumber) {
     return this->algorithm.getArcTrueAnomalyCoefficients(arcNumber);
 };

--- a/algorithms/oeStateEphem/oeStateEphem.h
+++ b/algorithms/oeStateEphem/oeStateEphem.h
@@ -30,8 +30,8 @@ class OEStateEphem : public SysModel {
     Message<EphemerisMsgF32Payload> stateFitOutMsg;                       //!< [-] output navigation message for pos/vel
     ReadFunctor<TDBVehicleClockCorrelationMsgF32Payload> clockCorrInMsg;  //!< clock correlation input message
 
-    void setCentralBodyGravitationalParameter(float gravitationalParameter);
-    float getCentralBodyGravitationalParameter() const;
+    void setCentralBodyGravitationalParameter(double gravitationalParameter);
+    double getCentralBodyGravitationalParameter() const;
 
     void setNumberOfArcs(unsigned int arcs);
     unsigned int getNumberOfArcs() const;
@@ -58,19 +58,19 @@ class OEStateEphem : public SysModel {
                                            const std::array<double, kMaxOeCoeff> &radiusPeriapsisCoefficients);
     std::array<double, kMaxOeCoeff> getArcRadiusPeriapsisCoefficients(unsigned int arcNumber);
     void setArcEccentricityCoefficients(unsigned int arcNumber,
-                                        const std::array<float, kMaxOeCoeff> &eccentricityCoefficients);
-    std::array<float, kMaxOeCoeff> getArcEccentricityCoefficients(unsigned int arcNumber);
+                                        const std::array<double, kMaxOeCoeff> &eccentricityCoefficients);
+    std::array<double, kMaxOeCoeff> getArcEccentricityCoefficients(unsigned int arcNumber);
     void setArcInclinationCoefficients(unsigned int arcNumber,
-                                       const std::array<float, kMaxOeCoeff> &inclinationCoefficients);
-    std::array<float, kMaxOeCoeff> getArcInclinationCoefficients(unsigned int arcNumber);
+                                       const std::array<double, kMaxOeCoeff> &inclinationCoefficients);
+    std::array<double, kMaxOeCoeff> getArcInclinationCoefficients(unsigned int arcNumber);
     void setArcArgPeriapsisCoefficients(unsigned int arcNumber,
-                                        const std::array<float, kMaxOeCoeff> &argPeriapsisCoefficients);
-    std::array<float, kMaxOeCoeff> getArcArgPeriapsisCoefficients(unsigned int arcNumber);
-    void setArcRaanCoefficients(unsigned int arcNumber, const std::array<float, kMaxOeCoeff> &raanCoefficients);
-    std::array<float, kMaxOeCoeff> getArcRaanCoefficients(unsigned int arcNumber);
+                                        const std::array<double, kMaxOeCoeff> &argPeriapsisCoefficients);
+    std::array<double, kMaxOeCoeff> getArcArgPeriapsisCoefficients(unsigned int arcNumber);
+    void setArcRaanCoefficients(unsigned int arcNumber, const std::array<double, kMaxOeCoeff> &raanCoefficients);
+    std::array<double, kMaxOeCoeff> getArcRaanCoefficients(unsigned int arcNumber);
     void setArcTrueAnomalyCoefficients(unsigned int arcNumber,
-                                       const std::array<float, kMaxOeCoeff> &trueAnomalyCoefficients);
-    std::array<float, kMaxOeCoeff> getArcTrueAnomalyCoefficients(unsigned int arcNumber);
+                                       const std::array<double, kMaxOeCoeff> &trueAnomalyCoefficients);
+    std::array<double, kMaxOeCoeff> getArcTrueAnomalyCoefficients(unsigned int arcNumber);
 
    private:
     OEStateEphemAlgorithm algorithm{};

--- a/algorithms/oeStateEphem/oeStateEphemAlgorithm.cpp
+++ b/algorithms/oeStateEphem/oeStateEphemAlgorithm.cpp
@@ -59,37 +59,37 @@ double OEStateEphemAlgorithm::scaleEphemerisTime(const ChebyshevFitArc& arc) con
     eccentricity, inclination, argument of periapsis, RAAN, and true anomaly) from the stored
     Chebyshev coefficients. The method handles different orbit types (elliptic, hyperbolic, parabolic)
     and converts mean anomaly to true anomaly when necessary.
-    @return ClassicalElementsF32 The computed classical orbital elements
+    @return ClassicalElements The computed classical orbital elements
     @param currentScaledValue The normalized time value in the range [-1, 1]
     @param arc The Chebyshev fit arc containing all coefficient arrays
 */
-ClassicalElementsF32 OEStateEphemAlgorithm::evaluateCoefficients(const double currentScaledValue,
-                                                                 const ChebyshevFitArc& arc) {
+ClassicalElements OEStateEphemAlgorithm::evaluateCoefficients(const double currentScaledValue,
+                                                              const ChebyshevFitArc& arc) {
     /* - determine orbit elements from chebychev polynominals */
-    ClassicalElementsF32 elements{};
+    ClassicalElements elements{};
     const double radiusPeriapsis =
         calculateChebyValue(arc.radiusPeriapsisCoefficients, arc.numberChebCoefficients, currentScaledValue);
-    elements.inclination = calculateChebyValue(
-        arc.inclinationCoefficients, arc.numberChebCoefficients, static_cast<float>(currentScaledValue));
-    elements.eccentricity = calculateChebyValue(
-        arc.eccentricityCoefficients, arc.numberChebCoefficients, static_cast<float>(currentScaledValue));
-    elements.argPeriapsis = calculateChebyValue(
-        arc.argPeriapsisCoefficients, arc.numberChebCoefficients, static_cast<float>(currentScaledValue));
+    elements.inclination =
+        calculateChebyValue(arc.inclinationCoefficients, arc.numberChebCoefficients, currentScaledValue);
+    elements.eccentricity =
+        calculateChebyValue(arc.eccentricityCoefficients, arc.numberChebCoefficients, currentScaledValue);
+    elements.argPeriapsis =
+        calculateChebyValue(arc.argPeriapsisCoefficients, arc.numberChebCoefficients, currentScaledValue);
     elements.rightAscensionAscendingNode =
-        calculateChebyValue(arc.raanCoefficients, arc.numberChebCoefficients, static_cast<float>(currentScaledValue));
-    const float anomalyAngle = calculateChebyValue(
-        arc.trueAnomalyCoefficients, arc.numberChebCoefficients, static_cast<float>(currentScaledValue));
+        calculateChebyValue(arc.raanCoefficients, arc.numberChebCoefficients, currentScaledValue);
+    const double anomalyAngle =
+        calculateChebyValue(arc.trueAnomalyCoefficients, arc.numberChebCoefficients, currentScaledValue);
 
     /*! - determine the true anomaly angle */
     if (arc.anomalyFlag == AnomalyType::TRUE_ANOMALY) {
         elements.trueAnomaly = anomalyAngle;
     } else if (elements.eccentricity < 1.0) {
         /* input is mean elliptic anomaly angle */
-        elements.trueAnomaly = OrbitalMotion::meanToTrueAnomalyF32(anomalyAngle, elements.eccentricity);
+        elements.trueAnomaly = OrbitalMotion::meanToTrueAnomaly(anomalyAngle, elements.eccentricity);
     } else {
         /* input is mean hyperbolic anomaly angle */
-        elements.trueAnomaly = OrbitalMotion::hyperbolicToTrueAnomalyF32(
-            OrbitalMotion::meanToHyperbolicAnomalyF32(anomalyAngle, elements.eccentricity), elements.eccentricity);
+        elements.trueAnomaly = OrbitalMotion::hyperbolicToTrueAnomaly(
+            OrbitalMotion::meanToHyperbolicAnomaly(anomalyAngle, elements.eccentricity), elements.eccentricity);
     }
 
     /*! - determine semi-major axis */
@@ -138,7 +138,7 @@ CartesianState OEStateEphemAlgorithm::update(const uint64_t callTime) {
     const auto orbitalElements = evaluateCoefficients(currentScaledValue, currentArc);
 
     /*! - Determine position and velocity vectors */
-    outputCartesianState = OrbitalMotion::elementsToCartesianStateF32(this->mu, orbitalElements);
+    outputCartesianState = OrbitalMotion::elementsToCartesianState(this->mu, orbitalElements);
 
     return outputCartesianState;
 }
@@ -210,7 +210,7 @@ void OEStateEphemAlgorithm::setArcMiddleTime(const unsigned int arcNumber, const
 
 double OEStateEphemAlgorithm::getArcMiddleTime(const unsigned int arcNumber) const {
     /*! This method retrieves the middle time for a specified arc.
-        @return float The ephemeris time at the arc's midpoint (seconds)
+        @return double The ephemeris time at the arc's midpoint (seconds)
         @param arcNumber The index of the arc to query
     */
     return this->fitCoefficients.at(arcNumber).ephemerisTimeMiddle;
@@ -230,7 +230,7 @@ void OEStateEphemAlgorithm::setArcRadiusTime(const unsigned int arcNumber, const
 
 double OEStateEphemAlgorithm::getArcRadiusTime(const unsigned int arcNumber) const {
     /*! This method retrieves the time radius for a specified arc.
-        @return float The time radius for the arc (seconds)
+        @return double The time radius for the arc (seconds)
         @param arcNumber The index of the arc to query
     */
     return this->fitCoefficients.at(arcNumber).ephemerisTimeRadius;
@@ -281,15 +281,15 @@ std::array<double, kMaxOeCoeff> OEStateEphemAlgorithm::getArcRadiusPeriapsisCoef
 */
 void OEStateEphemAlgorithm::setArcEccentricityCoefficients(
     const unsigned int arcNumber,
-    const std::array<float, kMaxOeCoeff>& eccentricityCoefficients) {
+    const std::array<double, kMaxOeCoeff>& eccentricityCoefficients) {
     this->fitCoefficients.at(arcNumber).eccentricityCoefficients = eccentricityCoefficients;
 };
 
 /*! This method retrieves the Chebyshev coefficients for eccentricity for a specified arc.
-    @return std::array<float, kMaxOeCoeff> Array of Chebyshev coefficients for eccentricity
+    @return std::array<double, kMaxOeCoeff> Array of Chebyshev coefficients for eccentricity
     @param arcNumber The index of the arc to query
 */
-std::array<float, kMaxOeCoeff> OEStateEphemAlgorithm::getArcEccentricityCoefficients(
+std::array<double, kMaxOeCoeff> OEStateEphemAlgorithm::getArcEccentricityCoefficients(
     const unsigned int arcNumber) const {
     return this->fitCoefficients.at(arcNumber).eccentricityCoefficients;
 };
@@ -301,15 +301,15 @@ std::array<float, kMaxOeCoeff> OEStateEphemAlgorithm::getArcEccentricityCoeffici
 */
 void OEStateEphemAlgorithm::setArcInclinationCoefficients(
     const unsigned int arcNumber,
-    const std::array<float, kMaxOeCoeff>& inclinationCoefficients) {
+    const std::array<double, kMaxOeCoeff>& inclinationCoefficients) {
     this->fitCoefficients.at(arcNumber).inclinationCoefficients = inclinationCoefficients;
 };
 
 /*! This method retrieves the Chebyshev coefficients for inclination for a specified arc.
-    @return std::array<float, kMaxOeCoeff> Array of Chebyshev coefficients for inclination
+    @return std::array<double, kMaxOeCoeff> Array of Chebyshev coefficients for inclination
     @param arcNumber The index of the arc to query
 */
-std::array<float, kMaxOeCoeff> OEStateEphemAlgorithm::getArcInclinationCoefficients(
+std::array<double, kMaxOeCoeff> OEStateEphemAlgorithm::getArcInclinationCoefficients(
     const unsigned int arcNumber) const {
     return this->fitCoefficients.at(arcNumber).inclinationCoefficients;
 };
@@ -321,15 +321,15 @@ std::array<float, kMaxOeCoeff> OEStateEphemAlgorithm::getArcInclinationCoefficie
 */
 void OEStateEphemAlgorithm::setArcArgPeriapsisCoefficients(
     const unsigned int arcNumber,
-    const std::array<float, kMaxOeCoeff>& argPeriapsisCoefficients) {
+    const std::array<double, kMaxOeCoeff>& argPeriapsisCoefficients) {
     this->fitCoefficients.at(arcNumber).argPeriapsisCoefficients = argPeriapsisCoefficients;
 };
 
 /*! This method retrieves the Chebyshev coefficients for argument of periapsis for a specified arc.
-    @return std::array<float, kMaxOeCoeff> Array of Chebyshev coefficients for argument of periapsis
+    @return std::array<double, kMaxOeCoeff> Array of Chebyshev coefficients for argument of periapsis
     @param arcNumber The index of the arc to query
 */
-std::array<float, kMaxOeCoeff> OEStateEphemAlgorithm::getArcArgPeriapsisCoefficients(
+std::array<double, kMaxOeCoeff> OEStateEphemAlgorithm::getArcArgPeriapsisCoefficients(
     const unsigned int arcNumber) const {
     return this->fitCoefficients.at(arcNumber).argPeriapsisCoefficients;
 };
@@ -341,16 +341,16 @@ std::array<float, kMaxOeCoeff> OEStateEphemAlgorithm::getArcArgPeriapsisCoeffici
     @param raanCoefficients Array of Chebyshev coefficients for RAAN
 */
 void OEStateEphemAlgorithm::setArcRaanCoefficients(const unsigned int arcNumber,
-                                                   const std::array<float, kMaxOeCoeff>& raanCoefficients) {
+                                                   const std::array<double, kMaxOeCoeff>& raanCoefficients) {
     this->fitCoefficients.at(arcNumber).raanCoefficients = raanCoefficients;
 };
 
 /*! This method retrieves the Chebyshev coefficients for right ascension of the ascending node (RAAN)
     for a specified arc.
-    @return std::array<float, kMaxOeCoeff> Array of Chebyshev coefficients for RAAN
+    @return std::array<double, kMaxOeCoeff> Array of Chebyshev coefficients for RAAN
     @param arcNumber The index of the arc to query
 */
-std::array<float, kMaxOeCoeff> OEStateEphemAlgorithm::getArcRaanCoefficients(const unsigned int arcNumber) const {
+std::array<double, kMaxOeCoeff> OEStateEphemAlgorithm::getArcRaanCoefficients(const unsigned int arcNumber) const {
     return this->fitCoefficients.at(arcNumber).raanCoefficients;
 };
 
@@ -361,15 +361,15 @@ std::array<float, kMaxOeCoeff> OEStateEphemAlgorithm::getArcRaanCoefficients(con
 */
 void OEStateEphemAlgorithm::setArcTrueAnomalyCoefficients(
     const unsigned int arcNumber,
-    const std::array<float, kMaxOeCoeff>& trueAnomalyCoefficients) {
+    const std::array<double, kMaxOeCoeff>& trueAnomalyCoefficients) {
     this->fitCoefficients.at(arcNumber).trueAnomalyCoefficients = trueAnomalyCoefficients;
 };
 
 /*! This method retrieves the Chebyshev coefficients for true anomaly for a specified arc.
-    @return std::array<float, kMaxOeCoeff> Array of Chebyshev coefficients for true anomaly
+    @return std::array<double, kMaxOeCoeff> Array of Chebyshev coefficients for true anomaly
     @param arcNumber The index of the arc to query
 */
-std::array<float, kMaxOeCoeff> OEStateEphemAlgorithm::getArcTrueAnomalyCoefficients(
+std::array<double, kMaxOeCoeff> OEStateEphemAlgorithm::getArcTrueAnomalyCoefficients(
     const unsigned int arcNumber) const {
     return this->fitCoefficients.at(arcNumber).trueAnomalyCoefficients;
 };

--- a/algorithms/oeStateEphem/oeStateEphemAlgorithm.h
+++ b/algorithms/oeStateEphem/oeStateEphemAlgorithm.h
@@ -12,7 +12,6 @@
 #include <cstddef>
 
 inline constexpr double kTolerance = 1e-10;
-inline constexpr float kToleranceF32 = 1e-6;
 inline constexpr std::size_t kMaxOeCoeff = 20;
 inline constexpr std::size_t kMaxOeRecords = 10;
 
@@ -28,13 +27,13 @@ struct ChebyshevFitArc {
     double ephemerisTimeRadius{};           //!< [s] "Radius" of time that curve is valid for (half of total range)
     std::array<double, kMaxOeCoeff>
         radiusPeriapsisCoefficients{};  //!< [-] Set of chebyshev coefficients for radius at periapses
-    std::array<float, kMaxOeCoeff> eccentricityCoefficients{};  //!< [-] Set of chebyshev coefficients for eccentricity
-    std::array<float, kMaxOeCoeff> inclinationCoefficients{};   //!< [-] Set of chebyshev coefficients for inclination
-    std::array<float, kMaxOeCoeff>
+    std::array<double, kMaxOeCoeff> eccentricityCoefficients{};  //!< [-] Set of chebyshev coefficients for eccentricity
+    std::array<double, kMaxOeCoeff> inclinationCoefficients{};   //!< [-] Set of chebyshev coefficients for inclination
+    std::array<double, kMaxOeCoeff>
         argPeriapsisCoefficients{};  //!< [-] Set of chebyshev coefficients for argument of periapses
-    std::array<float, kMaxOeCoeff>
+    std::array<double, kMaxOeCoeff>
         raanCoefficients{};  //!< [-] Set of chebyshev coefficients for right ascention of the ascending node
-    std::array<float, kMaxOeCoeff>
+    std::array<double, kMaxOeCoeff>
         trueAnomalyCoefficients{};                       //!< [-] Set of chebyshev coefficients for true anomaly angle
     AnomalyType anomalyFlag{AnomalyType::TRUE_ANOMALY};  //!< [-] Flag indicating if the anomaly angle is true or mean
 };
@@ -73,24 +72,24 @@ class OEStateEphemAlgorithm {
                                            const std::array<double, kMaxOeCoeff> &radiusPeriapsisCoefficients);
     std::array<double, kMaxOeCoeff> getArcRadiusPeriapsisCoefficients(unsigned int arcNumber) const;
     void setArcEccentricityCoefficients(unsigned int arcNumber,
-                                        const std::array<float, kMaxOeCoeff> &eccentricityCoefficients);
-    std::array<float, kMaxOeCoeff> getArcEccentricityCoefficients(unsigned int arcNumber) const;
+                                        const std::array<double, kMaxOeCoeff> &eccentricityCoefficients);
+    std::array<double, kMaxOeCoeff> getArcEccentricityCoefficients(unsigned int arcNumber) const;
     void setArcInclinationCoefficients(unsigned int arcNumber,
-                                       const std::array<float, kMaxOeCoeff> &inclinationCoefficients);
-    std::array<float, kMaxOeCoeff> getArcInclinationCoefficients(unsigned int arcNumber) const;
+                                       const std::array<double, kMaxOeCoeff> &inclinationCoefficients);
+    std::array<double, kMaxOeCoeff> getArcInclinationCoefficients(unsigned int arcNumber) const;
     void setArcArgPeriapsisCoefficients(unsigned int arcNumber,
-                                        const std::array<float, kMaxOeCoeff> &argPeriapsisCoefficients);
-    std::array<float, kMaxOeCoeff> getArcArgPeriapsisCoefficients(unsigned int arcNumber) const;
-    void setArcRaanCoefficients(unsigned int arcNumber, const std::array<float, kMaxOeCoeff> &raanCoefficients);
-    std::array<float, kMaxOeCoeff> getArcRaanCoefficients(unsigned int arcNumber) const;
+                                        const std::array<double, kMaxOeCoeff> &argPeriapsisCoefficients);
+    std::array<double, kMaxOeCoeff> getArcArgPeriapsisCoefficients(unsigned int arcNumber) const;
+    void setArcRaanCoefficients(unsigned int arcNumber, const std::array<double, kMaxOeCoeff> &raanCoefficients);
+    std::array<double, kMaxOeCoeff> getArcRaanCoefficients(unsigned int arcNumber) const;
     void setArcTrueAnomalyCoefficients(unsigned int arcNumber,
-                                       const std::array<float, kMaxOeCoeff> &trueAnomalyCoefficients);
-    std::array<float, kMaxOeCoeff> getArcTrueAnomalyCoefficients(unsigned int arcNumber) const;
+                                       const std::array<double, kMaxOeCoeff> &trueAnomalyCoefficients);
+    std::array<double, kMaxOeCoeff> getArcTrueAnomalyCoefficients(unsigned int arcNumber) const;
 
    private:
     ChebyshevFitArc findCurrentArc(uint64_t spacecraftClockTime);
     double scaleEphemerisTime(const ChebyshevFitArc &arc) const;
-    static ClassicalElementsF32 evaluateCoefficients(double currentScaledValue, const ChebyshevFitArc &arc);
+    static ClassicalElements evaluateCoefficients(double currentScaledValue, const ChebyshevFitArc &arc);
     bool allParametersNull() const;
     unsigned int numberOfArcs{};
     double currentEphTime{};

--- a/algorithms/utilities/_tests/test_orbitalMotion_degenerate.cpp
+++ b/algorithms/utilities/_tests/test_orbitalMotion_degenerate.cpp
@@ -4,10 +4,10 @@
  Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
  Tests for degenerate / singular orbital geometries:
-   - Near-parabolic elliptic (e → 1⁻)
+   - Near-parabolic elliptic (e -> 1-)
    - Exactly parabolic (e = 1)
    - Rectilinear (h = 0, purely radial motion)
-   - Near-rectilinear (h → 0⁺)
+   - Near-rectilinear (h -> 0+)
 */
 
 #include "../orbitalMotion.hpp"
@@ -16,62 +16,62 @@
 #include <Eigen/Geometry>
 #include <cmath>
 
-constexpr double kMuEarth = 3.986004418e14;  // m³/s²
+constexpr double kMuEarth = 3.986004418e14;  // m^3/s^2
 constexpr double kRpM = 7.0e6;               // periapsis radius, m
 
 // ============================================================================
-// Near-parabolic elliptic (e → 1⁻)
+// Near-parabolic elliptic (e -> 1-)
 //
-// As e → 1 the semi-latus rectum p = a(1−e²) → 0 and the semi-major axis
-// a → ∞. The closed-form anomaly functions use sqrt(1−e) and sqrt(1+e), both
+// As e -> 1 the semi-latus rectum p = a(1-e^2) -> 0 and the semi-major axis
+// a -> inf. The closed-form anomaly functions use sqrt(1-e) and sqrt(1+e), both
 // of which remain finite. The Newton solver for meanToEccentric is tested at a
 // small mean anomaly to keep the converged E inside the solver's safe range.
 // ============================================================================
 
 class NearParabolicEllipticTest : public ::testing::Test {
    protected:
-    static constexpr float kE = 0.9999f;  // eccentricity near 1
-    static constexpr float kF = 0.5f;     // true anomaly — within safe trig range
-    static constexpr float kEc = 0.4f;    // eccentric anomaly seed
+    static constexpr double kE = 0.9999;  // eccentricity near 1
+    static constexpr double kF = 0.5;     // true anomaly -- within safe trig range
+    static constexpr double kEc = 0.4;    // eccentric anomaly seed
 };
 
 // All closed-form anomaly conversions must return finite values.
 TEST_F(NearParabolicEllipticTest, ClosedFormAnomalies_AllFinite) {
-    const float E = OrbitalMotion::trueToEccentricAnomalyF32(kF, kE);
+    const double E = OrbitalMotion::trueToEccentricAnomaly(kF, kE);
     EXPECT_TRUE(std::isfinite(E)) << "trueToEccentric";
 
-    const float f_back = OrbitalMotion::eccentricToTrueAnomalyF32(kEc, kE);
+    const double f_back = OrbitalMotion::eccentricToTrueAnomaly(kEc, kE);
     EXPECT_TRUE(std::isfinite(f_back)) << "eccentricToTrue";
 
-    const float M = OrbitalMotion::eccentricToMeanAnomalyF32(kEc, kE);
+    const double M = OrbitalMotion::eccentricToMeanAnomaly(kEc, kE);
     EXPECT_TRUE(std::isfinite(M)) << "eccentricToMean";
 
-    const float M2 = OrbitalMotion::trueToMeanAnomalyF32(kF, kE);
+    const double M2 = OrbitalMotion::trueToMeanAnomaly(kF, kE);
     EXPECT_TRUE(std::isfinite(M2)) << "trueToMean";
 }
 
 // The Newton solver must converge to a finite E for small M.
 // Small M keeps the converged E near zero where the solver's safe
-// trig calls (safeSinf, safeCosf) are exact and the denominator
-// 1 − e·cos(E) stays well away from zero.
+// trig calls (safeSin, safeCos) are exact and the denominator
+// 1 - e*cos(E) stays well away from zero.
 TEST_F(NearParabolicEllipticTest, NewtonSolver_SmallM_Converges) {
-    const float E = OrbitalMotion::meanToEccentricAnomalyF32(0.005f, kE);
+    const double E = OrbitalMotion::meanToEccentricAnomaly(0.005, kE);
     EXPECT_TRUE(std::isfinite(E));
     // Verify it actually satisfies Kepler's equation to solver tolerance.
-    EXPECT_NEAR(E - kE * sinf(E), 0.005f, 1e-4f);
+    EXPECT_NEAR(E - kE * sin(E), 0.005, 1e-7);
 }
 
-// elementsToCartesianStateF32 must produce a finite Cartesian state.
+// elementsToCartesianState must produce a finite Cartesian state.
 TEST_F(NearParabolicEllipticTest, ElementsToCartesian_AllFinite) {
-    ClassicalElementsF32 el;
+    ClassicalElements el;
     el.semiMajorAxis = kRpM / (1.0 - kE);  // very large but finite
     el.eccentricity = kE;
-    el.inclination = 0.3f;
-    el.rightAscensionAscendingNode = 0.0f;
-    el.argPeriapsis = 0.0f;
+    el.inclination = 0.3;
+    el.rightAscensionAscendingNode = 0.0;
+    el.argPeriapsis = 0.0;
     el.trueAnomaly = kF;  // near periapsis
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMuEarth, el);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMuEarth, el);
 
     for (int i = 0; i < 3; ++i) {
         EXPECT_TRUE(std::isfinite(state.position[i])) << "position[" << i << ']';
@@ -81,15 +81,15 @@ TEST_F(NearParabolicEllipticTest, ElementsToCartesian_AllFinite) {
 
 // Vis-viva must hold at periapsis (f = 0) where the orbit is most numerically stable.
 TEST_F(NearParabolicEllipticTest, VisViva_AtPeriapsis) {
-    ClassicalElementsF32 el;
+    ClassicalElements el;
     el.semiMajorAxis = kRpM / (1.0 - kE);
     el.eccentricity = kE;
-    el.inclination = 0.3f;
-    el.rightAscensionAscendingNode = 0.0f;
-    el.argPeriapsis = 0.0f;
-    el.trueAnomaly = 0.0f;  // periapsis: most stable
+    el.inclination = 0.3;
+    el.rightAscensionAscendingNode = 0.0;
+    el.argPeriapsis = 0.0;
+    el.trueAnomaly = 0.0;  // periapsis: most stable
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMuEarth, el);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMuEarth, el);
     const double r = state.position.norm();
     const double v2 = state.velocity.squaredNorm();
     const double v2_expected = kMuEarth * (2.0 / r - 1.0 / el.semiMajorAxis);
@@ -101,71 +101,71 @@ TEST_F(NearParabolicEllipticTest, VisViva_AtPeriapsis) {
 // ============================================================================
 // Exactly parabolic (e = 1)
 //
-// Closed-form functions: sqrt(1−e) = 0, but atan2(y, 0) is well-defined,
+// Closed-form functions: sqrt(1-e) = 0, but atan2(y, 0) is well-defined,
 // so trueToEccentric, eccentricToTrue, and trueToMean all remain finite.
 //
-// elementsToCartesianStateF32: p = a(1−e²) = 0 → h = sqrt(μp) = 0 →
-// velocity = μ/h × (…) = Inf. This is a genuine singularity; the tests
+// elementsToCartesianState: p = a(1-e^2) = 0 -> h = sqrt(mu*p) = 0 ->
+// velocity = mu/h * (...) = Inf. This is a genuine singularity; the tests
 // document it explicitly.
 //
-// cartesianStateToElementsF32: the eccentricity vector magnitude equals 1
+// cartesianStateToElements: the eccentricity vector magnitude equals 1
 // for a parabolic / rectilinear trajectory.
 // ============================================================================
 
 TEST(ParabolicOrbitTest, TrueToEccentric_Finite) {
-    // sqrt(1−1) = 0, cos_part = 0; atan2(y, 0) = ±π/2 (defined).
-    for (const float f : {-0.7f, -0.3f, 0.0f, 0.3f, 0.7f}) {
-        const float E = OrbitalMotion::trueToEccentricAnomalyF32(f, 1.0f);
+    // sqrt(1-1) = 0, cos_part = 0; atan2(y, 0) = +/-pi/2 (defined).
+    for (const double f : {-0.7, -0.3, 0.0, 0.3, 0.7}) {
+        const double E = OrbitalMotion::trueToEccentricAnomaly(f, 1.0);
         EXPECT_TRUE(std::isfinite(E)) << "f=" << f;
     }
 }
 
 TEST(ParabolicOrbitTest, EccentricToTrue_Finite) {
-    for (const float E : {-0.7f, -0.3f, 0.0f, 0.3f, 0.7f}) {
-        const float f = OrbitalMotion::eccentricToTrueAnomalyF32(E, 1.0f);
+    for (const double E : {-0.7, -0.3, 0.0, 0.3, 0.7}) {
+        const double f = OrbitalMotion::eccentricToTrueAnomaly(E, 1.0);
         EXPECT_TRUE(std::isfinite(f)) << "E=" << E;
     }
 }
 
 TEST(ParabolicOrbitTest, TrueToMean_Finite) {
-    // Chains trueToEccentric (finite) then eccentricToMean (E − sin E, finite).
-    for (const float f : {-0.7f, -0.3f, 0.0f, 0.3f, 0.7f}) {
-        const float M = OrbitalMotion::trueToMeanAnomalyF32(f, 1.0f);
+    // Chains trueToEccentric (finite) then eccentricToMean (E - sin E, finite).
+    for (const double f : {-0.7, -0.3, 0.0, 0.3, 0.7}) {
+        const double M = OrbitalMotion::trueToMeanAnomaly(f, 1.0);
         EXPECT_TRUE(std::isfinite(M)) << "f=" << f;
     }
 }
 
-// The Newton solver denominator 1 − e·cos(E) is zero at E = 0 when e = 1,
+// The Newton solver denominator 1 - e*cos(E) is zero at E = 0 when e = 1,
 // so meanToEccentric(0, 1) is singular. Non-zero M starts the solver away
 // from E = 0, giving a finite (if not exact) result.
 TEST(ParabolicOrbitTest, MeanToEccentric_NonzeroM_Finite) {
-    const float E = OrbitalMotion::meanToEccentricAnomalyF32(0.5f, 1.0f);
+    const double E = OrbitalMotion::meanToEccentricAnomaly(0.5, 1.0);
     EXPECT_TRUE(std::isfinite(E));
 }
 
-// elementsToCartesianStateF32 with a = r_p/(1−e): for e = 1 this is Inf,
-// so p = a(1−e²) = Inf * 0, which is NaN. Set a directly from the parabolic
-// semi-latus rectum p = 2·r_p, with a = 0 (the parabolic limit stored by
-// cartesianStateToElementsF32). This exercises the h = 0 branch explicitly.
+// elementsToCartesianState with a = r_p/(1-e): for e = 1 this is Inf,
+// so p = a(1-e^2) = Inf * 0, which is NaN. Set a directly from the parabolic
+// semi-latus rectum p = 2*r_p, with a = 0 (the parabolic limit stored by
+// cartesianStateToElements). This exercises the h = 0 branch explicitly.
 TEST(ParabolicOrbitTest, ElementsToCartesian_ZeroSemiMajorAxis_VelocityInfinite) {
-    // cartesianStateToElementsF32 sets semiMajorAxis = 0 when alpha ≈ 0.
-    // Passing that back through elementsToCartesianStateF32 gives p = 0, h = 0,
-    // and velocity = μ/0 = ±Inf.  This test documents the singularity.
-    ClassicalElementsF32 el;
+    // cartesianStateToElements sets semiMajorAxis = 0 when alpha ~ 0.
+    // Passing that back through elementsToCartesianState gives p = 0, h = 0,
+    // and velocity = mu/0 = +/-Inf.  This test documents the singularity.
+    ClassicalElements el;
     el.semiMajorAxis = 0.0;  // as stored after round-trip through parabolic state
-    el.eccentricity = 1.0f;
-    el.inclination = 0.3f;
-    el.rightAscensionAscendingNode = 0.0f;
-    el.argPeriapsis = 0.0f;
-    el.trueAnomaly = 0.0f;
+    el.eccentricity = 1.0;
+    el.inclination = 0.3;
+    el.rightAscensionAscendingNode = 0.0;
+    el.argPeriapsis = 0.0;
+    el.trueAnomaly = 0.0;
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMuEarth, el);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMuEarth, el);
 
-    // Position is zero (r = p/(1+cos f) = 0/2 = 0) — finite but degenerate.
+    // Position is zero (r = p/(1+cos f) = 0/2 = 0) -- finite but degenerate.
     for (int i = 0; i < 3; ++i) {
         EXPECT_TRUE(std::isfinite(state.position[i])) << "position[" << i << ']';
     }
-    // Velocity diverges: v = μ/h × (…), h = 0.
+    // Velocity diverges: v = mu/h * (...), h = 0.
     const double v2 = state.velocity.squaredNorm();
     EXPECT_FALSE(std::isfinite(v2)) << "Expected infinite velocity for zero-a parabolic input; got " << v2;
 }
@@ -173,7 +173,7 @@ TEST(ParabolicOrbitTest, ElementsToCartesian_ZeroSemiMajorAxis_VelocityInfinite)
 // ============================================================================
 // Rectilinear orbit  (h = 0, purely radial velocity)
 //
-// r × v = 0 when v is parallel to r.  cartesianStateToElementsF32 divides
+// r x v = 0 when v is parallel to r.  cartesianStateToElements divides
 // by h to compute inclination and uses hVec.normalized() for omega and f.
 // Both produce NaN when h = 0.  The tests document these singularities and
 // verify the code does not crash or invoke undefined behaviour.
@@ -184,32 +184,32 @@ static const Eigen::Vector3d kRVecRadial(kRpM, 0.0, 0.0);
 static const Eigen::Vector3d kVVecRadial(1000.0, 0.0, 0.0);
 
 TEST(RectilinearOrbitTest, CartesianToElements_DoesNotCrash) {
-    EXPECT_NO_FATAL_FAILURE(OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, kVVecRadial));
+    EXPECT_NO_FATAL_FAILURE(OrbitalMotion::cartesianStateToElements(kMuEarth, kRVecRadial, kVVecRadial));
 }
 
 // For purely radial motion the eccentricity vector has magnitude 1.
 TEST(RectilinearOrbitTest, Eccentricity_IsOne) {
-    const ClassicalElementsF32 el = OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, kVVecRadial);
-    EXPECT_NEAR(el.eccentricity, 1.0f, 1e-4f);
+    const ClassicalElements el = OrbitalMotion::cartesianStateToElements(kMuEarth, kRVecRadial, kVVecRadial);
+    EXPECT_NEAR(el.eccentricity, 1.0, 1e-4);
 }
 
 // Inclination, argPeriapsis, and trueAnomaly are undefined (NaN) when h = 0.
 TEST(RectilinearOrbitTest, RectilinearDefaults) {
-    const ClassicalElementsF32 el = OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, kVVecRadial);
-    EXPECT_TRUE(el.inclination == 0.0F) << "expected 0 inclination for h=0";
-    EXPECT_TRUE(el.argPeriapsis == 0.0F) << "expected 0 argPeriapsis for h=0";
-    EXPECT_TRUE(el.trueAnomaly == static_cast<float>(M_PI)) << "expected pi trueAnomaly for h=0";
+    const ClassicalElements el = OrbitalMotion::cartesianStateToElements(kMuEarth, kRVecRadial, kVVecRadial);
+    EXPECT_TRUE(el.inclination == 0.0) << "expected 0 inclination for h=0";
+    EXPECT_TRUE(el.argPeriapsis == 0.0) << "expected 0 argPeriapsis for h=0";
+    EXPECT_TRUE(el.trueAnomaly == M_PI) << "expected pi trueAnomaly for h=0";
 }
 
 // ============================================================================
-// Near-rectilinear  (h → 0⁺, tiny transverse velocity)
+// Near-rectilinear  (h -> 0+, tiny transverse velocity)
 //
 // Configuration: r along +x, v = (v_radial, 0, v_transverse).
-// This gives hVec along −y (a polar orbit), so:
-//   inclination = acos(0)   = π/2  (finite)
-//   nVec = UnitZ × hVec     along +x (finite)
-//   hVec.normalized()       = (0, −1, 0) (finite for v_t > 0)
-// All elements remain finite even as v_transverse → 0⁺.
+// This gives hVec along -y (a polar orbit), so:
+//   inclination = acos(0)   = pi/2  (finite)
+//   nVec = UnitZ x hVec     along +x (finite)
+//   hVec.normalized()       = (0, -1, 0) (finite for v_t > 0)
+// All elements remain finite even as v_transverse -> 0+.
 // ============================================================================
 
 class NearRectilinearTest : public ::testing::Test {
@@ -219,8 +219,7 @@ class NearRectilinearTest : public ::testing::Test {
 
 TEST_F(NearRectilinearTest, AllElements_Finite) {
     for (const double vt : {10.0, 1.0, 0.1, 0.01}) {
-        const ClassicalElementsF32 el =
-            OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, makeVelocity(vt));
+        const ClassicalElements el = OrbitalMotion::cartesianStateToElements(kMuEarth, kRVecRadial, makeVelocity(vt));
 
         EXPECT_TRUE(std::isfinite(el.semiMajorAxis)) << "sma,  vt=" << vt;
         EXPECT_TRUE(std::isfinite(el.eccentricity)) << "ecc,  vt=" << vt;
@@ -233,15 +232,13 @@ TEST_F(NearRectilinearTest, AllElements_Finite) {
 
 // As transverse velocity shrinks toward zero the eccentricity must approach 1.
 TEST_F(NearRectilinearTest, Eccentricity_ApproachesOne) {
-    float prev_ecc = 0.0f;
+    double prev_ecc = 0.0;
     for (const double vt : {100.0, 10.0, 1.0}) {
-        const ClassicalElementsF32 el =
-            OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, makeVelocity(vt));
+        const ClassicalElements el = OrbitalMotion::cartesianStateToElements(kMuEarth, kRVecRadial, makeVelocity(vt));
         EXPECT_GT(el.eccentricity, prev_ecc) << "ecc should increase as vt decreases; vt=" << vt;
         prev_ecc = el.eccentricity;
     }
     // At vt = 0.1 m/s, eccentricity should be very close to 1.
-    const ClassicalElementsF32 el =
-        OrbitalMotion::cartesianStateToElementsF32(kMuEarth, kRVecRadial, makeVelocity(0.01));
-    EXPECT_NEAR(el.eccentricity, 1.0f, 0.01f);
+    const ClassicalElements el = OrbitalMotion::cartesianStateToElements(kMuEarth, kRVecRadial, makeVelocity(0.01));
+    EXPECT_NEAR(el.eccentricity, 1.0, 0.01);
 }

--- a/algorithms/utilities/_tests/test_orbitalMotion_functions.cpp
+++ b/algorithms/utilities/_tests/test_orbitalMotion_functions.cpp
@@ -5,8 +5,8 @@
 
 // Test constants
 const double muEarth = 3.986004418e14;  // m^3/s^2
-inline constexpr float kAnomalyTol = 1e-5f;
-inline constexpr double kStateRelTol = 1e-3;
+inline constexpr double kAnomalyTol = 1e-8;
+inline constexpr double kStateRelTol = 1e-6;
 
 // =============================================================================
 // Anomaly Conversion Tests
@@ -14,223 +14,223 @@ inline constexpr double kStateRelTol = 1e-3;
 
 class AnomalyConversionTest : public ::testing::Test {
    protected:
-    const float e_circular = 0.0f;
-    const float e_elliptical = 0.5f;
-    const float e_parabolic = 1.0f;
-    const float e_hyperbolic = 1.5f;
+    const double e_circular = 0.0;
+    const double e_elliptical = 0.5;
+    const double e_parabolic = 1.0;
+    const double e_hyperbolic = 1.5;
 };
 
 // Eccentric to True Anomaly Tests
 TEST_F(AnomalyConversionTest, EccentricToTrueAnomaly_ZeroEccentricity) {
-    float E = M_PI / 4.0f;
-    float f = OrbitalMotion::eccentricToTrueAnomalyF32(E, e_circular);
+    double E = M_PI / 4.0;
+    double f = OrbitalMotion::eccentricToTrueAnomaly(E, e_circular);
     ASSERT_TRUE(std::isfinite(f));
     EXPECT_NEAR(f, E, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, EccentricToTrueAnomaly_EllipticalOrbit) {
-    float E = M_PI / 3.0f;
-    float f = OrbitalMotion::eccentricToTrueAnomalyF32(E, e_elliptical);
+    double E = M_PI / 3.0;
+    double f = OrbitalMotion::eccentricToTrueAnomaly(E, e_elliptical);
     ASSERT_TRUE(std::isfinite(f));
     // Expected value: f = 2*atan(sqrt((1+e)/(1-e))*tan(E/2))
-    float expected = 2.0f * std::atan(std::sqrt((1.0f + e_elliptical) / (1.0f - e_elliptical)) * std::tan(E / 2.0f));
+    double expected = 2.0 * std::atan(std::sqrt((1.0 + e_elliptical) / (1.0 - e_elliptical)) * std::tan(E / 2.0));
     EXPECT_NEAR(f, expected, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, EccentricToTrueAnomaly_AtPeriapsis) {
-    float f = OrbitalMotion::eccentricToTrueAnomalyF32(0.0f, e_elliptical);
+    double f = OrbitalMotion::eccentricToTrueAnomaly(0.0, e_elliptical);
     ASSERT_TRUE(std::isfinite(f));
-    EXPECT_NEAR(f, 0.0f, kAnomalyTol);
+    EXPECT_NEAR(f, 0.0, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, EccentricToTrueAnomaly_AtApoapsis) {
-    float f = OrbitalMotion::eccentricToTrueAnomalyF32(M_PI, e_elliptical);
+    double f = OrbitalMotion::eccentricToTrueAnomaly(M_PI, e_elliptical);
     ASSERT_TRUE(std::isfinite(f));
     EXPECT_NEAR(f, M_PI, kAnomalyTol);
 }
 
 // Eccentric to Mean Anomaly Tests
 TEST_F(AnomalyConversionTest, EccentricToMeanAnomaly_Circular) {
-    float E = M_PI / 4.0f;
-    float M = OrbitalMotion::eccentricToMeanAnomalyF32(E, e_circular);
+    double E = M_PI / 4.0;
+    double M = OrbitalMotion::eccentricToMeanAnomaly(E, e_circular);
     ASSERT_TRUE(std::isfinite(M));
     EXPECT_NEAR(M, E, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, EccentricToMeanAnomaly_Elliptical) {
-    float E = M_PI / 3.0f;
-    float M = OrbitalMotion::eccentricToMeanAnomalyF32(E, e_elliptical);
+    double E = M_PI / 3.0;
+    double M = OrbitalMotion::eccentricToMeanAnomaly(E, e_elliptical);
     ASSERT_TRUE(std::isfinite(M));
-    float expected = E - e_elliptical * std::sin(E);
+    double expected = E - e_elliptical * std::sin(E);
     EXPECT_NEAR(M, expected, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, EccentricToMeanAnomaly_Zero) {
-    float M = OrbitalMotion::eccentricToMeanAnomalyF32(0.0f, e_elliptical);
+    double M = OrbitalMotion::eccentricToMeanAnomaly(0.0, e_elliptical);
     ASSERT_TRUE(std::isfinite(M));
-    EXPECT_NEAR(M, 0.0f, kAnomalyTol);
+    EXPECT_NEAR(M, 0.0, kAnomalyTol);
 }
 
 // True to Eccentric Anomaly Tests
 TEST_F(AnomalyConversionTest, TrueToEccentricAnomaly_Circular) {
-    float f = M_PI / 4.0f;
-    float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e_circular);
+    double f = M_PI / 4.0;
+    double E = OrbitalMotion::trueToEccentricAnomaly(f, e_circular);
     ASSERT_TRUE(std::isfinite(E));
     EXPECT_NEAR(E, f, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, TrueToEccentricAnomaly_Elliptical) {
-    float f = M_PI / 3.0f;
-    float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e_elliptical);
+    double f = M_PI / 3.0;
+    double E = OrbitalMotion::trueToEccentricAnomaly(f, e_elliptical);
     ASSERT_TRUE(std::isfinite(E));
     // Expected value: E = 2*atan(sqrt((1-e)/(1+e))*tan(f/2))
-    float expected = 2.0f * std::atan(std::sqrt((1.0f - e_elliptical) / (1.0f + e_elliptical)) * std::tan(f / 2.0f));
+    double expected = 2.0 * std::atan(std::sqrt((1.0 - e_elliptical) / (1.0 + e_elliptical)) * std::tan(f / 2.0));
     EXPECT_NEAR(E, expected, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, TrueToEccentricAnomaly_RoundTrip) {
-    float E_original = M_PI / 4.0f;
-    float f = OrbitalMotion::eccentricToTrueAnomalyF32(E_original, e_elliptical);
+    double E_original = M_PI / 4.0;
+    double f = OrbitalMotion::eccentricToTrueAnomaly(E_original, e_elliptical);
     ASSERT_TRUE(std::isfinite(f));
-    float E_result = OrbitalMotion::trueToEccentricAnomalyF32(f, e_elliptical);
+    double E_result = OrbitalMotion::trueToEccentricAnomaly(f, e_elliptical);
     ASSERT_TRUE(std::isfinite(E_result));
     EXPECT_NEAR(E_result, E_original, kAnomalyTol);
 }
 
 // True to Hyperbolic Anomaly Tests
 TEST_F(AnomalyConversionTest, TrueToHyperbolicAnomaly_HyperbolicOrbit) {
-    float f = M_PI / 6.0f;
-    float H = OrbitalMotion::trueToHyperbolicAnomalyF32(f, e_hyperbolic);
+    double f = M_PI / 6.0;
+    double H = OrbitalMotion::trueToHyperbolicAnomaly(f, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(H));
     // Expected value: H = 2*atanh(sqrt((e-1)/(e+1))*tan(f/2))
-    float expected = 2.0f * std::atanh(std::sqrt((e_hyperbolic - 1.0f) / (e_hyperbolic + 1.0f)) * std::tan(f / 2.0f));
+    double expected = 2.0 * std::atanh(std::sqrt((e_hyperbolic - 1.0) / (e_hyperbolic + 1.0)) * std::tan(f / 2.0));
     EXPECT_NEAR(H, expected, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, TrueToHyperbolicAnomaly_AtPeriapsis) {
-    float H = OrbitalMotion::trueToHyperbolicAnomalyF32(0.0f, e_hyperbolic);
+    double H = OrbitalMotion::trueToHyperbolicAnomaly(0.0, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(H));
-    EXPECT_NEAR(H, 0.0f, kAnomalyTol);
+    EXPECT_NEAR(H, 0.0, kAnomalyTol);
 }
 
 // True to Mean Anomaly Tests
 TEST_F(AnomalyConversionTest, TrueToMeanAnomaly_Circular) {
-    float f = M_PI / 4.0f;
-    float M = OrbitalMotion::trueToMeanAnomalyF32(f, e_circular);
+    double f = M_PI / 4.0;
+    double M = OrbitalMotion::trueToMeanAnomaly(f, e_circular);
     ASSERT_TRUE(std::isfinite(M));
     EXPECT_NEAR(M, f, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, TrueToMeanAnomaly_Elliptical) {
-    float f = M_PI / 3.0f;
-    float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e_elliptical);
-    float M = OrbitalMotion::trueToMeanAnomalyF32(f, e_elliptical);
+    double f = M_PI / 3.0;
+    double E = OrbitalMotion::trueToEccentricAnomaly(f, e_elliptical);
+    double M = OrbitalMotion::trueToMeanAnomaly(f, e_elliptical);
     ASSERT_TRUE(std::isfinite(M));
-    float expected = E - e_elliptical * std::sin(E);
+    double expected = E - e_elliptical * std::sin(E);
     EXPECT_NEAR(M, expected, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, TrueToMeanAnomaly_RoundTrip) {
-    float f_original = M_PI / 4.0f;
-    float M = OrbitalMotion::trueToMeanAnomalyF32(f_original, e_elliptical);
+    double f_original = M_PI / 4.0;
+    double M = OrbitalMotion::trueToMeanAnomaly(f_original, e_elliptical);
     ASSERT_TRUE(std::isfinite(M));
-    float f_result = OrbitalMotion::meanToTrueAnomalyF32(M, e_elliptical);
+    double f_result = OrbitalMotion::meanToTrueAnomaly(M, e_elliptical);
     ASSERT_TRUE(std::isfinite(f_result));
     EXPECT_NEAR(f_result, f_original, kAnomalyTol);
 }
 
 // Hyperbolic to True Anomaly Tests
 TEST_F(AnomalyConversionTest, HyperbolicToTrueAnomaly_HyperbolicOrbit) {
-    float H = 0.5f;
-    float f = OrbitalMotion::hyperbolicToTrueAnomalyF32(H, e_hyperbolic);
+    double H = 0.5;
+    double f = OrbitalMotion::hyperbolicToTrueAnomaly(H, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(f));
     // Expected value: f = 2*atan(sqrt((e+1)/(e-1))*tanh(H/2))
-    float expected = 2.0f * std::atan(std::sqrt((e_hyperbolic + 1.0f) / (e_hyperbolic - 1.0f)) * std::tanh(H / 2.0f));
+    double expected = 2.0 * std::atan(std::sqrt((e_hyperbolic + 1.0) / (e_hyperbolic - 1.0)) * std::tanh(H / 2.0));
     EXPECT_NEAR(f, expected, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, HyperbolicToTrueAnomaly_RoundTrip) {
-    float f_original = M_PI / 6.0f;
-    float H = OrbitalMotion::trueToHyperbolicAnomalyF32(f_original, e_hyperbolic);
+    double f_original = M_PI / 6.0;
+    double H = OrbitalMotion::trueToHyperbolicAnomaly(f_original, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(H));
-    float f_result = OrbitalMotion::hyperbolicToTrueAnomalyF32(H, e_hyperbolic);
+    double f_result = OrbitalMotion::hyperbolicToTrueAnomaly(H, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(f_result));
     EXPECT_NEAR(f_result, f_original, kAnomalyTol);
 }
 
 // Hyperbolic to Mean Anomaly Tests
 TEST_F(AnomalyConversionTest, HyperbolicToMeanAnomaly_HyperbolicOrbit) {
-    float H = 0.5f;
-    float N = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e_hyperbolic);
+    double H = 0.5;
+    double N = OrbitalMotion::hyperbolicToMeanAnomaly(H, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(N));
-    float expected = e_hyperbolic * std::sinh(H) - H;
+    double expected = e_hyperbolic * std::sinh(H) - H;
     EXPECT_NEAR(N, expected, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, HyperbolicToMeanAnomaly_Zero) {
-    float N = OrbitalMotion::hyperbolicToMeanAnomalyF32(0.0f, e_hyperbolic);
+    double N = OrbitalMotion::hyperbolicToMeanAnomaly(0.0, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(N));
-    EXPECT_NEAR(N, 0.0f, kAnomalyTol);
+    EXPECT_NEAR(N, 0.0, kAnomalyTol);
 }
 
 // Mean to Eccentric Anomaly Tests
 TEST_F(AnomalyConversionTest, MeanToEccentricAnomaly_Circular) {
-    float M = M_PI / 4.0f;
-    float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e_circular);
+    double M = M_PI / 4.0;
+    double E = OrbitalMotion::meanToEccentricAnomaly(M, e_circular);
     ASSERT_TRUE(std::isfinite(E));
     EXPECT_NEAR(E, M, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, MeanToEccentricAnomaly_Elliptical) {
-    float M = M_PI / 4.0f;
-    float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e_elliptical);
+    double M = M_PI / 4.0;
+    double E = OrbitalMotion::meanToEccentricAnomaly(M, e_elliptical);
     ASSERT_TRUE(std::isfinite(E));
     // Verify Kepler's equation: M = E - e*sin(E)
-    float M_check = E - e_elliptical * std::sin(E);
+    double M_check = E - e_elliptical * std::sin(E);
     EXPECT_NEAR(M_check, M, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, MeanToEccentricAnomaly_RoundTrip) {
-    float E_original = M_PI / 4.0f;
-    float M = OrbitalMotion::eccentricToMeanAnomalyF32(E_original, e_elliptical);
+    double E_original = M_PI / 4.0;
+    double M = OrbitalMotion::eccentricToMeanAnomaly(E_original, e_elliptical);
     ASSERT_TRUE(std::isfinite(M));
-    float E_result = OrbitalMotion::meanToEccentricAnomalyF32(M, e_elliptical);
+    double E_result = OrbitalMotion::meanToEccentricAnomaly(M, e_elliptical);
     ASSERT_TRUE(std::isfinite(E_result));
     EXPECT_NEAR(E_result, E_original, kAnomalyTol);
 }
 
 // Mean to True Anomaly Tests
 TEST_F(AnomalyConversionTest, MeanToTrueAnomaly_Circular) {
-    float M = M_PI / 4.0f;
-    float f = OrbitalMotion::meanToTrueAnomalyF32(M, e_circular);
+    double M = M_PI / 4.0;
+    double f = OrbitalMotion::meanToTrueAnomaly(M, e_circular);
     ASSERT_TRUE(std::isfinite(f));
     EXPECT_NEAR(f, M, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, MeanToTrueAnomaly_Elliptical) {
-    float M = M_PI / 4.0f;
-    float f = OrbitalMotion::meanToTrueAnomalyF32(M, e_elliptical);
+    double M = M_PI / 4.0;
+    double f = OrbitalMotion::meanToTrueAnomaly(M, e_elliptical);
     ASSERT_TRUE(std::isfinite(f));
-    float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e_elliptical);
-    float expected = OrbitalMotion::eccentricToTrueAnomalyF32(E, e_elliptical);
+    double E = OrbitalMotion::meanToEccentricAnomaly(M, e_elliptical);
+    double expected = OrbitalMotion::eccentricToTrueAnomaly(E, e_elliptical);
     EXPECT_NEAR(f, expected, kAnomalyTol);
 }
 
 // Mean to Hyperbolic Anomaly Tests
 TEST_F(AnomalyConversionTest, MeanToHyperbolicAnomaly_HyperbolicOrbit) {
-    float N = 0.5f;
-    float H = OrbitalMotion::meanToHyperbolicAnomalyF32(N, e_hyperbolic);
+    double N = 0.5;
+    double H = OrbitalMotion::meanToHyperbolicAnomaly(N, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(H));
     // Verify hyperbolic Kepler's equation: N = e*sinh(H) - H
-    float N_check = e_hyperbolic * std::sinh(H) - H;
+    double N_check = e_hyperbolic * std::sinh(H) - H;
     EXPECT_NEAR(N_check, N, kAnomalyTol);
 }
 
 TEST_F(AnomalyConversionTest, MeanToHyperbolicAnomaly_RoundTrip) {
-    float H_original = 0.5f;
-    float N = OrbitalMotion::hyperbolicToMeanAnomalyF32(H_original, e_hyperbolic);
+    double H_original = 0.5;
+    double N = OrbitalMotion::hyperbolicToMeanAnomaly(H_original, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(N));
-    float H_result = OrbitalMotion::meanToHyperbolicAnomalyF32(N, e_hyperbolic);
+    double H_result = OrbitalMotion::meanToHyperbolicAnomaly(N, e_hyperbolic);
     ASSERT_TRUE(std::isfinite(H_result));
     EXPECT_NEAR(H_result, H_original, kAnomalyTol);
 }
@@ -245,15 +245,15 @@ class StateConversionTest : public ::testing::Test {
 };
 
 TEST_F(StateConversionTest, CircularOrbit_Conversion) {
-    ClassicalElementsF32 elements;
+    ClassicalElements elements;
     elements.semiMajorAxis = 7000000.0;  // 7000 km
-    elements.eccentricity = 0.0f;
-    elements.inclination = 0.0f;
-    elements.rightAscensionAscendingNode = 0.0f;
-    elements.argPeriapsis = 0.0f;
-    elements.trueAnomaly = 0.0f;
+    elements.eccentricity = 0.0;
+    elements.inclination = 0.0;
+    elements.rightAscensionAscendingNode = 0.0;
+    elements.argPeriapsis = 0.0;
+    elements.trueAnomaly = 0.0;
 
-    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
+    CartesianState state = OrbitalMotion::elementsToCartesianState(mu, elements);
     for (int j = 0; j < 3; ++j) {
         ASSERT_TRUE(std::isfinite(state.position[j]));
         ASSERT_TRUE(std::isfinite(state.velocity[j]));
@@ -271,15 +271,15 @@ TEST_F(StateConversionTest, CircularOrbit_Conversion) {
 }
 
 TEST_F(StateConversionTest, EllipticalOrbit_Conversion) {
-    ClassicalElementsF32 elements;
+    ClassicalElements elements;
     elements.semiMajorAxis = 8000000.0;
-    elements.eccentricity = 0.3f;
-    elements.inclination = 0.5f;
-    elements.rightAscensionAscendingNode = 0.2f;
-    elements.argPeriapsis = 0.8f;
-    elements.trueAnomaly = M_PI / 4.0f;
+    elements.eccentricity = 0.3;
+    elements.inclination = 0.5;
+    elements.rightAscensionAscendingNode = 0.2;
+    elements.argPeriapsis = 0.8;
+    elements.trueAnomaly = M_PI / 4.0;
 
-    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
+    CartesianState state = OrbitalMotion::elementsToCartesianState(mu, elements);
     for (int j = 0; j < 3; ++j) {
         ASSERT_TRUE(std::isfinite(state.position[j]));
         ASSERT_TRUE(std::isfinite(state.velocity[j]));
@@ -298,16 +298,16 @@ TEST_F(StateConversionTest, EllipticalOrbit_Conversion) {
 }
 
 TEST_F(StateConversionTest, CartesianToElements_RoundTrip) {
-    ClassicalElementsF32 original;
+    ClassicalElements original;
     original.semiMajorAxis = 7500000.0;
-    original.eccentricity = 0.2f;
-    original.inclination = 0.3f;
-    original.rightAscensionAscendingNode = 0.5f;
-    original.argPeriapsis = 1.0f;
-    original.trueAnomaly = M_PI / 3.0f;
+    original.eccentricity = 0.2;
+    original.inclination = 0.3;
+    original.rightAscensionAscendingNode = 0.5;
+    original.argPeriapsis = 1.0;
+    original.trueAnomaly = M_PI / 3.0;
 
-    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, original);
-    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(mu, state.position, state.velocity);
+    CartesianState state = OrbitalMotion::elementsToCartesianState(mu, original);
+    ClassicalElements result = OrbitalMotion::cartesianStateToElements(mu, state.position, state.velocity);
 
     EXPECT_NEAR(result.semiMajorAxis, original.semiMajorAxis, std::abs(original.semiMajorAxis) * kStateRelTol);
     EXPECT_NEAR(result.eccentricity, original.eccentricity, kStateRelTol);
@@ -321,8 +321,8 @@ TEST_F(StateConversionTest, ElementsToCartesian_RoundTrip) {
     Eigen::Vector3d r_original(7000000.0, 1000000.0, 500000.0);
     Eigen::Vector3d v_original(500.0, 7000.0, 100.0);
 
-    ClassicalElementsF32 elements = OrbitalMotion::cartesianStateToElementsF32(mu, r_original, v_original);
-    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
+    ClassicalElements elements = OrbitalMotion::cartesianStateToElements(mu, r_original, v_original);
+    CartesianState state = OrbitalMotion::elementsToCartesianState(mu, elements);
 
     EXPECT_NEAR(state.position.x(), r_original.x(), std::abs(r_original.x()) * kStateRelTol + kAnomalyTol);
     EXPECT_NEAR(state.position.y(), r_original.y(), std::abs(r_original.y()) * kStateRelTol + kAnomalyTol);
@@ -333,33 +333,33 @@ TEST_F(StateConversionTest, ElementsToCartesian_RoundTrip) {
 }
 
 TEST_F(StateConversionTest, EquatorialOrbit_NoRAANAmbiguity) {
-    ClassicalElementsF32 elements;
+    ClassicalElements elements;
     elements.semiMajorAxis = 7000000.0;
-    elements.eccentricity = 0.1f;
-    elements.inclination = 0.0f;  // Equatorial
-    elements.rightAscensionAscendingNode = 0.0f;
-    elements.argPeriapsis = M_PI / 4.0f;
-    elements.trueAnomaly = M_PI / 6.0f;
+    elements.eccentricity = 0.1;
+    elements.inclination = 0.0;  // Equatorial
+    elements.rightAscensionAscendingNode = 0.0;
+    elements.argPeriapsis = M_PI / 4.0;
+    elements.trueAnomaly = M_PI / 6.0;
 
-    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
-    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(mu, state.position, state.velocity);
+    CartesianState state = OrbitalMotion::elementsToCartesianState(mu, elements);
+    ClassicalElements result = OrbitalMotion::cartesianStateToElements(mu, state.position, state.velocity);
 
-    EXPECT_NEAR(result.inclination, 0.0f, kAnomalyTol);
+    EXPECT_NEAR(result.inclination, 0.0, kAnomalyTol);
 }
 
 TEST_F(StateConversionTest, CircularOrbit_NoArgPeriapsisAmbiguity) {
-    ClassicalElementsF32 elements;
+    ClassicalElements elements;
     elements.semiMajorAxis = 7000000.0;
-    elements.eccentricity = 0.0f;  // Circular
-    elements.inclination = 0.5f;
-    elements.rightAscensionAscendingNode = 0.3f;
-    elements.argPeriapsis = 0.0f;
-    elements.trueAnomaly = M_PI / 4.0f;
+    elements.eccentricity = 0.0;  // Circular
+    elements.inclination = 0.5;
+    elements.rightAscensionAscendingNode = 0.3;
+    elements.argPeriapsis = 0.0;
+    elements.trueAnomaly = M_PI / 4.0;
 
-    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(mu, elements);
-    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(mu, state.position, state.velocity);
+    CartesianState state = OrbitalMotion::elementsToCartesianState(mu, elements);
+    ClassicalElements result = OrbitalMotion::cartesianStateToElements(mu, state.position, state.velocity);
 
-    EXPECT_NEAR(result.eccentricity, 0.0f, kAnomalyTol);
+    EXPECT_NEAR(result.eccentricity, 0.0, kAnomalyTol);
 }
 
 // =============================================================================
@@ -369,56 +369,56 @@ TEST_F(StateConversionTest, CircularOrbit_NoArgPeriapsisAmbiguity) {
 class EdgeCasesTest : public ::testing::Test {};
 
 TEST_F(EdgeCasesTest, NearParabolicOrbit_Eccentricity) {
-    float e = 0.9999f;
-    float f = M_PI / 6.0f;
+    double e = 0.9999;
+    double f = M_PI / 6.0;
 
-    float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e);
+    double E = OrbitalMotion::trueToEccentricAnomaly(f, e);
     EXPECT_TRUE(std::isfinite(E));
 }
 
 TEST_F(EdgeCasesTest, VerySmallEccentricity) {
-    float e = 1e-6f;
-    float M = M_PI / 4.0f;
+    double e = 1e-8;
+    double M = M_PI / 4.0;
 
-    float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e);
+    double E = OrbitalMotion::meanToEccentricAnomaly(M, e);
     ASSERT_TRUE(std::isfinite(E));
     EXPECT_NEAR(E, M, kAnomalyTol);
 }
 
 TEST_F(EdgeCasesTest, LargeHyperbolicEccentricity) {
-    float e = 10.0f;
-    float f = M_PI / 12.0f;
+    double e = 10.0;
+    double f = M_PI / 12.0;
 
-    float H = OrbitalMotion::trueToHyperbolicAnomalyF32(f, e);
+    double H = OrbitalMotion::trueToHyperbolicAnomaly(f, e);
     EXPECT_TRUE(std::isfinite(H));
 }
 
 TEST_F(EdgeCasesTest, PolarOrbit) {
-    ClassicalElementsF32 elements;
+    ClassicalElements elements;
     elements.semiMajorAxis = 7000000.0;
-    elements.eccentricity = 0.0f;
-    elements.inclination = M_PI / 2.0f;  // Polar orbit
-    elements.rightAscensionAscendingNode = 0.0f;
-    elements.argPeriapsis = 0.0f;
-    elements.trueAnomaly = 0.0f;
+    elements.eccentricity = 0.0;
+    elements.inclination = M_PI / 2.0;  // Polar orbit
+    elements.rightAscensionAscendingNode = 0.0;
+    elements.argPeriapsis = 0.0;
+    elements.trueAnomaly = 0.0;
 
-    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(muEarth, elements);
-    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(muEarth, state.position, state.velocity);
+    CartesianState state = OrbitalMotion::elementsToCartesianState(muEarth, elements);
+    ClassicalElements result = OrbitalMotion::cartesianStateToElements(muEarth, state.position, state.velocity);
 
-    EXPECT_NEAR(result.inclination, M_PI / 2.0f, kAnomalyTol);
+    EXPECT_NEAR(result.inclination, M_PI / 2.0, kAnomalyTol);
 }
 
 TEST_F(EdgeCasesTest, RetrogradeOrbit) {
-    ClassicalElementsF32 elements;
+    ClassicalElements elements;
     elements.semiMajorAxis = 7000000.0;
-    elements.eccentricity = 0.1f;
-    elements.inclination = 3.0f * M_PI / 4.0f;  // Retrograde
-    elements.rightAscensionAscendingNode = 1.0f;
-    elements.argPeriapsis = 0.5f;
-    elements.trueAnomaly = M_PI / 3.0f;
+    elements.eccentricity = 0.1;
+    elements.inclination = 3.0 * M_PI / 4.0;  // Retrograde
+    elements.rightAscensionAscendingNode = 1.0;
+    elements.argPeriapsis = 0.5;
+    elements.trueAnomaly = M_PI / 3.0;
 
-    CartesianState state = OrbitalMotion::elementsToCartesianStateF32(muEarth, elements);
-    ClassicalElementsF32 result = OrbitalMotion::cartesianStateToElementsF32(muEarth, state.position, state.velocity);
+    CartesianState state = OrbitalMotion::elementsToCartesianState(muEarth, elements);
+    ClassicalElements result = OrbitalMotion::cartesianStateToElements(muEarth, state.position, state.velocity);
 
-    EXPECT_GT(result.inclination, M_PI / 2.0f);
+    EXPECT_GT(result.inclination, M_PI / 2.0);
 }

--- a/algorithms/utilities/_tests/test_orbitalMotion_fuzz.cpp
+++ b/algorithms/utilities/_tests/test_orbitalMotion_fuzz.cpp
@@ -11,137 +11,133 @@
 #include <Eigen/Geometry>
 #include <cmath>
 
-// Earth's gravitational parameter (m³/s²)
+// Earth's gravitational parameter (m^3/s^2)
 constexpr double kMu = 3.986004418e14;
 
 // Semi-major axis used for Keplerian conserved-quantity tests (m).
 // Fixed so the fuzzer can vary the remaining orbital shape parameters freely.
 constexpr double kSemiMajorAxis = 7.0e6;
 
-inline constexpr float kAnomalyTol = 1e-5f;
-inline constexpr double kStateRelTol = 1e-3;
+inline constexpr double kAnomalyTol = 1e-8;
+inline constexpr double kStateRelTol = 1e-6;
 
 // ============================================================================
 // Elliptic anomaly identities
 // ============================================================================
 
-// Kepler's equation holds exactly: eccentricToMean(E, e) == E − e·sin(E).
-void fuzzKeplersEquation(float E, float e) {
-    const float result = OrbitalMotion::eccentricToMeanAnomalyF32(E, e);
+// Kepler's equation holds exactly: eccentricToMean(E, e) == E - e*sin(E).
+void fuzzKeplersEquation(double E, double e) {
+    const double result = OrbitalMotion::eccentricToMeanAnomaly(E, e);
     ASSERT_TRUE(std::isfinite(result));
-    EXPECT_FLOAT_EQ(result, E - e * sinf(E));
+    EXPECT_DOUBLE_EQ(result, E - e * sin(E));
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzKeplersEquation)
-    .WithDomains(fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)),
-                 fuzztest::InRange(0.0f, 0.99f));
+    .WithDomains(fuzztest::InRange(-M_PI, M_PI), fuzztest::InRange(0.0, 0.99));
 
-// Mean anomaly is odd in eccentric anomaly: M(−E, e) = −M(E, e).
-void fuzzMeanAnomalyIsOdd(float E, float e) {
-    const float pos = OrbitalMotion::eccentricToMeanAnomalyF32(E, e);
-    const float neg = OrbitalMotion::eccentricToMeanAnomalyF32(-E, e);
+// Mean anomaly is odd in eccentric anomaly: M(-E, e) = -M(E, e).
+void fuzzMeanAnomalyIsOdd(double E, double e) {
+    const double pos = OrbitalMotion::eccentricToMeanAnomaly(E, e);
+    const double neg = OrbitalMotion::eccentricToMeanAnomaly(-E, e);
     ASSERT_TRUE(std::isfinite(pos));
     ASSERT_TRUE(std::isfinite(neg));
-    EXPECT_FLOAT_EQ(neg, -pos);
+    EXPECT_DOUBLE_EQ(neg, -pos);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanAnomalyIsOdd)
-    .WithDomains(fuzztest::InRange(0.0f, static_cast<float>(M_PI)), fuzztest::InRange(0.0f, 0.99f));
+    .WithDomains(fuzztest::InRange(0.0, M_PI), fuzztest::InRange(0.0, 0.99));
 
-// The Newton-Raphson solver must return E satisfying E − e·sin(E) = M.
-void fuzzMeanToEccentricSolvesKepler(float M, float e) {
-    const float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e);
+// The Newton-Raphson solver must return E satisfying E - e*sin(E) = M.
+void fuzzMeanToEccentricSolvesKepler(double M, double e) {
+    const double E = OrbitalMotion::meanToEccentricAnomaly(M, e);
     ASSERT_TRUE(std::isfinite(E));
-    EXPECT_NEAR(E - e * sinf(E), M, kAnomalyTol);
+    EXPECT_NEAR(E - e * sin(E), M, kAnomalyTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanToEccentricSolvesKepler)
-    .WithDomains(fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)),
-                 fuzztest::InRange(0.0f, 0.99f));
+    .WithDomains(fuzztest::InRange(-M_PI, M_PI), fuzztest::InRange(0.0, 0.99));
 
-// E → f → E closed-form round-trip.
-void fuzzEccentricTrueRoundTrip(float E, float e) {
-    const float f = OrbitalMotion::eccentricToTrueAnomalyF32(E, e);
+// E -> f -> E closed-form round-trip.
+void fuzzEccentricTrueRoundTrip(double E, double e) {
+    const double f = OrbitalMotion::eccentricToTrueAnomaly(E, e);
     ASSERT_TRUE(std::isfinite(f));
-    const float E_back = OrbitalMotion::trueToEccentricAnomalyF32(f, e);
+    const double E_back = OrbitalMotion::trueToEccentricAnomaly(f, e);
     ASSERT_TRUE(std::isfinite(E_back));
     EXPECT_NEAR(E_back, E, kAnomalyTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzEccentricTrueRoundTrip)
-    .WithDomains(fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)),
-                 fuzztest::InRange(0.0f, 0.99f));
+    .WithDomains(fuzztest::InRange(-M_PI, M_PI), fuzztest::InRange(0.0, 0.99));
 
-// M → E → M round-trip: meanToEccentric then eccentricToMean must recover M.
-void fuzzMeanEccentricRoundTrip(float M, float e) {
-    const float E = OrbitalMotion::meanToEccentricAnomalyF32(M, e);
+// M -> E -> M round-trip: meanToEccentric then eccentricToMean must recover M.
+void fuzzMeanEccentricRoundTrip(double M, double e) {
+    const double E = OrbitalMotion::meanToEccentricAnomaly(M, e);
     ASSERT_TRUE(std::isfinite(E));
-    const float M_back = OrbitalMotion::eccentricToMeanAnomalyF32(E, e);
+    const double M_back = OrbitalMotion::eccentricToMeanAnomaly(E, e);
     ASSERT_TRUE(std::isfinite(M_back));
     EXPECT_NEAR(M_back, M, kAnomalyTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanEccentricRoundTrip)
-    .WithDomains(fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)),
-                 fuzztest::InRange(0.0f, 0.99f));
+    .WithDomains(fuzztest::InRange(-M_PI, M_PI), fuzztest::InRange(0.0, 0.99));
 
 // ============================================================================
 // Hyperbolic anomaly identities
 // ============================================================================
 
-// Hyperbolic Kepler's equation: hyperbolicToMean(H, e) == e·sinh(H) − H.
-void fuzzHyperbolicKeplersEquation(float H, float e) {
-    const float result = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e);
+// Hyperbolic Kepler's equation: hyperbolicToMean(H, e) == e*sinh(H) - H.
+void fuzzHyperbolicKeplersEquation(double H, double e) {
+    const double result = OrbitalMotion::hyperbolicToMeanAnomaly(H, e);
     ASSERT_TRUE(std::isfinite(result));
-    EXPECT_FLOAT_EQ(result, e * sinhf(H) - H);
+    EXPECT_DOUBLE_EQ(result, e * sinh(H) - H);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicKeplersEquation)
-    .WithDomains(fuzztest::InRange(-3.0f, 3.0f), fuzztest::InRange(1.05f, 5.0f));
+    .WithDomains(fuzztest::InRange(-3.0, 3.0), fuzztest::InRange(1.05, 5.0));
 
-// Hyperbolic mean anomaly is odd: N(−H, e) = −N(H, e).
-void fuzzHyperbolicMeanIsOdd(float H, float e) {
-    const float pos = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e);
-    const float neg = OrbitalMotion::hyperbolicToMeanAnomalyF32(-H, e);
+// Hyperbolic mean anomaly is odd: N(-H, e) = -N(H, e).
+void fuzzHyperbolicMeanIsOdd(double H, double e) {
+    const double pos = OrbitalMotion::hyperbolicToMeanAnomaly(H, e);
+    const double neg = OrbitalMotion::hyperbolicToMeanAnomaly(-H, e);
     ASSERT_TRUE(std::isfinite(pos));
     ASSERT_TRUE(std::isfinite(neg));
-    EXPECT_FLOAT_EQ(neg, -pos);
+    EXPECT_DOUBLE_EQ(neg, -pos);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicMeanIsOdd)
-    .WithDomains(fuzztest::InRange(0.0f, 3.0f), fuzztest::InRange(1.05f, 5.0f));
+    .WithDomains(fuzztest::InRange(0.0, 3.0), fuzztest::InRange(1.05, 5.0));
 
-// The Newton-Raphson solver must return H satisfying e·sinh(H) − H = N.
-void fuzzMeanToHyperbolicSolvesKepler(float N, float e) {
-    const float H = OrbitalMotion::meanToHyperbolicAnomalyF32(N, e);
+// The Newton-Raphson solver must return H satisfying e*sinh(H) - H = N.
+void fuzzMeanToHyperbolicSolvesKepler(double N, double e) {
+    const double H = OrbitalMotion::meanToHyperbolicAnomaly(N, e);
     ASSERT_TRUE(std::isfinite(H));
-    EXPECT_NEAR(e * sinhf(H) - H, N, kAnomalyTol);
+    EXPECT_NEAR(e * sinh(H) - H, N, kAnomalyTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanToHyperbolicSolvesKepler)
-    .WithDomains(fuzztest::InRange(-5.0f, 5.0f), fuzztest::InRange(1.01f, 10.0f));
+    .WithDomains(fuzztest::InRange(-5.0, 5.0), fuzztest::InRange(1.01, 10.0));
 
-// H → f → H closed-form round-trip.
-void fuzzHyperbolicTrueRoundTrip(float H, float e) {
-    const float f = OrbitalMotion::hyperbolicToTrueAnomalyF32(H, e);
+// H -> f -> H closed-form round-trip.
+void fuzzHyperbolicTrueRoundTrip(double H, double e) {
+    const double f = OrbitalMotion::hyperbolicToTrueAnomaly(H, e);
     ASSERT_TRUE(std::isfinite(f));
-    const float H_back = OrbitalMotion::trueToHyperbolicAnomalyF32(f, e);
+    const double H_back = OrbitalMotion::trueToHyperbolicAnomaly(f, e);
     ASSERT_TRUE(std::isfinite(H_back));
     EXPECT_NEAR(H_back, H, kAnomalyTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicTrueRoundTrip)
-    .WithDomains(fuzztest::InRange(-2.0f, 2.0f), fuzztest::InRange(1.01f, 10.0f));
+    .WithDomains(fuzztest::InRange(-2.0, 2.0), fuzztest::InRange(1.01, 10.0));
 
-// N → H → N round-trip: meanToHyperbolic then hyperbolicToMean must recover N.
-void fuzzHyperbolicMeanRoundTrip(float N, float e) {
-    const float H = OrbitalMotion::meanToHyperbolicAnomalyF32(N, e);
+// N -> H -> N round-trip: meanToHyperbolic then hyperbolicToMean must recover N.
+void fuzzHyperbolicMeanRoundTrip(double N, double e) {
+    const double H = OrbitalMotion::meanToHyperbolicAnomaly(N, e);
     ASSERT_TRUE(std::isfinite(H));
-    const float N_back = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e);
+    const double N_back = OrbitalMotion::hyperbolicToMeanAnomaly(H, e);
     ASSERT_TRUE(std::isfinite(N_back));
     EXPECT_NEAR(N_back, N, kAnomalyTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicMeanRoundTrip)
-    .WithDomains(fuzztest::InRange(-5.0f, 5.0f), fuzztest::InRange(1.01f, 10.0f));
+    .WithDomains(fuzztest::InRange(-5.0, 5.0), fuzztest::InRange(1.01, 10.0));
 
 // ============================================================================
 // Keplerian conserved quantities
 // ============================================================================
 
-// Vis-viva equation: v² = μ (2/r − 1/a)
-void fuzzVisViva(float e, float i, float Omega, float omega, float f) {
-    ClassicalElementsF32 el;
+// Vis-viva equation: v^2 = mu (2/r - 1/a)
+void fuzzVisViva(double e, double i, double Omega, double omega, double f) {
+    ClassicalElements el;
     el.semiMajorAxis = kSemiMajorAxis;
     el.eccentricity = e;
     el.inclination = i;
@@ -149,7 +145,7 @@ void fuzzVisViva(float e, float i, float Omega, float omega, float f) {
     el.argPeriapsis = omega;
     el.trueAnomaly = f;
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMu, el);
     const double r = state.position.norm();
     const double v2 = state.velocity.squaredNorm();
     ASSERT_TRUE(std::isfinite(r));
@@ -158,15 +154,15 @@ void fuzzVisViva(float e, float i, float Omega, float omega, float f) {
     EXPECT_NEAR(v2, v2_expected, v2_expected * kStateRelTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzVisViva)
-    .WithDomains(fuzztest::InRange(0.0f, 0.9f),
-                 fuzztest::InRange(0.0f, static_cast<float>(M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+    .WithDomains(fuzztest::InRange(0.0, 0.9),
+                 fuzztest::InRange(0.0, M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI));
 
-// Specific orbital energy: v²/2 − μ/r = −μ/(2a)
-void fuzzSpecificEnergy(float e, float i, float Omega, float omega, float f) {
-    ClassicalElementsF32 el;
+// Specific orbital energy: v^2/2 - mu/r = -mu/(2a)
+void fuzzSpecificEnergy(double e, double i, double Omega, double omega, double f) {
+    ClassicalElements el;
     el.semiMajorAxis = kSemiMajorAxis;
     el.eccentricity = e;
     el.inclination = i;
@@ -174,7 +170,7 @@ void fuzzSpecificEnergy(float e, float i, float Omega, float omega, float f) {
     el.argPeriapsis = omega;
     el.trueAnomaly = f;
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMu, el);
     const double r = state.position.norm();
     const double energy = state.velocity.squaredNorm() / 2.0 - kMu / r;
     const double energy_expected = -kMu / (2.0 * kSemiMajorAxis);
@@ -182,15 +178,15 @@ void fuzzSpecificEnergy(float e, float i, float Omega, float omega, float f) {
     EXPECT_NEAR(energy, energy_expected, std::abs(energy_expected) * kStateRelTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzSpecificEnergy)
-    .WithDomains(fuzztest::InRange(0.0f, 0.9f),
-                 fuzztest::InRange(0.0f, static_cast<float>(M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+    .WithDomains(fuzztest::InRange(0.0, 0.9),
+                 fuzztest::InRange(0.0, M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI));
 
-// Angular momentum magnitude: |r × v| = √(μ · a · (1 − e²))
-void fuzzAngularMomentum(float e, float i, float Omega, float omega, float f) {
-    ClassicalElementsF32 el;
+// Angular momentum magnitude: |r x v| = sqrt(mu * a * (1 - e^2))
+void fuzzAngularMomentum(double e, double i, double Omega, double omega, double f) {
+    ClassicalElements el;
     el.semiMajorAxis = kSemiMajorAxis;
     el.eccentricity = e;
     el.inclination = i;
@@ -198,22 +194,22 @@ void fuzzAngularMomentum(float e, float i, float Omega, float omega, float f) {
     el.argPeriapsis = omega;
     el.trueAnomaly = f;
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMu, el);
     const double h = state.position.cross(state.velocity).norm();
-    const double h_expected = std::sqrt(kMu * kSemiMajorAxis * (1.0 - static_cast<double>(e) * e));
+    const double h_expected = std::sqrt(kMu * kSemiMajorAxis * (1.0 - e * e));
     ASSERT_TRUE(std::isfinite(h));
     EXPECT_NEAR(h, h_expected, h_expected * kStateRelTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzAngularMomentum)
-    .WithDomains(fuzztest::InRange(0.0f, 0.9f),
-                 fuzztest::InRange(0.0f, static_cast<float>(M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+    .WithDomains(fuzztest::InRange(0.0, 0.9),
+                 fuzztest::InRange(0.0, M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI));
 
-// Orbit equation: r = p / (1 + e·cos f)  where p = a(1 − e²).
-void fuzzOrbitEquation(float e, float i, float Omega, float omega, float f) {
-    ClassicalElementsF32 el;
+// Orbit equation: r = p / (1 + e*cos f)  where p = a(1 - e^2).
+void fuzzOrbitEquation(double e, double i, double Omega, double omega, double f) {
+    ClassicalElements el;
     el.semiMajorAxis = kSemiMajorAxis;
     el.eccentricity = e;
     el.inclination = i;
@@ -221,28 +217,28 @@ void fuzzOrbitEquation(float e, float i, float Omega, float omega, float f) {
     el.argPeriapsis = omega;
     el.trueAnomaly = f;
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMu, el);
     const double r = state.position.norm();
-    const double p = kSemiMajorAxis * (1.0 - static_cast<double>(e) * e);
-    const double r_expected = p / (1.0 + e * cosf(f));
+    const double p = kSemiMajorAxis * (1.0 - e * e);
+    const double r_expected = p / (1.0 + e * cos(f));
     ASSERT_TRUE(std::isfinite(r));
     EXPECT_NEAR(r, r_expected, r_expected * kStateRelTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzOrbitEquation)
-    .WithDomains(fuzztest::InRange(0.0f, 0.9f),
-                 fuzztest::InRange(0.0f, static_cast<float>(M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+    .WithDomains(fuzztest::InRange(0.0, 0.9),
+                 fuzztest::InRange(0.0, M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI));
 
 // ============================================================================
-// Elements ↔ Cartesian round-trip
+// Elements <-> Cartesian round-trip
 // ============================================================================
 
-// elementsToCartesian → cartesianToElements must recover semi-major axis,
-// eccentricity, and inclination to within float precision.
-void fuzzElementsRoundTrip(float e, float i, float Omega, float omega, float f) {
-    ClassicalElementsF32 in;
+// elementsToCartesian -> cartesianToElements must recover semi-major axis,
+// eccentricity, and inclination to within double precision.
+void fuzzElementsRoundTrip(double e, double i, double Omega, double omega, double f) {
+    ClassicalElements in;
     in.semiMajorAxis = kSemiMajorAxis;
     in.eccentricity = e;
     in.inclination = i;
@@ -250,27 +246,27 @@ void fuzzElementsRoundTrip(float e, float i, float Omega, float omega, float f) 
     in.argPeriapsis = omega;
     in.trueAnomaly = f;
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, in);
-    const ClassicalElementsF32 out = OrbitalMotion::cartesianStateToElementsF32(kMu, state.position, state.velocity);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMu, in);
+    const ClassicalElements out = OrbitalMotion::cartesianStateToElements(kMu, state.position, state.velocity);
 
     EXPECT_NEAR(out.semiMajorAxis, in.semiMajorAxis, in.semiMajorAxis * kStateRelTol);
     EXPECT_NEAR(out.eccentricity, in.eccentricity, kStateRelTol);
     EXPECT_NEAR(out.inclination, in.inclination, kStateRelTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzElementsRoundTrip)
-    .WithDomains(fuzztest::InRange(0.01f, 0.9f),
-                 fuzztest::InRange(0.05f, static_cast<float>(M_PI) - 0.05f),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+    .WithDomains(fuzztest::InRange(0.01, 0.9),
+                 fuzztest::InRange(0.05, M_PI - 0.05),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI));
 
 // ============================================================================
 // Near-circular and equatorial round-trip singularity tests
 // ============================================================================
 
-// e ≈ 0: argPeriapsis is undefined, but a, e, i should round-trip.
-void fuzzNearCircularRoundTrip(float e, float i, float Omega, float omega, float f) {
-    ClassicalElementsF32 in;
+// e ~ 0: argPeriapsis is undefined, but a, e, i should round-trip.
+void fuzzNearCircularRoundTrip(double e, double i, double Omega, double omega, double f) {
+    ClassicalElements in;
     in.semiMajorAxis = kSemiMajorAxis;
     in.eccentricity = e;
     in.inclination = i;
@@ -278,23 +274,23 @@ void fuzzNearCircularRoundTrip(float e, float i, float Omega, float omega, float
     in.argPeriapsis = omega;
     in.trueAnomaly = f;
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, in);
-    const ClassicalElementsF32 out = OrbitalMotion::cartesianStateToElementsF32(kMu, state.position, state.velocity);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMu, in);
+    const ClassicalElements out = OrbitalMotion::cartesianStateToElements(kMu, state.position, state.velocity);
 
     EXPECT_NEAR(out.semiMajorAxis, in.semiMajorAxis, in.semiMajorAxis * kStateRelTol);
     EXPECT_NEAR(out.eccentricity, in.eccentricity, kStateRelTol);
     EXPECT_NEAR(out.inclination, in.inclination, kStateRelTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzNearCircularRoundTrip)
-    .WithDomains(fuzztest::InRange(0.0f, 0.001f),
-                 fuzztest::InRange(0.05f, static_cast<float>(M_PI) - 0.05f),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+    .WithDomains(fuzztest::InRange(0.0, 0.001),
+                 fuzztest::InRange(0.05, M_PI - 0.05),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI));
 
-// i ≈ 0: RAAN is undefined, but a, e, i should round-trip.
-void fuzzEquatorialRoundTrip(float e, float i, float Omega, float omega, float f) {
-    ClassicalElementsF32 in;
+// i ~ 0: RAAN is undefined, but a, e, i should round-trip.
+void fuzzEquatorialRoundTrip(double e, double i, double Omega, double omega, double f) {
+    ClassicalElements in;
     in.semiMajorAxis = kSemiMajorAxis;
     in.eccentricity = e;
     in.inclination = i;
@@ -302,97 +298,96 @@ void fuzzEquatorialRoundTrip(float e, float i, float Omega, float omega, float f
     in.argPeriapsis = omega;
     in.trueAnomaly = f;
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, in);
-    const ClassicalElementsF32 out = OrbitalMotion::cartesianStateToElementsF32(kMu, state.position, state.velocity);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMu, in);
+    const ClassicalElements out = OrbitalMotion::cartesianStateToElements(kMu, state.position, state.velocity);
 
     EXPECT_NEAR(out.semiMajorAxis, in.semiMajorAxis, in.semiMajorAxis * kStateRelTol);
     EXPECT_NEAR(out.eccentricity, in.eccentricity, kStateRelTol);
     EXPECT_NEAR(out.inclination, in.inclination, kStateRelTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzEquatorialRoundTrip)
-    .WithDomains(fuzztest::InRange(0.05f, 0.5f),
-                 fuzztest::InRange(0.0f, 0.001f),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)),
-                 fuzztest::InRange(0.0f, static_cast<float>(2 * M_PI)));
+    .WithDomains(fuzztest::InRange(0.05, 0.5),
+                 fuzztest::InRange(0.0, 0.001),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI));
 
 // ============================================================================
 // All-anomaly finiteness
 // ============================================================================
 
 // Every anomaly conversion function must return finite for valid inputs.
-void fuzzAllAnomalyConversionsFinite(float e, float angle) {
-    if (e < 1.0f) {
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToTrueAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToEccentricAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToMeanAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToMeanAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::meanToEccentricAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::meanToTrueAnomalyF32(angle, e)));
+void fuzzAllAnomalyConversionsFinite(double e, double angle) {
+    if (e < 1.0) {
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToTrueAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToEccentricAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToMeanAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToMeanAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::meanToEccentricAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::meanToTrueAnomaly(angle, e)));
     } else {
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToTrueAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToMeanAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::meanToHyperbolicAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToHyperbolicAnomalyF32(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToTrueAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToMeanAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::meanToHyperbolicAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToHyperbolicAnomaly(angle, e)));
     }
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzAllAnomalyConversionsFinite)
-    .WithDomains(fuzztest::InRange(0.0f, 0.9999f),
-                 fuzztest::InRange(static_cast<float>(-M_PI), static_cast<float>(M_PI)));
+    .WithDomains(fuzztest::InRange(0.0, 0.9999), fuzztest::InRange(-M_PI, M_PI));
 
 // ============================================================================
 // Near-parabolic and near-rectilinear degenerate cases
 // ============================================================================
 
-// Closed-form anomaly functions must return finite values for e → 1⁻.
-void fuzzNearParabolicEllipticAnomalyFinite(float f, float e) {
-    const float E = OrbitalMotion::trueToEccentricAnomalyF32(f, e);
-    const float fb = OrbitalMotion::eccentricToTrueAnomalyF32(E, e);
-    const float M = OrbitalMotion::eccentricToMeanAnomalyF32(E, e);
-    const float M2 = OrbitalMotion::trueToMeanAnomalyF32(f, e);
+// Closed-form anomaly functions must return finite values for e -> 1-.
+void fuzzNearParabolicEllipticAnomalyFinite(double f, double e) {
+    const double E = OrbitalMotion::trueToEccentricAnomaly(f, e);
+    const double fb = OrbitalMotion::eccentricToTrueAnomaly(E, e);
+    const double M = OrbitalMotion::eccentricToMeanAnomaly(E, e);
+    const double M2 = OrbitalMotion::trueToMeanAnomaly(f, e);
     EXPECT_TRUE(std::isfinite(E)) << "trueToEccentric";
     EXPECT_TRUE(std::isfinite(fb)) << "eccentricToTrue";
     EXPECT_TRUE(std::isfinite(M)) << "eccentricToMean";
     EXPECT_TRUE(std::isfinite(M2)) << "trueToMean";
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicEllipticAnomalyFinite)
-    .WithDomains(fuzztest::InRange(-0.8f, 0.8f), fuzztest::InRange(0.9f, 0.9999f));
+    .WithDomains(fuzztest::InRange(-0.8, 0.8), fuzztest::InRange(0.9, 0.9999));
 
-// elementsToCartesianStateF32 must return a finite Cartesian state for e → 1⁻.
-void fuzzNearParabolicCartesianFinite(float e, float f) {
-    ClassicalElementsF32 el;
+// elementsToCartesianState must return a finite Cartesian state for e -> 1-.
+void fuzzNearParabolicCartesianFinite(double e, double f) {
+    ClassicalElements el;
     el.semiMajorAxis = 7.0e6 / (1.0 - e);
     el.eccentricity = e;
-    el.inclination = 0.3f;
-    el.rightAscensionAscendingNode = 0.0f;
-    el.argPeriapsis = 0.0f;
+    el.inclination = 0.3;
+    el.rightAscensionAscendingNode = 0.0;
+    el.argPeriapsis = 0.0;
     el.trueAnomaly = f;
 
-    const CartesianState state = OrbitalMotion::elementsToCartesianStateF32(kMu, el);
+    const CartesianState state = OrbitalMotion::elementsToCartesianState(kMu, el);
     for (int i = 0; i < 3; ++i) {
         EXPECT_TRUE(std::isfinite(state.position[i])) << "position[" << i << ']';
         EXPECT_TRUE(std::isfinite(state.velocity[i])) << "velocity[" << i << ']';
     }
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicCartesianFinite)
-    .WithDomains(fuzztest::InRange(0.9f, 0.9999f), fuzztest::InRange(0.0f, 1.0f));
+    .WithDomains(fuzztest::InRange(0.9, 0.9999), fuzztest::InRange(0.0, 1.0));
 
 // Hyperbolic anomaly functions must stay finite for e just above 1.
-void fuzzNearParabolicHyperbolicAnomalyFinite(float H, float e) {
-    const float N = OrbitalMotion::hyperbolicToMeanAnomalyF32(H, e);
-    const float f = OrbitalMotion::hyperbolicToTrueAnomalyF32(H, e);
+void fuzzNearParabolicHyperbolicAnomalyFinite(double H, double e) {
+    const double N = OrbitalMotion::hyperbolicToMeanAnomaly(H, e);
+    const double f = OrbitalMotion::hyperbolicToTrueAnomaly(H, e);
     EXPECT_TRUE(std::isfinite(N)) << "hyperbolicToMean";
     EXPECT_TRUE(std::isfinite(f)) << "hyperbolicToTrue";
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicHyperbolicAnomalyFinite)
-    .WithDomains(fuzztest::InRange(-0.5f, 0.5f), fuzztest::InRange(1.0001f, 1.1f));
+    .WithDomains(fuzztest::InRange(-0.5, 0.5), fuzztest::InRange(1.0001, 1.1));
 
 // Rectilinear orbit: h=0 singularity. v_transverse = 0, all outputs must be finite.
 void fuzzRectilinearElementsFinite(double v_radial) {
     const Eigen::Vector3d r_vec(7.0e6, 0.0, 0.0);
     const Eigen::Vector3d v_vec(v_radial, 0.0, 0.0);
 
-    const ClassicalElementsF32 el = OrbitalMotion::cartesianStateToElementsF32(kMu, r_vec, v_vec);
+    const ClassicalElements el = OrbitalMotion::cartesianStateToElements(kMu, r_vec, v_vec);
 
     EXPECT_TRUE(std::isfinite(el.semiMajorAxis)) << "sma";
     EXPECT_TRUE(std::isfinite(el.eccentricity)) << "ecc";
@@ -408,7 +403,7 @@ void fuzzNearRectilinearElementsFinite(double v_radial, double v_transverse) {
     const Eigen::Vector3d r_vec(7.0e6, 0.0, 0.0);
     const Eigen::Vector3d v_vec(v_radial, 0.0, v_transverse);
 
-    const ClassicalElementsF32 el = OrbitalMotion::cartesianStateToElementsF32(kMu, r_vec, v_vec);
+    const ClassicalElements el = OrbitalMotion::cartesianStateToElements(kMu, r_vec, v_vec);
 
     EXPECT_TRUE(std::isfinite(el.semiMajorAxis)) << "sma";
     EXPECT_TRUE(std::isfinite(el.eccentricity)) << "ecc";
@@ -421,30 +416,30 @@ FUZZ_TEST(OrbitalMotionFuzz, fuzzNearRectilinearElementsFinite)
     .WithDomains(fuzztest::InRange(-8000.0, 8000.0), fuzztest::InRange(0.01, 100.0));
 
 // Parabolic boundary: e = 1.0 exactly. All closed-form anomaly functions finite.
-void fuzzParabolicAnomalyFinite(float angle) {
-    const float E = OrbitalMotion::trueToEccentricAnomalyF32(angle, 1.0f);
-    const float f = OrbitalMotion::eccentricToTrueAnomalyF32(angle, 1.0f);
-    const float M = OrbitalMotion::eccentricToMeanAnomalyF32(angle, 1.0f);
-    const float M2 = OrbitalMotion::trueToMeanAnomalyF32(angle, 1.0f);
+void fuzzParabolicAnomalyFinite(double angle) {
+    const double E = OrbitalMotion::trueToEccentricAnomaly(angle, 1.0);
+    const double f = OrbitalMotion::eccentricToTrueAnomaly(angle, 1.0);
+    const double M = OrbitalMotion::eccentricToMeanAnomaly(angle, 1.0);
+    const double M2 = OrbitalMotion::trueToMeanAnomaly(angle, 1.0);
     EXPECT_TRUE(std::isfinite(E)) << "trueToEccentric";
     EXPECT_TRUE(std::isfinite(f)) << "eccentricToTrue";
     EXPECT_TRUE(std::isfinite(M)) << "eccentricToMean";
     EXPECT_TRUE(std::isfinite(M2)) << "trueToMean";
 }
-FUZZ_TEST(OrbitalMotionFuzz, fuzzParabolicAnomalyFinite).WithDomains(fuzztest::InRange(-0.8f, 0.8f));
+FUZZ_TEST(OrbitalMotionFuzz, fuzzParabolicAnomalyFinite).WithDomains(fuzztest::InRange(-0.8, 0.8));
 
 // Straddles the elliptic/hyperbolic boundary: e in [0.999, 1.001].
-void fuzzParabolicHyperbolicBoundary(float e, float angle) {
-    if (e < 1.0f) {
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToEccentricAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToTrueAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToMeanAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToMeanAnomalyF32(angle, e)));
-    } else if (e > 1.0f) {
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToTrueAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToMeanAnomalyF32(angle, e)));
-        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToHyperbolicAnomalyF32(angle, e)));
+void fuzzParabolicHyperbolicBoundary(double e, double angle) {
+    if (e < 1.0) {
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToEccentricAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToTrueAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::eccentricToMeanAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToMeanAnomaly(angle, e)));
+    } else if (e > 1.0) {
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToTrueAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::hyperbolicToMeanAnomaly(angle, e)));
+        EXPECT_TRUE(std::isfinite(OrbitalMotion::trueToHyperbolicAnomaly(angle, e)));
     }
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzParabolicHyperbolicBoundary)
-    .WithDomains(fuzztest::InRange(0.999f, 1.001f), fuzztest::InRange(-0.8f, 0.8f));
+    .WithDomains(fuzztest::InRange(0.999, 1.001), fuzztest::InRange(-0.8, 0.8));

--- a/algorithms/utilities/orbitalMotion.cpp
+++ b/algorithms/utilities/orbitalMotion.cpp
@@ -24,8 +24,7 @@
 #include <numbers>
 
 inline constexpr int kMaxNumberOfIterations = 200;
-inline constexpr float kClamp = 7;
-inline constexpr float kToleranceF32 = 1e-6;
+inline constexpr double kClamp = 7;
 inline constexpr double kTolerance = 1e-9;
 
 /**
@@ -34,9 +33,9 @@ inline constexpr double kTolerance = 1e-9;
  * @param e Orbital eccentricity.
  * @return True anomaly in radians.
  */
-float OrbitalMotion::eccentricToTrueAnomalyF32(float const E, float const e) {
+double OrbitalMotion::eccentricToTrueAnomaly(double const E, double const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    return 2 * safeAtan2f(safeSqrtf(1 + e) * safeSinf(E / 2), safeSqrtf(1 - e) * safeCosf(E / 2));
+    return 2 * safeAtan2(safeSqrt(1 + e) * safeSin(E / 2), safeSqrt(1 - e) * safeCos(E / 2));
 }
 
 /**
@@ -45,9 +44,9 @@ float OrbitalMotion::eccentricToTrueAnomalyF32(float const E, float const e) {
  * @param e Orbital eccentricity.
  * @return Mean anomaly in radians.
  */
-float OrbitalMotion::eccentricToMeanAnomalyF32(float const E, float const e) {
+double OrbitalMotion::eccentricToMeanAnomaly(double const E, double const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    return E - (e * safeSinf(E));
+    return E - (e * safeSin(E));
 }
 
 /**
@@ -56,9 +55,9 @@ float OrbitalMotion::eccentricToMeanAnomalyF32(float const E, float const e) {
  * @param e Orbital eccentricity.
  * @return Eccentric anomaly in radians.
  */
-float OrbitalMotion::trueToEccentricAnomalyF32(float const f, float const e) {
+double OrbitalMotion::trueToEccentricAnomaly(double const f, double const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    return 2 * safeAtan2f(safeSqrtf(1 - e) * safeSinf(f / 2), safeSqrtf(1 + e) * safeCosf(f / 2));
+    return 2 * safeAtan2(safeSqrt(1 - e) * safeSin(f / 2), safeSqrt(1 + e) * safeCos(f / 2));
 }
 
 /**
@@ -67,10 +66,10 @@ float OrbitalMotion::trueToEccentricAnomalyF32(float const f, float const e) {
  * @param e Orbital eccentricity (0 <= e < 1).
  * @return Mean anomaly in radians.
  */
-float OrbitalMotion::trueToMeanAnomalyF32(float const f, float const e) {
+double OrbitalMotion::trueToMeanAnomaly(double const f, double const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    float const eccentric = trueToEccentricAnomalyF32(f, e);
-    return eccentricToMeanAnomalyF32(eccentric, e);
+    double const eccentric = trueToEccentricAnomaly(f, e);
+    return eccentricToMeanAnomaly(eccentric, e);
 }
 
 /**
@@ -79,9 +78,9 @@ float OrbitalMotion::trueToMeanAnomalyF32(float const f, float const e) {
  * @param e Orbital eccentricity (> 1).
  * @return Hyperbolic anomaly in radians.
  */
-float OrbitalMotion::trueToHyperbolicAnomalyF32(float const f, float const e) {
+double OrbitalMotion::trueToHyperbolicAnomaly(double const f, double const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
-    return 2 * safeAtanHf(safeSqrtf((e - 1) / (e + 1)) * safeTanf(f / 2));
+    return 2 * safeAtanH(safeSqrt((e - 1) / (e + 1)) * safeTan(f / 2));
 }
 
 /**
@@ -90,9 +89,9 @@ float OrbitalMotion::trueToHyperbolicAnomalyF32(float const f, float const e) {
  * @param e Orbital eccentricity (> 1).
  * @return True anomaly in radians.
  */
-float OrbitalMotion::hyperbolicToTrueAnomalyF32(float const H, float const e) {
+double OrbitalMotion::hyperbolicToTrueAnomaly(double const H, double const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
-    return 2 * safeAtanf(safeSqrtf((e + 1) / (e - 1)) * safeTanHf(H / 2));
+    return 2 * safeAtan(safeSqrt((e + 1) / (e - 1)) * safeTanH(H / 2));
 }
 
 /**
@@ -101,9 +100,9 @@ float OrbitalMotion::hyperbolicToTrueAnomalyF32(float const H, float const e) {
  * @param e Orbital eccentricity (> 1).
  * @return Mean hyperbolic anomaly in radians.
  */
-float OrbitalMotion::hyperbolicToMeanAnomalyF32(float const H, float const e) {
+double OrbitalMotion::hyperbolicToMeanAnomaly(double const H, double const e) {
     assert(e > 1.0 && "Eccentricity must be > 1 for hyperbolic orbits");
-    return (e * safeSinHf(H)) - H;
+    return (e * safeSinH(H)) - H;
 }
 
 /**
@@ -112,13 +111,13 @@ float OrbitalMotion::hyperbolicToMeanAnomalyF32(float const H, float const e) {
  * @param e Orbital eccentricity (0 <= e < 1).
  * @return Eccentric anomaly in radians.
  */
-float OrbitalMotion::meanToEccentricAnomalyF32(float M, float e) {
+double OrbitalMotion::meanToEccentricAnomaly(double M, double e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    float E = M;
+    double E = M;
     for (int i = 0; i < kMaxNumberOfIterations; ++i) {
-        float const dE = (E - e * safeSinf(E) - M) / (1 - e * safeCosf(E));
-        E -= fmaxf(-0.5F, fminf(0.5F, dE));  // Clamp step size in case of near parabolic orbits
-        if (fabsf(dE) < kToleranceF32) {
+        double const dE = (E - e * safeSin(E) - M) / (1 - e * safeCos(E));
+        E -= fmax(-0.5, fmin(0.5, dE));  // Clamp step size in case of near parabolic orbits
+        if (fabs(dE) < kTolerance) {
             break;
         }
     }
@@ -131,10 +130,10 @@ float OrbitalMotion::meanToEccentricAnomalyF32(float M, float e) {
  * @param e Orbital eccentricity (0 <= e < 1).
  * @return True anomaly in radians.
  */
-float OrbitalMotion::meanToTrueAnomalyF32(float const M, float const e) {
+double OrbitalMotion::meanToTrueAnomaly(double const M, double const e) {
     assert((e >= 0.0 || e < 1.0) && "Eccentricity out of bounds (0 <= e < 1)");
-    float const eccentric = meanToEccentricAnomalyF32(M, e);
-    return eccentricToTrueAnomalyF32(eccentric, e);
+    double const eccentric = meanToEccentricAnomaly(M, e);
+    return eccentricToTrueAnomaly(eccentric, e);
 }
 
 /**
@@ -143,14 +142,14 @@ float OrbitalMotion::meanToTrueAnomalyF32(float const M, float const e) {
  * @param e Orbital eccentricity (> 1).
  * @return Hyperbolic anomaly in radians.
  */
-float OrbitalMotion::meanToHyperbolicAnomalyF32(const float N, const float e) {
+double OrbitalMotion::meanToHyperbolicAnomaly(const double N, const double e) {
     assert(e > 1.0 && "Eccentricity must be > 1");
     const int signN = (N > 0 ? 1 : -1);
-    float H = fabsf(N) > kClamp ? kClamp * static_cast<float>(signN) : N;
+    double H = fabs(N) > kClamp ? kClamp * static_cast<double>(signN) : N;
     for (int i = 0; i < kMaxNumberOfIterations; ++i) {
-        const float dH = (e * safeSinHf(H) - H - N) / (e * safeCosHf(H) - 1);
+        const double dH = (e * safeSinH(H) - H - N) / (e * safeCosH(H) - 1);
         H -= dH;
-        if (fabsf(dH) < kToleranceF32) {
+        if (fabs(dH) < kTolerance) {
             break;
         }
     }
@@ -163,29 +162,29 @@ float OrbitalMotion::meanToHyperbolicAnomalyF32(const float N, const float e) {
  * @param elements Classical orbital elements (a, e, i, Omega, omega, f).
  * @param CartesianState Output: position and velocity vectors in km and km/s.
  */
-CartesianState OrbitalMotion::elementsToCartesianStateF32(double const mu, const ClassicalElementsF32& elements) {
+CartesianState OrbitalMotion::elementsToCartesianState(double const mu, const ClassicalElements& elements) {
     double const a = elements.semiMajorAxis;
-    float const e = elements.eccentricity;
-    float const i = elements.inclination;
-    float const Omega = elements.rightAscensionAscendingNode;
-    float const omega = elements.argPeriapsis;
-    float const f = elements.trueAnomaly;
+    double const e = elements.eccentricity;
+    double const i = elements.inclination;
+    double const Omega = elements.rightAscensionAscendingNode;
+    double const omega = elements.argPeriapsis;
+    double const f = elements.trueAnomaly;
 
     double const p = a * (1 - e * e);
-    double const r = p / (1 + e * safeCosf(f));
+    double const r = p / (1 + e * safeCos(f));
     double const h = safeSqrt(mu * p);
 
-    float const cos_O = safeCosf(Omega);
-    float const sin_O = safeSinf(Omega);
-    float const cos_o = safeCosf(omega);
-    float const sin_o = safeSinf(omega);
-    float const cos_i = safeCosf(i);
-    float const sin_i = safeSinf(i);
-    float const cos_f = safeCosf(f);
-    float const sin_f = safeSinf(f);
+    double const cos_O = safeCos(Omega);
+    double const sin_O = safeSin(Omega);
+    double const cos_o = safeCos(omega);
+    double const sin_o = safeSin(omega);
+    double const cos_i = safeCos(i);
+    double const sin_i = safeSin(i);
+    double const cos_f = safeCos(f);
+    double const sin_f = safeSin(f);
 
-    float const cos_theta = (cos_o * cos_f) - (sin_o * sin_f);
-    float const sin_theta = (sin_o * cos_f) + (cos_o * sin_f);
+    double const cos_theta = (cos_o * cos_f) - (sin_o * sin_f);
+    double const sin_theta = (sin_o * cos_f) + (cos_o * sin_f);
 
     Eigen::Vector3d rVec{};
     rVec(0) = r * (cos_O * cos_theta - sin_O * sin_theta * cos_i);
@@ -212,9 +211,9 @@ CartesianState OrbitalMotion::elementsToCartesianStateF32(double const mu, const
  * @param vVec Velocity vector in km/s.
  * @return elements : classical orbital elements (a, e, i, Omega, omega, f).
  */
-ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
-                                                                const Eigen::Vector3d& rVec,
-                                                                const Eigen::Vector3d& vVec) {
+ClassicalElements OrbitalMotion::cartesianStateToElements(const double mu,
+                                                          const Eigen::Vector3d& rVec,
+                                                          const Eigen::Vector3d& vVec) {
     const double r = rVec.norm();
     const double v = vVec.norm();
     const Eigen::Vector3d hVec = rVec.cross(vVec);
@@ -222,30 +221,30 @@ ClassicalElementsF32 OrbitalMotion::cartesianStateToElementsF32(const double mu,
     const Eigen::Vector3d nVec = Eigen::Vector3d::UnitZ().cross(hVec);
     const Eigen::Vector3d eVec = (((v * v) - (mu / r)) * rVec - (rVec.dot(vVec)) * vVec) / mu;
 
-    ClassicalElementsF32 elements{};
+    ClassicalElements elements{};
 
     elements.radiusMagnitude = r;
-    elements.eccentricity = static_cast<float>(eVec.norm());
+    elements.eccentricity = eVec.norm();
     if (h < kTolerance) {
-        elements.inclination = 0.0F;  // rectilinear orbit
+        elements.inclination = 0.0;  // rectilinear orbit
     } else {
-        elements.inclination = static_cast<float>(std::acos(hVec(2) / h));
+        elements.inclination = std::acos(hVec(2) / h);
     }
     elements.alpha = (2 / r) - (v * v / mu);
     elements.semiMajorAxis = fabs(elements.alpha) > kTolerance ? 1 / elements.alpha : 0.0;
 
-    auto Omega = static_cast<float>(safeAtan2(nVec(1), nVec(0)));
-    elements.rightAscensionAscendingNode = Omega < 0 ? static_cast<float>(Omega + (2 * std::numbers::pi)) : Omega;
+    const double Omega = safeAtan2(nVec(1), nVec(0));
+    elements.rightAscensionAscendingNode = Omega < 0 ? Omega + (2 * std::numbers::pi) : Omega;
 
-    auto omega = static_cast<float>(safeAtan2(nVec.cross(eVec).dot(hVec.normalized()), nVec.dot(eVec)));
-    elements.argPeriapsis = omega < 0 ? static_cast<float>(omega + (2 * std::numbers::pi)) : omega;
+    const double omega = safeAtan2(nVec.cross(eVec).dot(hVec.normalized()), nVec.dot(eVec));
+    elements.argPeriapsis = omega < 0 ? omega + (2 * std::numbers::pi) : omega;
 
-    auto f = static_cast<float>(safeAtan2(eVec.cross(rVec).dot(hVec.normalized()), eVec.dot(rVec)));
-    elements.trueAnomaly = f < 0 ? static_cast<float>(f + (2 * std::numbers::pi)) : f;
+    const double f = safeAtan2(eVec.cross(rVec).dot(hVec.normalized()), eVec.dot(rVec));
+    elements.trueAnomaly = f < 0 ? f + (2 * std::numbers::pi) : f;
 
     elements.radiusPeriapsis = h * h / mu / (1 + elements.eccentricity);
-    if (fabsf(elements.eccentricity - 1) < kTolerance) {
-        elements.radiusApoapsis = 0.0F;  // parabolic orbit
+    if (fabs(elements.eccentricity - 1) < kTolerance) {
+        elements.radiusApoapsis = 0.0;  // parabolic orbit
     } else {
         elements.radiusApoapsis = h * h / mu / (1 - elements.eccentricity);
     }

--- a/algorithms/utilities/orbitalMotion.hpp
+++ b/algorithms/utilities/orbitalMotion.hpp
@@ -17,8 +17,8 @@
 
  */
 
-#ifndef ORBITAL_MOTION_FP32_HPP
-#define ORBITAL_MOTION_FP32_HPP
+#ifndef ORBITAL_MOTION_HPP
+#define ORBITAL_MOTION_HPP
 
 #include <Eigen/Core>
 
@@ -27,14 +27,14 @@ struct CartesianState {
     Eigen::Vector3d velocity;
 };
 
-class ClassicalElementsF32 {
+class ClassicalElements {
    public:
     double semiMajorAxis = 0;
-    float eccentricity = 0;
-    float inclination = 0;
-    float rightAscensionAscendingNode = 0;
-    float argPeriapsis = 0;
-    float trueAnomaly = 0;
+    double eccentricity = 0;
+    double inclination = 0;
+    double rightAscensionAscendingNode = 0;
+    double argPeriapsis = 0;
+    double trueAnomaly = 0;
     double radiusMagnitude = 0;
     double alpha = 0;
     double radiusPeriapsis = 0;
@@ -43,20 +43,20 @@ class ClassicalElementsF32 {
 
 class OrbitalMotion {
    public:
-    static float eccentricToTrueAnomalyF32(float E, float e);
-    static float eccentricToMeanAnomalyF32(float E, float e);
-    static float trueToEccentricAnomalyF32(float f, float e);
-    static float trueToHyperbolicAnomalyF32(float f, float e);
-    static float trueToMeanAnomalyF32(float f, float e);
-    static float hyperbolicToTrueAnomalyF32(float H, float e);
-    static float hyperbolicToMeanAnomalyF32(float H, float e);
-    static float meanToEccentricAnomalyF32(float M, float e);
-    static float meanToTrueAnomalyF32(float M, float e);
-    static float meanToHyperbolicAnomalyF32(float N, float e);
-    static CartesianState elementsToCartesianStateF32(double mu, const ClassicalElementsF32& elements);
-    static ClassicalElementsF32 cartesianStateToElementsF32(double mu,
-                                                            const Eigen::Vector3d& rVec,
-                                                            const Eigen::Vector3d& vVec);
+    static double eccentricToTrueAnomaly(double E, double e);
+    static double eccentricToMeanAnomaly(double E, double e);
+    static double trueToEccentricAnomaly(double f, double e);
+    static double trueToHyperbolicAnomaly(double f, double e);
+    static double trueToMeanAnomaly(double f, double e);
+    static double hyperbolicToTrueAnomaly(double H, double e);
+    static double hyperbolicToMeanAnomaly(double H, double e);
+    static double meanToEccentricAnomaly(double M, double e);
+    static double meanToTrueAnomaly(double M, double e);
+    static double meanToHyperbolicAnomaly(double N, double e);
+    static CartesianState elementsToCartesianState(double mu, const ClassicalElements& elements);
+    static ClassicalElements cartesianStateToElements(double mu,
+                                                      const Eigen::Vector3d& rVec,
+                                                      const Eigen::Vector3d& vVec);
 };
 
 #endif


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2119
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
Clenshaw and all other attempts failed, so I tried moving the cheby fit to doubles. Everything works of course

## Verification
Tests pass

## Documentation
None

## Future work
None
