### PR TITLE
Limit ctest to fp32-fsw-xmera build products

### DIFF
--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -165,14 +165,14 @@ jobs:
         run: cmake --build ../build --parallel
 
       - name: Run fuzz smoke tests (CTest)
-        working-directory: xmera/build
+        working-directory: xmera/build/fp32-fsw-xmera/algorithms
         env:
           XMERA_FUZZTEST_REPLAY_CORPUS: __ALL__
           XMERA_FUZZTEST_REPLAY_FOR: inf
         run: ctest --output-on-failure -L fuzz
 
       - name: Run extended fuzz sessions
-        working-directory: xmera/build
+        working-directory: xmera/build/fp32-fsw-xmera/algorithms
         env:
           ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1:check_initialization_order=1
           UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:suppressions=/dev/null

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -285,7 +285,7 @@ jobs:
           python -m pip install -e .
 
       - name: Run CTest (C/C++ tests)
-        working-directory: xmera/build
+        working-directory: xmera/build/fp32-fsw-xmera/algorithms
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/junit"
           ctest --output-on-failure --output-junit "${GITHUB_WORKSPACE}/junit/ctest-${{ matrix.os }}.xml"


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Ctests were being run from the `build` directory and as a result, were running all of Xmera and fp32 tests. We only need to run fp32 tests. This PR change the run directory to `build/fp32-fsw-xmera`.

## Verification
The output of this PR's CI should show only fp32 Ctests are run.

## Documentation
NA

## Future work
None
