### PR TITLE
Add delta quaternion to platform to body converter

### DIFF
--- a/algorithms/convertStPlatformToBody/CMakeLists.txt
+++ b/algorithms/convertStPlatformToBody/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources("${module}" PRIVATE
   convertStPlatformToBodyAlgorithm.cpp
 )
 
-target_include_directories("${module}" PUBLIC "..")
+target_include_directories("${module}" PUBLIC ".." "../..")
 
 target_link_libraries("${module}" PRIVATE Eigen3::Eigen)
 

--- a/algorithms/convertStPlatformToBody/_tests/test_convertStPlatformToBody.cpp
+++ b/algorithms/convertStPlatformToBody/_tests/test_convertStPlatformToBody.cpp
@@ -9,6 +9,7 @@
 #include "test_convertStPlatformToBody_helpers.h"
 
 #include <cmath>
+#include <cstdint>
 
 // ─── Getter / Setter Tests ──────────────────────────────────────────────────
 
@@ -33,12 +34,16 @@ TEST(ConvertStPlatformToBody, SetGetDcmCB) {
 TEST(ConvertStPlatformToBody, TimeTagPassThrough) {
     ConvertStPlatformToBodyAlgorithm algorithm;
 
-    StSensorInput sensorIn{};
-    sensorIn.timeTag = 42.5F;
-    sensorIn.qInrtl2Case[0] = 1.0F;  // identity quaternion
+    PlatformAttitude attitude{};
+    attitude.timeTag = 42'500'000'000ULL;
+    attitude.q_CN[0] = 1.0F;  // identity quaternion (scalar-first)
 
-    StAttitudeOutput result = algorithm.update(sensorIn);
-    EXPECT_FLOAT_EQ(result.timeTag, 42.5F);
+    PlatformAngularVelocity angularVelocity{};
+    angularVelocity.timeTag = 42'500'000'000ULL;
+    angularVelocity.dq_CN[3] = 1.0F;  // identity delta quaternion (scalar-last)
+
+    StAttitudeOutput result = algorithm.update(attitude, angularVelocity);
+    EXPECT_EQ(result.timeTag, 42'500'000'000ULL);
 }
 
 // ─── Identity DCM Tests ─────────────────────────────────────────────────────
@@ -116,31 +121,96 @@ TEST(ConvertStPlatformToBody, ZeroOmega_NonTrivialAttitude) {
 
 TEST(ConvertStPlatformToBody, ZeroedInputPayload) {
     ConvertStPlatformToBodyAlgorithm algorithm;
-    StSensorInput sensorIn{};
-    // All zeros — invalid quaternion, but algorithm should not crash
-    StAttitudeOutput result = algorithm.update(sensorIn);
-    for (int i = 0; i < 3; i++) {
+    PlatformAttitude attitude{};
+    PlatformAngularVelocity angularVelocity{};
+    // All zeros — invalid quaternion and zero-vector delta quaternion, but algorithm
+    // must not crash or emit non-finite outputs.
+    StAttitudeOutput result = algorithm.update(attitude, angularVelocity);
+    for (int i = 0; i < 3; ++i) {
         EXPECT_TRUE(std::isfinite(result.sigma_BN[i]) || result.sigma_BN[i] == 0.0F);
+        EXPECT_TRUE(std::isfinite(result.omega_BN_B[i]));
     }
 }
 
-// ─── DCM Pass-Through Verification ──────────────────────────────────────────
+// ─── Delta Quaternion Tests ─────────────────────────────────────────────────
 
-TEST(ConvertStPlatformToBody, DcmOutputMatchesSetting) {
+TEST(ConvertStPlatformToBody, IdentityDeltaQuaternion_ProducesZeroOmega) {
+    // dq_CN = [0, 0, 0, 1] (scalar-last identity rotation) must map to zero angular
+    // velocity for any mounting DCM.
+    ConvertStPlatformToBodyAlgorithm algorithm;
+    Eigen::Matrix3f dcm_CB = epToDcm(axisAngleToEp(Eigen::Vector3d(0.3, -0.7, 0.5), 0.9)).cast<float>();
+    algorithm.setDcmCB(dcm_CB);
+
+    PlatformAttitude attitude{};
+    attitude.q_CN[0] = 1.0F;
+    PlatformAngularVelocity angularVelocity{};
+    angularVelocity.dq_CN[3] = 1.0F;
+
+    StAttitudeOutput result = algorithm.update(attitude, angularVelocity);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(result.omega_BN_B[i], 0.0F, OMEGA_TOLERANCE);
+    }
+}
+
+TEST(ConvertStPlatformToBody, ZeroDeltaQuaternion_ProducesZeroOmega) {
+    // dq_CN = [0, 0, 0, 0] is what a default-initialized PlatformAngularVelocity carries.
+    // The algorithm's ‖vec‖ > 0 guard must fire and produce ω = 0 without letting the
+    // dq[3]=0 branch (acos(0)=π/2) combine with a zero denominator to emit NaN/Inf.
     ConvertStPlatformToBodyAlgorithm algorithm;
 
-    Eigen::Matrix3f dcm;
-    dcm << 0.5F, 0.866025F, 0.0F, -0.866025F, 0.5F, 0.0F, 0.0F, 0.0F, 1.0F;
-    algorithm.setDcmCB(dcm);
+    PlatformAttitude attitude{};
+    attitude.q_CN[0] = 1.0F;
+    PlatformAngularVelocity angularVelocity{};  // all four dq_CN components = 0
 
-    StSensorInput sensorIn{};
-    sensorIn.qInrtl2Case[0] = 1.0F;
-    StAttitudeOutput result = algorithm.update(sensorIn);
+    StAttitudeOutput result = algorithm.update(attitude, angularVelocity);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_TRUE(std::isfinite(result.omega_BN_B[i]));
+        EXPECT_NEAR(result.omega_BN_B[i], 0.0F, OMEGA_TOLERANCE);
+    }
+}
 
-    // eigenMatrixToCArray stores Eigen data into a row-major flat array
-    for (int row = 0; row < 3; row++) {
-        for (int col = 0; col < 3; col++) {
-            EXPECT_NEAR(result.dcm_CB[row * 3 + col], dcm(row, col), 1e-5F);
-        }
+TEST(ConvertStPlatformToBody, DeltaQuaternionHalfPi_MatchesExpectedOmega) {
+    // Drive the algorithm with an explicit unit delta quaternion for θ = π/2 about +x.
+    // Expected recovered angular velocity is (π/2, 0, 0) with identity mounting.
+    ConvertStPlatformToBodyAlgorithm algorithm;  // identity dcm_CB
+
+    const double theta = M_PI / 2.0;
+    PlatformAttitude attitude{};
+    attitude.q_CN[0] = 1.0F;
+
+    PlatformAngularVelocity angularVelocity{};
+    angularVelocity.dq_CN[0] = static_cast<float>(std::sin(theta / 2.0));
+    angularVelocity.dq_CN[1] = 0.0F;
+    angularVelocity.dq_CN[2] = 0.0F;
+    angularVelocity.dq_CN[3] = static_cast<float>(std::cos(theta / 2.0));
+
+    StAttitudeOutput result = algorithm.update(attitude, angularVelocity);
+    EXPECT_NEAR(result.omega_BN_B[0], static_cast<float>(theta), OMEGA_TOLERANCE);
+    EXPECT_NEAR(result.omega_BN_B[1], 0.0F, OMEGA_TOLERANCE);
+    EXPECT_NEAR(result.omega_BN_B[2], 0.0F, OMEGA_TOLERANCE);
+}
+
+TEST(ConvertStPlatformToBody, DeltaQuaternionNearPi_MatchesExpectedOmega) {
+    // θ ≈ π − 0.01 about (1,2,3)/‖(1,2,3)‖. Near-π is a well-conditioned regime for
+    // acos (derivative ≈ −1 near dq_CN[3] ≈ 0), so tight OMEGA_TOLERANCE is appropriate.
+    ConvertStPlatformToBodyAlgorithm algorithm;
+
+    const double theta = M_PI - 0.01;
+    const Eigen::Vector3d axis = Eigen::Vector3d(1.0, 2.0, 3.0).normalized();
+    const Eigen::Vector3d omegaExpected = theta * axis;
+
+    PlatformAttitude attitude{};
+    attitude.q_CN[0] = 1.0F;
+
+    PlatformAngularVelocity angularVelocity{};
+    const double s = std::sin(theta / 2.0);
+    angularVelocity.dq_CN[0] = static_cast<float>(s * axis(0));
+    angularVelocity.dq_CN[1] = static_cast<float>(s * axis(1));
+    angularVelocity.dq_CN[2] = static_cast<float>(s * axis(2));
+    angularVelocity.dq_CN[3] = static_cast<float>(std::cos(theta / 2.0));
+
+    StAttitudeOutput result = algorithm.update(attitude, angularVelocity);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(result.omega_BN_B[i], static_cast<float>(omegaExpected(i)), OMEGA_TOLERANCE);
     }
 }

--- a/algorithms/convertStPlatformToBody/_tests/test_convertStPlatformToBody_fuzz.cpp
+++ b/algorithms/convertStPlatformToBody/_tests/test_convertStPlatformToBody_fuzz.cpp
@@ -57,14 +57,16 @@ void fuzzConvertStPlatformToBody(double q0,
     EXPECT_NO_THROW(testConvertStPlatformToBody(ep_CN, omega_CN_C, dcm_CB));
 }
 
+// Keep ‖ω‖ < π so the helper's ω→δq conversion stays single-valued:
+// ‖ω‖ ≤ √3 · 0.9 ≈ 1.56 rad, well under π.
 FUZZ_TEST(ConvertStPlatformToBodyFuzz, fuzzConvertStPlatformToBody)
     .WithDomains(fuzztest::InRange(-1.0, 1.0),                              // q0
                  fuzztest::InRange(-1.0, 1.0),                              // q1
                  fuzztest::InRange(-1.0, 1.0),                              // q2
                  fuzztest::InRange(-1.0, 1.0),                              // q3
-                 fuzztest::InRange(-1.0, 1.0),                              // wx [rad/s]
-                 fuzztest::InRange(-1.0, 1.0),                              // wy
-                 fuzztest::InRange(-1.0, 1.0),                              // wz
+                 fuzztest::InRange(-0.9, 0.9),                              // wx [rad/s]
+                 fuzztest::InRange(-0.9, 0.9),                              // wy
+                 fuzztest::InRange(-0.9, 0.9),                              // wz
                  fuzztest::InRange(0.0, 2.0 * M_PI),                        // yaw
                  fuzztest::InRange(-M_PI / 2.0 + 0.01, M_PI / 2.0 - 0.01),  // pitch (avoid gimbal lock)
                  fuzztest::InRange(0.0, 2.0 * M_PI));                       // roll
@@ -114,3 +116,55 @@ FUZZ_TEST(ConvertStPlatformToBodyFuzz, fuzzConvertStPlatformToBodyDcmEdges)
                  fuzztest::OneOf(fuzztest::InRange(-0.01, 0.01),                         // Near-zero pitch
                                  fuzztest::InRange(M_PI / 2 - 0.01, M_PI / 2 - 0.001)),  // Near-90 pitch
                  fuzztest::InRange(0.0, 2.0 * M_PI));                                    // Full roll range
+
+/*!
+ * @brief Fuzz the algorithm with delta quaternions supplied directly.
+ *
+ * The other fuzz harnesses reach the algorithm through the helper's ω→δq conversion,
+ * which always produces unit delta quaternions. This harness normalizes the four
+ * fuzzed components to a unit δq but otherwise bypasses the helper so that adversarial
+ * scalar-part values (near ±1 and near 0) stress-test the algorithm's safeSqrtf and
+ * safeAcosf guards directly. Only safety properties are checked — no truth value.
+ */
+void fuzzConvertStPlatformToBodyDeltaQuaternion(double dqx,
+                                                double dqy,
+                                                double dqz,
+                                                double dqw,
+                                                double yaw,
+                                                double pitch,
+                                                double roll) {
+    Eigen::Vector4d dq(dqx, dqy, dqz, dqw);
+    const double norm = dq.norm();
+    if (norm < 1e-12) {
+        dq = Eigen::Vector4d(0.0, 0.0, 0.0, 1.0);
+    } else {
+        dq /= norm;
+    }
+
+    ConvertStPlatformToBodyAlgorithm algorithm;
+    algorithm.setDcmCB(makeDcm(yaw, pitch, roll).cast<float>());
+
+    PlatformAttitude attitude{};
+    attitude.q_CN[0] = 1.0F;  // identity inertial attitude — isolate δq path
+    PlatformAngularVelocity angularVelocity{};
+    angularVelocity.dq_CN[0] = static_cast<float>(dq(0));
+    angularVelocity.dq_CN[1] = static_cast<float>(dq(1));
+    angularVelocity.dq_CN[2] = static_cast<float>(dq(2));
+    angularVelocity.dq_CN[3] = static_cast<float>(dq(3));
+
+    StAttitudeOutput result;
+    EXPECT_NO_THROW(result = algorithm.update(attitude, angularVelocity));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_TRUE(std::isfinite(result.sigma_BN[i]));
+        EXPECT_TRUE(std::isfinite(result.omega_BN_B[i]));
+    }
+}
+
+FUZZ_TEST(ConvertStPlatformToBodyFuzz, fuzzConvertStPlatformToBodyDeltaQuaternion)
+    .WithDomains(fuzztest::InRange(-1.0, 1.0),                              // dqx
+                 fuzztest::InRange(-1.0, 1.0),                              // dqy
+                 fuzztest::InRange(-1.0, 1.0),                              // dqz
+                 fuzztest::InRange(-1.0, 1.0),                              // dqw (scalar part)
+                 fuzztest::InRange(0.0, 2.0 * M_PI),                        // yaw
+                 fuzztest::InRange(-M_PI / 2.0 + 0.01, M_PI / 2.0 - 0.01),  // pitch
+                 fuzztest::InRange(0.0, 2.0 * M_PI));                       // roll

--- a/algorithms/convertStPlatformToBody/_tests/test_convertStPlatformToBody_helpers.h
+++ b/algorithms/convertStPlatformToBody/_tests/test_convertStPlatformToBody_helpers.h
@@ -14,13 +14,15 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <cmath>
+#include <cstdint>
 
 /// Tolerance for float-precision attitude computations
 inline constexpr float ATTITUDE_TOLERANCE = 1e-6F;
 /// Tolerance for angular velocity computations
 inline constexpr float OMEGA_TOLERANCE = 1e-6F;
-/// Tolerance for DCM element comparisons
-inline constexpr float DCM_TOLERANCE = 1e-6F;
+
+/// Representative nanosecond time tag used by the unit tests
+inline constexpr uint64_t TEST_TIME_TAG_NS = 100'000'000'000ULL;
 
 /*!
  * @brief Build a unit quaternion [q0, q1, q2, q3] from an axis-angle rotation.
@@ -36,10 +38,35 @@ inline Eigen::Vector4d axisAngleToEp(const Eigen::Vector3d& axis, double angle) 
 }
 
 /*!
+ * @brief Convert a case-frame angular velocity to a unit delta quaternion (scalar-last).
+ *
+ * Uses a one-sample interval (Δt = 1) so θ = ‖ω‖ and axis = ω/‖ω‖. The result is
+ * dq = [sin(θ/2)·axis, cos(θ/2)], matching the scalar-last convention consumed by
+ * ConvertStPlatformToBodyAlgorithm. Returns [0, 0, 0, 1] (identity rotation) when
+ * ‖ω‖ is below a small threshold.
+ */
+inline void omegaToDeltaQuaternion(const Eigen::Vector3d& omega_CN_C, float dq_CN[4]) {
+    const double angle = omega_CN_C.norm();
+    if (angle < 1e-12) {
+        dq_CN[0] = 0.0F;
+        dq_CN[1] = 0.0F;
+        dq_CN[2] = 0.0F;
+        dq_CN[3] = 1.0F;
+        return;
+    }
+    const Eigen::Vector3d axis = omega_CN_C / angle;
+    const double s = std::sin(angle / 2.0);
+    dq_CN[0] = static_cast<float>(s * axis(0));
+    dq_CN[1] = static_cast<float>(s * axis(1));
+    dq_CN[2] = static_cast<float>(s * axis(2));
+    dq_CN[3] = static_cast<float>(std::cos(angle / 2.0));
+}
+
+/*!
  * @brief Compute the expected output of ConvertStPlatformToBodyAlgorithm in double precision.
  *
  * Given a star tracker sensor input (quaternion, omega) and a mounting DCM,
- * compute the expected body-frame attitude (MRP), angular velocity, and DCM.
+ * compute the expected body-frame attitude (MRP) and angular velocity.
  *
  * @param ep_CN       Quaternion from inertial to case frame [q0, q1, q2, q3]
  * @param omega_CN_C  Angular velocity of case frame w.r.t. inertial, in case frame [rad/s]
@@ -67,6 +94,11 @@ inline void computeTruthValues(const Eigen::Vector4d& ep_CN,
 
 /*!
  * @brief Run the algorithm with the given inputs and verify against double-precision truth.
+ *
+ * Tests express the sensor measurement in physical units (quaternion + angular velocity);
+ * this harness internally converts ω to the delta-quaternion representation the algorithm
+ * now consumes, then confirms the algorithm recovers the expected body-frame attitude and
+ * angular velocity.
  */
 inline void testConvertStPlatformToBody(const Eigen::Vector4d& ep_CN,
                                         const Eigen::Vector3d& omega_CN_C,
@@ -76,23 +108,24 @@ inline void testConvertStPlatformToBody(const Eigen::Vector4d& ep_CN,
     Eigen::Vector3d omega_BN_B_truth;
     computeTruthValues(ep_CN, omega_CN_C, dcm_CB, sigma_BN_truth, omega_BN_B_truth);
 
-    // Build float-precision input
-    StSensorInput sensorIn{};
-    sensorIn.timeTag = 100.0F;
-    for (int i = 0; i < 4; i++) {
-        sensorIn.qInrtl2Case[i] = static_cast<float>(ep_CN(i));
+    // Build float-precision inputs
+    PlatformAttitude attitude{};
+    attitude.timeTag = TEST_TIME_TAG_NS;
+    for (int i = 0; i < 4; ++i) {
+        attitude.q_CN[i] = static_cast<float>(ep_CN(i));
     }
-    for (int i = 0; i < 3; i++) {
-        sensorIn.omega_CN_C[i] = static_cast<float>(omega_CN_C(i));
-    }
+
+    PlatformAngularVelocity angularVelocity{};
+    angularVelocity.timeTag = TEST_TIME_TAG_NS;
+    omegaToDeltaQuaternion(omega_CN_C, angularVelocity.dq_CN);
 
     // Configure and run algorithm
     ConvertStPlatformToBodyAlgorithm algorithm;
     algorithm.setDcmCB(dcm_CB.cast<float>());
-    StAttitudeOutput result = algorithm.update(sensorIn);
+    StAttitudeOutput result = algorithm.update(attitude, angularVelocity);
 
     // Verify timeTag pass-through
-    EXPECT_FLOAT_EQ(result.timeTag, 100.0F);
+    EXPECT_EQ(result.timeTag, TEST_TIME_TAG_NS);
 
     // Verify MRP (account for shadow set ambiguity near |σ|=1)
     Eigen::Vector3f sigma_result(result.sigma_BN[0], result.sigma_BN[1], result.sigma_BN[2]);
@@ -100,29 +133,20 @@ inline void testConvertStPlatformToBody(const Eigen::Vector4d& ep_CN,
     if ((sigma_result - mrpShadow(sigma_expected)).squaredNorm() < (sigma_result - sigma_expected).squaredNorm()) {
         sigma_expected = mrpShadow(sigma_expected);
     }
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 3; ++i) {
         EXPECT_NEAR(sigma_result(i), sigma_expected(i), ATTITUDE_TOLERANCE) << "sigma_BN[" << i << "] mismatch";
     }
 
     // Verify angular velocity
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 3; ++i) {
         EXPECT_NEAR(result.omega_BN_B[i], static_cast<float>(omega_BN_B_truth(i)), OMEGA_TOLERANCE)
             << "omega_BN_B[" << i << "] mismatch";
     }
 
-    // Verify DCM is passed through (row-major layout)
-    Eigen::Matrix<float, 3, 3, Eigen::RowMajor> dcm_CB_rm = dcm_CB.cast<float>();
-    for (int i = 0; i < 9; i++) {
-        EXPECT_NEAR(result.dcm_CB[i], dcm_CB_rm.data()[i], DCM_TOLERANCE) << "dcm_CB[" << i << "] mismatch";
-    }
-
     // Verify all outputs are finite
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 3; ++i) {
         EXPECT_TRUE(std::isfinite(result.sigma_BN[i]));
         EXPECT_TRUE(std::isfinite(result.omega_BN_B[i]));
-    }
-    for (float i : result.dcm_CB) {
-        EXPECT_TRUE(std::isfinite(i));
     }
 }
 

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBody.cpp
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBody.cpp
@@ -25,16 +25,13 @@ void ConvertStPlatformToBody::updateState(const uint64_t callTime) {
         }
     }
 
-    const auto [timeTag, sigma_BN, omega_BN_B, dcm_CB] = this->algorithm.update(sensorIn);
+    const auto [timeTag, sigma_BN, omega_BN_B] = this->algorithm.update(attitude, angularVelocity);
 
     STAttMsgPayload attOutMsg{};
     attOutMsg.timeTag = static_cast<double>(timeTag);
     for (int i = 0; i < 3; i++) {
         attOutMsg.MRP_BdyInrtl[i] = static_cast<double>(sigma_BN[i]);
         attOutMsg.omega_BN_B[i] = static_cast<double>(omega_BN_B[i]);
-    }
-    for (int i = 0; i < 9; i++) {
-        attOutMsg.dcm_CB[i] = static_cast<double>(dcm_CB[i]);
     }
 
     this->stAttOutMsg.write(&attOutMsg, this->moduleID, callTime);

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBody.cpp
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBody.cpp
@@ -62,4 +62,4 @@ void ConvertStPlatformToBody::setDcmCB(const Eigen::Matrix3d& dcm_CB) {
     this->algorithm.setDcmCB(dcm_CB.cast<float>());
 }
 
-const Eigen::Matrix3d ConvertStPlatformToBody::getDcmCB() const { return this->algorithm.getDcmCB().cast<double>(); }
+Eigen::Matrix3d ConvertStPlatformToBody::getDcmCB() const { return this->algorithm.getDcmCB().cast<double>(); }

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBody.cpp
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBody.cpp
@@ -50,7 +50,7 @@ void ConvertStPlatformToBody::updateState(const uint64_t callTime) {
 
     STAttMsgPayload attOutMsg{};
     attOutMsg.timeTag = static_cast<double>(timeTag);
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 3; ++i) {
         attOutMsg.MRP_BdyInrtl[i] = static_cast<double>(sigma_BN[i]);
         attOutMsg.omega_BN_B[i] = static_cast<double>(omega_BN_B[i]);
     }

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBody.cpp
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBody.cpp
@@ -6,6 +6,9 @@
 
 #include "convertStPlatformToBody.h"
 
+#include "architecture/utilities/eigenSupport.h"
+#include "utilities/timeConstants.h"
+
 void ConvertStPlatformToBody::reset(uint64_t callTime) {
     if (!this->stSensorInMsg.isLinked()) {
         this->bskLogger.bskLog(BSK_ERROR, "Error: convertStPlatformToBody.stSensorInMsg wasn't connected.");
@@ -13,16 +16,34 @@ void ConvertStPlatformToBody::reset(uint64_t callTime) {
 }
 
 void ConvertStPlatformToBody::updateState(const uint64_t callTime) {
-    StSensorInput sensorIn{};
+    PlatformAttitude attitude{};
+    PlatformAngularVelocity angularVelocity{};
     if (this->stSensorInMsg.isWritten()) {
-        const STSensorMsgPayload sensorMsg = this->stSensorInMsg();
-        sensorIn.timeTag = static_cast<float>(sensorMsg.timeTag);
-        for (int i = 0; i < 4; i++) {
-            sensorIn.qInrtl2Case[i] = static_cast<float>(sensorMsg.qInrtl2Case[i]);
+        const auto [timeTag, qInrtl2Case, omega_CN_C] = this->stSensorInMsg();
+        attitude.timeTag = static_cast<uint64_t>(timeTag * kSec2Nano);
+        angularVelocity.timeTag = static_cast<uint64_t>(timeTag * kSec2Nano);
+
+        for (int i = 0; i < 4; ++i) {
+            attitude.q_CN[i] = static_cast<float>(qInrtl2Case[i]);
         }
-        for (int i = 0; i < 3; i++) {
-            sensorIn.omega_CN_C[i] = static_cast<float>(sensorMsg.omega_CN_C[i]);
-        }
+
+        // This is temporary given the module that feeds this algorithm
+        // is still producing omega and not delta quaternions.
+        // When it becomes delta quaternions this will become a pass
+        // through.
+        //
+        // Build a unit delta quaternion dq_CN = [sin(θ/2)·axis, cos(θ/2)] with unit
+        // axis = ω/‖ω‖ and θ = ‖ω‖. The algorithm's atan2-based recovery requires a
+        // unit δq on input.
+        const Eigen::Vector3d omegaVec = cArrayToEigenVector3(omega_CN_C);
+        const double angle = omegaVec.norm();
+        const double halfSin = std::sin(angle / 2.0);
+        const double halfCos = std::cos(angle / 2.0);
+        const Eigen::Vector3d axis = (angle > 0.0) ? (omegaVec / angle).eval() : Eigen::Vector3d::Zero();
+        angularVelocity.dq_CN[0] = static_cast<float>(axis[0] * halfSin);
+        angularVelocity.dq_CN[1] = static_cast<float>(axis[1] * halfSin);
+        angularVelocity.dq_CN[2] = static_cast<float>(axis[2] * halfSin);
+        angularVelocity.dq_CN[3] = static_cast<float>(halfCos);
     }
 
     const auto [timeTag, sigma_BN, omega_BN_B] = this->algorithm.update(attitude, angularVelocity);

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBody.h
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBody.h
@@ -29,7 +29,7 @@ class ConvertStPlatformToBody : public SysModel {
     void updateState(uint64_t callTime) override;
 
     void setDcmCB(const Eigen::Matrix3d& dcm_CB);
-    const Eigen::Matrix3d getDcmCB() const;
+    Eigen::Matrix3d getDcmCB() const;
 
     ReadFunctor<STSensorMsgPayload> stSensorInMsg;  //!< Input msg
     Message<STAttMsgPayload> stAttOutMsg;           //!< Output msg

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBody.rst
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBody.rst
@@ -7,9 +7,11 @@ Executive Summary
 -----------------
 
 The ``convertStPlatformToBody`` module converts a star tracker attitude measurement from the sensor (case) frame into
-the spacecraft body frame. It takes the inertial-to-case attitude quaternion and case-frame angular velocity produced
+the spacecraft body frame. It takes the inertial-to-case attitude quaternion and case-frame delta quaternion produced
 by the star tracker and, using a configured body-to-case mounting DCM, outputs the inertial-to-body MRP and body-frame
-angular velocity suitable for downstream navigation and control modules.
+angular velocity suitable for downstream navigation and control modules. The adapter layer accepts the legacy
+angular-velocity field on ``STSensorMsgPayload`` and converts it to a delta quaternion before invoking the algorithm,
+so upstream producers may continue to publish angular velocity until the message layout is updated.
 
 
 -------------------------------
@@ -75,7 +77,10 @@ The adapter (``ConvertStPlatformToBody``) provides the Xmera-facing interface an
 - Logging an error condition if ``stSensorInMsg`` is not connected
 - Reading the input message ``stSensorInMsg``
 - Converting the sensor message data from ``double`` to ``float``
-- Packing the float data into the ``StSensorInput`` struct
+- Converting the message time tag from seconds (``double``) to nanoseconds (``uint64_t``)
+- Packing the float data into the ``PlatformAttitude`` and ``PlatformAngularVelocity`` structs
+- Converting the case-frame angular velocity on the incoming message to a delta quaternion
+  ``dq_CN`` before handing it to the algorithm
 - Calling the algorithm layer ``ConvertStPlatformToBodyAlgorithm::update``
 - Converting the ``StAttitudeOutput`` struct fields back to ``double``
 - Writing the ``stAttOutMsg`` output message
@@ -85,7 +90,9 @@ The adapter (``ConvertStPlatformToBody``) provides the Xmera-facing interface an
 
 The algorithm (``ConvertStPlatformToBodyAlgorithm``) performs the core mathematical computations and is fully decoupled
 from the Xmera framework. It operates exclusively on the float input and output structs defined in
-:ref:`convertStPlatformToBodyTypes.h` and has no dependency on ``SysModel``, message readers, or writers.
+:ref:`convertStPlatformToBodyTypes.h` — ``PlatformAttitude`` (inertial-to-case attitude), ``PlatformAngularVelocity``
+(case-frame delta quaternion), and ``StAttitudeOutput`` (inertial-to-body MRP and body-frame angular velocity) —
+and has no dependency on ``SysModel``, message readers, or writers.
 
 
 -------------------------------------
@@ -93,11 +100,15 @@ Input Constraints and Assumptions
 -------------------------------------
 
 - The star tracker case is rigidly mounted to the hub so that
-:math:`^{C}\boldsymbol{\omega}_{CN} = [CB]\, {}^{B}\boldsymbol{\omega}_{BN}`
-- ``qInrtl2Case`` is a unit quaternion representing the rotation from the inertial frame
-:math:`\mathcal{N}` to the case frame :math:`\mathcal{C}`
+  :math:`^{C}\boldsymbol{\omega}_{CN} = [CB]\, {}^{B}\boldsymbol{\omega}_{BN}`
+- ``q_CN`` is a unit quaternion representing the rotation from the inertial frame
+  :math:`\mathcal{N}` to the case frame :math:`\mathcal{C}`
 - ``dcm_CB`` is a proper orthogonal direction cosine matrix (det = +1)
-- Input angular velocity ``omega_CN_C`` is expressed in the case frame
+- ``dq_CN`` is a unit delta quaternion in scalar-last convention,
+  :math:`\delta \boldsymbol{q}_{CN} = [\sin(\theta/2)\,\hat{\boldsymbol{e}},\ \cos(\theta/2)]`,
+  representing a one-sample case-frame rotation about unit axis :math:`\hat{\boldsymbol{e}}` by angle :math:`\theta`
+- A zero vector part (:math:`\lVert[\delta q_0, \delta q_1, \delta q_2]\rVert = 0`) is treated as a zero rotation
+  and yields :math:`^{C}\boldsymbol{\omega}_{CN} = \boldsymbol{0}`
 
 
 -------------------------------
@@ -127,7 +138,23 @@ The inertial-to-body MRP is then computed by MRP addition:
 
 :math:`\boldsymbol{\sigma}_{BN} = \boldsymbol{\sigma}_{BC} \oplus \boldsymbol{\sigma}_{CN}`
 
-**3. Angular velocity transformation**
+**3. Delta quaternion to angular velocity**
+
+The case-frame angular velocity is recovered from the incoming unit delta quaternion by inverting the standard
+axis-angle-to-quaternion mapping. The four-quadrant arctangent is used in place of :math:`\arccos` so that
+near-identity rotations (where :math:`\delta q_3 \approx 1`) retain float32 precision:
+
+.. math::
+
+    {}^{C}\boldsymbol{\omega}_{CN} =
+    \dfrac{2\,\mathrm{atan2}\!\left(\lVert[\delta q_0, \delta q_1, \delta q_2]\rVert,\ \delta q_3\right)}
+          {\lVert[\delta q_0, \delta q_1, \delta q_2]\rVert}\,
+    [\delta q_0, \delta q_1, \delta q_2]^{T}
+
+When the vector part has zero norm the recovered angular velocity is taken to be
+:math:`\boldsymbol{0}`, avoiding a divide-by-zero at the identity rotation.
+
+**4. Angular velocity transformation**
 
 Because the sensor is rigidly mounted, the angular velocity in the body frame is obtained by rotating the
 case-frame measurement through the mounting DCM:

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm.cpp
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm.cpp
@@ -22,12 +22,10 @@ StAttitudeOutput ConvertStPlatformToBodyAlgorithm::update(StSensorInput& stSenso
     const Eigen::Vector3f omega_CN_C = cArrayToEigenVector3<float>(stSensorIn.omega_CN_C);
     const Eigen::Vector3f omega_BN_B = this->dcm_CB.transpose() * omega_CN_C;
 
-    // Build output
     StAttitudeOutput stAttOut{};
     stAttOut.timeTag = stSensorIn.timeTag;
     eigenVectorToCArray(sigma_BN, stAttOut.sigma_BN);
     eigenVectorToCArray(omega_BN_B, stAttOut.omega_BN_B);
-    eigenMatrixToCArray(this->dcm_CB, stAttOut.dcm_CB);
     return stAttOut;
 }
 

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm.cpp
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm.cpp
@@ -6,24 +6,36 @@
 
 #include "convertStPlatformToBodyAlgorithm.h"
 
+#include "../utilities/safeMath.h"
 #include "architecture/utilities/eigenSupport.h"
 #include "architecture/utilities/rigidBodyKinematics.hpp"
 
-StAttitudeOutput ConvertStPlatformToBodyAlgorithm::update(StSensorInput& stSensorIn) const {
+StAttitudeOutput ConvertStPlatformToBodyAlgorithm::update(const PlatformAttitude& platformAttitude,
+                                                          const PlatformAngularVelocity& platformAngularRate) const {
     // Convert the star tracker inertial attitude from quaternion to MRP
-    const Eigen::Vector4f ep_CN = cArrayToEigenVector(stSensorIn.qInrtl2Case);
+    const Eigen::Vector4f ep_CN = cArrayToEigenVector(platformAttitude.q_CN);
     const Eigen::Vector3f sigma_CN = epToMrp(ep_CN);
 
     // Compute hub inertial attitude using specified dcm_CB
     const Eigen::Vector3f sigma_BC = dcmToMrp<float>(this->dcm_CB.transpose());
     const Eigen::Vector3f sigma_BN = addMrp(sigma_CN, sigma_BC);
 
-    // Compute hub inertial angular velocity using specified dcm_CB
-    const Eigen::Vector3f omega_CN_C = cArrayToEigenVector3<float>(stSensorIn.omega_CN_C);
+    // Recover case-frame angular velocity from the incoming unit delta quaternion.
+    // dq_CN = [sin(θ/2)·axis, cos(θ/2)] in scalar-last form. Using atan2 in place of
+    // acos avoids the derivative blow-up of acos near ±1, preserving float32 relative
+    // precision in the near-identity regime (cos(θ/2) ≈ 1).
+    const float dqVecNorm = safeSqrtf((platformAngularRate.dq_CN[0] * platformAngularRate.dq_CN[0]) +
+                                      (platformAngularRate.dq_CN[1] * platformAngularRate.dq_CN[1]) +
+                                      (platformAngularRate.dq_CN[2] * platformAngularRate.dq_CN[2]));
+    const float omegaScale =
+        (dqVecNorm > 0.0F) ? 2.0F * safeAtan2f(dqVecNorm, platformAngularRate.dq_CN[3]) / dqVecNorm : 0.0F;
+    const Eigen::Vector3f omega_CN_C = {platformAngularRate.dq_CN[0] * omegaScale,
+                                        platformAngularRate.dq_CN[1] * omegaScale,
+                                        platformAngularRate.dq_CN[2] * omegaScale};
     const Eigen::Vector3f omega_BN_B = this->dcm_CB.transpose() * omega_CN_C;
 
     StAttitudeOutput stAttOut{};
-    stAttOut.timeTag = stSensorIn.timeTag;
+    stAttOut.timeTag = platformAttitude.timeTag;
     eigenVectorToCArray(sigma_BN, stAttOut.sigma_BN);
     eigenVectorToCArray(omega_BN_B, stAttOut.omega_BN_B);
     return stAttOut;

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm.h
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm.h
@@ -13,7 +13,8 @@
 
 class ConvertStPlatformToBodyAlgorithm {
    public:
-    StAttitudeOutput update(StSensorInput& stSensorIn) const;
+    StAttitudeOutput update(const PlatformAttitude& platformAttitude,
+                            const PlatformAngularVelocity& platformAngularRate) const;
     void setDcmCB(const Eigen::Matrix3f& dcm_CB);
     const Eigen::Matrix3f& getDcmCB() const;
 

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm_c.cpp
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm_c.cpp
@@ -19,8 +19,9 @@ void ConvertStPlatformToBodyAlgorithm_destroy(ConvertStPlatformToBodyAlgorithm* 
 }
 
 StAttitudeOutput ConvertStPlatformToBodyAlgorithm_update(ConvertStPlatformToBodyAlgorithm* self,
-                                                         StSensorInput* stSensorIn) {
-    return reinterpret_cast<::ConvertStPlatformToBodyAlgorithm*>(self)->update(*stSensorIn);
+                                                         const PlatformAttitude* platformAttitude,
+                                                         const PlatformAngularVelocity* platformAngularRate) {
+    return reinterpret_cast<::ConvertStPlatformToBodyAlgorithm*>(self)->update(*platformAttitude, *platformAngularRate);
 }
 
 void ConvertStPlatformToBodyAlgorithm_setDcmCB(ConvertStPlatformToBodyAlgorithm* self, Matrix3f_c dcm_CB) {

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm_c.h
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm_c.h
@@ -39,12 +39,14 @@ void ConvertStPlatformToBodyAlgorithm_destroy(ConvertStPlatformToBodyAlgorithm* 
 
 /**
  * @brief Run the update step.
- * @param self        Pointer to the instance.
- * @param stSensorIn  Pointer to the star tracker sensor input.
+ * @param self               Pointer to the instance.
+ * @param platformAttitude   Pointer to the inertial-to-case attitude input.
+ * @param platformAngularRate Pointer to the case-frame delta quaternion input.
  * @return StAttitudeOutput  The computed star tracker attitude output.
  */
 StAttitudeOutput ConvertStPlatformToBodyAlgorithm_update(ConvertStPlatformToBodyAlgorithm* self,
-                                                         StSensorInput* stSensorIn);
+                                                         const PlatformAttitude* platformAttitude,
+                                                         const PlatformAngularVelocity* platformAngularRate);
 
 /**
  * @brief Set the DCM from body to star tracker case frame.

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBodyTypes.h
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBodyTypes.h
@@ -7,20 +7,27 @@
 #ifndef F32XIMERA_CONVERT_ST_PLATFORM_TO_BODY_TYPES_H
 #define F32XIMERA_CONVERT_ST_PLATFORM_TO_BODY_TYPES_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/*! @brief Star tracker sensor input for the platform-to-body conversion algorithm */
+/*! @brief Star tracker sensor angular velocity for the platform-to-body conversion algorithm */
 typedef struct {
-    float timeTag;        /*!< [s] Time tag associated with measurement */
-    float qInrtl2Case[4]; /*!< [-] Quaternion from inertial to case frame */
-    float omega_CN_C[3];  /*!< [rad/s] Case-frame angular velocity w.r.t. inertial */
-} StSensorInput;
+    uint64_t timeTag; /*!< [ns] Time tag associated with measurement */
+    float dq_CN[4];   /*!< [rad/s] Case-frame angular velocity w.r.t. inertial */
+} PlatformAngularVelocity;
+
+/*! @brief Star tracker sensor attitude solution for the platform-to-body conversion algorithm */
+typedef struct {
+    uint64_t timeTag; /*!< [ns] Time tag associated with measurement */
+    float q_CN[4];    /*!< [-] Quaternion from inertial to case frame */
+} PlatformAttitude;
 
 /*! @brief Star tracker body-frame attitude output from the platform-to-body conversion algorithm */
 typedef struct {
-    float timeTag;       /*!< [s] Time tag associated with measurement */
+    uint64_t timeTag;    /*!< [ns] Time tag associated with measurement */
     float sigma_BN[3];   /*!< [-] MRP from inertial to body frame */
     float omega_BN_B[3]; /*!< [rad/s] Body-frame angular velocity w.r.t. inertial */
 } StAttitudeOutput;

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBodyTypes.h
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBodyTypes.h
@@ -23,7 +23,6 @@ typedef struct {
     float timeTag;       /*!< [s] Time tag associated with measurement */
     float sigma_BN[3];   /*!< [-] MRP from inertial to body frame */
     float omega_BN_B[3]; /*!< [rad/s] Body-frame angular velocity w.r.t. inertial */
-    float dcm_CB[9];     /*!< [-] DCM from body to case frame (row-major) */
 } StAttitudeOutput;
 
 #ifdef __cplusplus

--- a/algorithms/utilities/timeConstants.h
+++ b/algorithms/utilities/timeConstants.h
@@ -2,8 +2,11 @@
 #define FSW_TIME_CONSTANTS_H
 
 inline constexpr double kNano2Sec = 1e-9;
-inline constexpr double kSec2Nano = 1e9;
 inline constexpr float kNano2SecF = 1e-9F;
+
+inline constexpr double kSec2Nano = 1e9;
+inline constexpr float kSec2NanoF = 1e9F;
+
 inline constexpr float kSec2Hour = 1.0 / 3600.0;
 inline constexpr float kSec2HourF = 1.0F / 3600.0F;
 

--- a/architecture/utilities/eigenSupport.h
+++ b/architecture/utilities/eigenSupport.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: ISC
+// Copyright (c) 2015, Autonomous Vehicle System Lab, University of Colorado at Boulder
+// Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
 #ifndef EIGEN_SUPPORT
 #define EIGEN_SUPPORT
 
@@ -206,8 +210,8 @@ void eigenVectorToCArray(const Eigen::Vector<ScalarT, size>& inVec, ScalarT* out
  * @return Eigen matrix populated with the values from `inArray`.
  */
 template <typename ScalarT, int rows, int cols>
-Eigen::Matrix<ScalarT, rows, cols> cArrayToEigenMatrix(ScalarT* inArray) {
-    return Eigen::Map<Eigen::Matrix<ScalarT, rows, cols>>(inArray);
+Eigen::Matrix<ScalarT, rows, cols> cArrayToEigenMatrix(const ScalarT* inArray) {
+    return Eigen::Map<const Eigen::Matrix<ScalarT, rows, cols>>(inArray);
 }
 
 /**
@@ -220,9 +224,9 @@ Eigen::Matrix<ScalarT, rows, cols> cArrayToEigenMatrix(ScalarT* inArray) {
  * @return Eigen dynamic matrix containing the mapped values.
  */
 template <typename ScalarT>
-Eigen::MatrixX<ScalarT> cArrayToEigenMatrixX(ScalarT* inArray, int nRows, int nCols) {
+Eigen::MatrixX<ScalarT> cArrayToEigenMatrixX(const ScalarT* inArray, int nRows, int nCols) {
     Eigen::MatrixX<ScalarT> outMat(nRows, nCols);
-    outMat = Eigen::Map<Eigen::MatrixX<ScalarT>>(inArray, outMat.rows(), outMat.cols());
+    outMat = Eigen::Map<const Eigen::MatrixX<ScalarT>>(inArray, outMat.rows(), outMat.cols());
     return outMat;
 }
 
@@ -235,8 +239,8 @@ Eigen::MatrixX<ScalarT> cArrayToEigenMatrixX(ScalarT* inArray, int nRows, int nC
  * @return Eigen vector whose contents match the input array.
  */
 template <typename ScalarT, int size>
-Eigen::Vector<ScalarT, size> cArrayToEigenVector(ScalarT (&inArray)[size]) {
-    return Eigen::Map<Eigen::Vector<ScalarT, size>>(inArray);
+Eigen::Vector<ScalarT, size> cArrayToEigenVector(const ScalarT (&inArray)[size]) {
+    return Eigen::Map<const Eigen::Vector<ScalarT, size>>(inArray);
 }
 
 /**
@@ -247,8 +251,8 @@ Eigen::Vector<ScalarT, size> cArrayToEigenVector(ScalarT (&inArray)[size]) {
  * @return Eigen::Vector3 populated from the input data.
  */
 template <typename ScalarT>
-Eigen::Vector3<ScalarT> cArrayToEigenVector3(ScalarT* inArray) {
-    return Eigen::Map<Eigen::Vector3<ScalarT>>(inArray);
+Eigen::Vector3<ScalarT> cArrayToEigenVector3(const ScalarT* inArray) {
+    return Eigen::Map<const Eigen::Vector3<ScalarT>>(inArray);
 }
 
 /**
@@ -259,9 +263,9 @@ Eigen::Vector3<ScalarT> cArrayToEigenVector3(ScalarT* inArray) {
  * @return Eigen::MRP constructed from the input.
  */
 template <typename ScalarT>
-Eigen::MRP<ScalarT> cArrayToEigenMrp(ScalarT* inArray) {
+Eigen::MRP<ScalarT> cArrayToEigenMrp(const ScalarT* inArray) {
     Eigen::MRP<ScalarT> sigma_Eigen;
-    sigma_Eigen = Eigen::Map<Eigen::Vector<ScalarT, 3>>(inArray);
+    sigma_Eigen = Eigen::Map<const Eigen::Vector<ScalarT, 3>>(inArray);
 
     return sigma_Eigen;
 }
@@ -274,8 +278,8 @@ Eigen::MRP<ScalarT> cArrayToEigenMrp(ScalarT* inArray) {
  * @return Eigen::Matrix3 with the copied values.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> cArrayToEigenMatrix3(ScalarT* inArray) {
-    return Eigen::Map<Eigen::Matrix3<ScalarT>>(inArray, 3, 3).transpose();
+Eigen::Matrix3<ScalarT> cArrayToEigenMatrix3(const ScalarT* inArray) {
+    return Eigen::Map<const Eigen::Matrix3<ScalarT>>(inArray, 3, 3).transpose();
 }
 
 /**


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Currently this algorithm takes a quaternion and omega as input. We need it to accept quaternion and delta quaternion (angular rate). This PR makes that change.

To note: the first commit of this PR updates this repositories copy of `eigenSupport.h` given the `const`-ness changes made in the Xmera repositories version. 

## Verification
The algorithm tests were updated.

## Documentation
Documentation was updated.

## Future work
The xmera module adapter currently contains some code to map an omega to delta quaternion. When other key algorithms are available this will be removed and the input to this module will be delta quaternion (not omega) and the delta quaternion will be passed straight through to the algorithm.
