### PR TITLE
Provide each fuzz test with a separate corpus directory

### DIFF
--- a/.github/scripts/run_long_fuzzers.sh
+++ b/.github/scripts/run_long_fuzzers.sh
@@ -68,26 +68,40 @@ CRASH_COUNT=0
 while IFS= read -r fuzz_bin; do
   [[ -z "$fuzz_bin" ]] && continue
   fuzz_name="$(basename "$fuzz_bin")"
-  echo ">>> Running long fuzz session for ${fuzz_name}"
-  cmd=("$fuzz_bin")
-  if [[ -n "$FUZZ_DURATION" ]]; then
-    cmd+=("--fuzz_for=${FUZZ_DURATION}")
+
+  # Enumerate FUZZ_TESTs inside this binary. --list_fuzz_tests prints one line
+  # per test in the form "[*] Fuzz test: <Suite.Name>" and exits.
+  mapfile -t fuzz_tests < <("$fuzz_bin" --list_fuzz_tests 2>/dev/null \
+    | sed -n 's/^\[\*\] Fuzz test: //p')
+
+  if [[ ${#fuzz_tests[@]} -eq 0 ]]; then
+    echo "WARNING: No FUZZ_TESTs discovered in ${fuzz_name}; skipping." >&2
+    continue
   fi
-  env_vars=()
-  if [[ -n "$CORPUS_DIR" ]]; then
-    fuzz_corpus_dir="${CORPUS_DIR}/${fuzz_name}"
-    mkdir -p "$fuzz_corpus_dir"
-    env_vars+=(
-      "FUZZTEST_TESTSUITE_OUT_DIR=${fuzz_corpus_dir}"
-      "FUZZTEST_TESTSUITE_IN_DIR=${fuzz_corpus_dir}"
-    )
-  fi
-  if env "${env_vars[@]}" "${cmd[@]}" 2>&1 | tee "$LOG_DIR/${fuzz_name}.log"; then
-    echo ">>> ${fuzz_name}: OK"
-  else
-    echo ">>> ${fuzz_name}: FAILED (exit $?)"
-    CRASH_COUNT=$((CRASH_COUNT + 1))
-  fi
+
+  for test_name in "${fuzz_tests[@]}"; do
+    echo ">>> Running long fuzz session for ${fuzz_name} :: ${test_name}"
+    cmd=("$fuzz_bin" "--fuzz=${test_name}")
+    if [[ -n "$FUZZ_DURATION" ]]; then
+      cmd+=("--fuzz_for=${FUZZ_DURATION}")
+    fi
+    env_vars=()
+    if [[ -n "$CORPUS_DIR" ]]; then
+      fuzz_corpus_dir="${CORPUS_DIR}/${fuzz_name}/${test_name}"
+      mkdir -p "$fuzz_corpus_dir"
+      env_vars+=(
+        "FUZZTEST_TESTSUITE_OUT_DIR=${fuzz_corpus_dir}"
+        "FUZZTEST_TESTSUITE_IN_DIR=${fuzz_corpus_dir}"
+      )
+    fi
+    log_file="${LOG_DIR}/${fuzz_name}.${test_name}.log"
+    if env "${env_vars[@]}" "${cmd[@]}" 2>&1 | tee "$log_file"; then
+      echo ">>> ${fuzz_name} :: ${test_name}: OK"
+    else
+      echo ">>> ${fuzz_name} :: ${test_name}: FAILED (exit $?)"
+      CRASH_COUNT=$((CRASH_COUNT + 1))
+    fi
+  done
 done <<< "$FUZZ_BINS"
 
 if [[ $CRASH_COUNT -gt 0 ]]; then

--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -190,17 +190,22 @@ jobs:
           {
             echo "## Daily Fuzz Report — $(date -u +%Y-%m-%d)"
             echo ""
-            echo "| Target | Corpus Files | Status |"
-            echo "|--------|-------------|--------|"
+            echo "| Binary | Fuzz Test | Corpus Files | Status |"
+            echo "|--------|-----------|--------------|--------|"
 
             for log in fuzz-logs/*.log; do
               [[ -f "$log" ]] || continue
               name="$(basename "$log" .log)"
 
-              # Count corpus files for this target
+              # Log names are "<binary>.<Suite.TestName>"; split on the first dot.
+              binary="${name%%.*}"
+              test_name="${name#*.}"
+
+              # Count corpus files for this specific test
               corpus_count=0
-              if [[ -d ".fuzztest_corpus" ]]; then
-                corpus_count=$(find ".fuzztest_corpus" -type f -path "*${name}*" 2>/dev/null | wc -l || echo 0)
+              corpus_path=".fuzztest_corpus/${binary}/${test_name}"
+              if [[ -d "$corpus_path" ]]; then
+                corpus_count=$(find "$corpus_path" -type f 2>/dev/null | wc -l || echo 0)
               fi
 
               # Check for crash indicators in log
@@ -210,7 +215,7 @@ jobs:
                 status="OK"
               fi
 
-              echo "| ${name} | ${corpus_count} | ${status} |"
+              echo "| ${binary} | ${test_name} | ${corpus_count} | ${status} |"
             done
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
FuzzTest's `TESTSUITE_IN_DIR` and `TESTSUITE_OUT_DIR` env vars are per-fuzz-test, not per-binary. When multiple fuzz tests in the same binary share a single directory, every test's corpus writes are made together, and on the next run the currently-selected fuzz test rejects the other tests' files because they don't match its domain.

This PR ensures that:
  - Each test gets its own corpus directory `${CORPUS_DIR}/${fuzz_name}/${test_name}/`                                                                                                                                                                  
  - Each test invocation uses `--fuzz="${test_name}"` `--fuzz_for="${FUZZ_DURATION}"` (full time budget per test)
  - Per-test log files `fuzz-logs/${fuzz_name}.${test_name}.log`
  - Crash count accumulates per test, so one crash doesn't mask its siblings.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't
add or update any tests justify this choice. -->

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and
completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
