### PR TITLE
Refactor average mimu to accepts goups of 10 rate data

### DIFF
--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -39,10 +39,12 @@ class ReferenceAverager {
             lastIngestedMaxMeasTime_ = std::max(lastIngestedMaxMeasTime_, firstSampleTime);
         }
 
-        // Phase 2: max-tail-time + window filter, derived sample schedule.
-        // Convert the algorithm's window to ns once and compare in integer.
+        // Phase 2: max-tail-time + per-modality window filter, derived sample
+        // schedule. Convert each window to ns once and compare in integer.
         const std::uint64_t gyroAveragingWindowNs =
             static_cast<std::uint64_t>(alg_.getGyroAveragingWindow() * 1.0e9);
+        const std::uint64_t accelAveragingWindowNs =
+            static_cast<std::uint64_t>(alg_.getAccelAveragingWindow() * 1.0e9);
 
         std::uint64_t maxSlotMeasTime = 0U;
         for (auto const& slot : ring_) {
@@ -62,7 +64,8 @@ class ReferenceAverager {
 
         Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
         Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
-        std::uint64_t measAvgCount = 0U;
+        std::uint64_t gyroAvgCount = 0U;
+        std::uint64_t accelAvgCount = 0U;
 
         for (auto const& slot : ring_) {
             if (!slot.isValid) {
@@ -71,18 +74,24 @@ class ReferenceAverager {
             for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT_C; ++s) {
                 const std::uint64_t sampleMeasTime =
                     slot.measTime + (s * AverageMimuDataAlgorithm::kMimuSamplePeriodNs);
-                if ((maxTimeTag - sampleMeasTime) <= gyroAveragingWindowNs) {
+                const std::uint64_t age = maxTimeTag - sampleMeasTime;
+                if (age <= gyroAveragingWindowNs) {
                     gyroSum_P += slot.samples[s].gyro_P;
+                    gyroAvgCount++;
+                }
+                if (age <= accelAveragingWindowNs) {
                     accelSum_P += slot.samples[s].accel_P;
-                    measAvgCount++;
+                    accelAvgCount++;
                 }
             }
         }
 
-        if (measAvgCount > 0U) {
-            gyroSum_P /= static_cast<float>(measAvgCount);
-            accelSum_P /= static_cast<float>(measAvgCount);
+        if (gyroAvgCount > 0U) {
+            gyroSum_P /= static_cast<float>(gyroAvgCount);
             out.gyroOmega_B = alg_.getDcmPltfToBdy() * gyroSum_P;
+        }
+        if (accelAvgCount > 0U) {
+            accelSum_P /= static_cast<float>(accelAvgCount);
             out.accel_B = alg_.getDcmPltfToBdy() * accelSum_P;
         }
 
@@ -121,6 +130,7 @@ inline void regressionTestAverageMimuData(float window, InputPktsData const& in)
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(window);
+    alg.setAccelAveragingWindow(window);
 
     ReferenceAverager ref(alg);
 
@@ -139,6 +149,7 @@ inline void sequencedRegressionTestAverageMimuData(float window, std::vector<Inp
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(window);
+    alg.setAccelAveragingWindow(window);
 
     ReferenceAverager ref(alg);
 

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -7,6 +7,8 @@
 #include <architecture/utilities/macroDefinitions.h>
 #include <gtest/gtest.h>
 
+#include <vector>
+
 OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const AverageMimuDataAlgorithm& alg) {
     // Mirrors the algorithm's staleness rule: a sample is fresh only when its
     // packet's isValid is true AND its measTime is non-zero.
@@ -70,6 +72,23 @@ inline void regressionTestAverageMimuData(float window, InputPktsData const& in)
 
     EXPECT_EQ(out_alg.gyroOmega_B, out_ref.gyroOmega_B);
     EXPECT_EQ(out_alg.accel_B, out_ref.accel_B);
+}
+
+/*! @brief Drives the algorithm across a sequence of ring-buffer snapshots.
+ *  For each snapshot, the algorithm output is compared against referenceUpdate
+ *  to catch any drift in the staleness / window-filter logic across cycles. */
+inline void sequencedRegressionTestAverageMimuData(float window, std::vector<InputPktsData> const& frames) {
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(window);
+
+    for (auto const& in : frames) {
+        const OutputAverageAccelAngleVel out_alg = alg.update(in);
+        const OutputAverageAccelAngleVel out_ref = referenceUpdate(in, alg);
+
+        EXPECT_EQ(out_alg.gyroOmega_B, out_ref.gyroOmega_B);
+        EXPECT_EQ(out_alg.accel_B, out_ref.accel_B);
+    }
 }
 
 #endif

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -1,5 +1,5 @@
-#ifndef TEST_EPHEMERIDESRECENTER_H
-#define TEST_EPHEMERIDESRECENTER_H
+#ifndef TEST_AVERAGE_MIMU_DATA_HELPERS_H
+#define TEST_AVERAGE_MIMU_DATA_HELPERS_H
 
 #include "averageMimuDataAlgorithm.h"
 #include "utilities/fsw/eigenSupport.h"
@@ -8,12 +8,17 @@
 #include <gtest/gtest.h>
 
 OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const AverageMimuDataAlgorithm& alg) {
-    // Mirrors the algorithm's staleness rule: a slot is fresh only when
-    // isValid is true AND measTime is non-zero.
+    // Mirrors the algorithm's staleness rule: a sample is fresh only when its
+    // packet's isValid is true AND its measTime is non-zero.
     uint64_t maxTimeTag = 0U;
-    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        if (localPkts.isValid[i] && localPkts.measTime[i] != 0U) {
-            maxTimeTag = std::max(localPkts.measTime[i], maxTimeTag);
+    for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
+        if (!localPkts.isValid[p]) {
+            continue;
+        }
+        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
+            if (localPkts.samples[p][s].measTime != 0U) {
+                maxTimeTag = std::max(localPkts.samples[p][s].measTime, maxTimeTag);
+            }
         }
     }
 
@@ -26,17 +31,20 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const
     Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
     uint64_t measAvgCount = 0U;
 
-    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        if (!localPkts.isValid[i] || localPkts.measTime[i] == 0U) {
+    for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
+        if (!localPkts.isValid[p]) {
             continue;
         }
-        const uint64_t measTime = localPkts.measTime[i];
-
-        // Rolling average with averaging window as window width or the maximum buffer size
-        if (static_cast<float>(maxTimeTag - measTime) * NANO2SEC <= alg.getAveragingWindow()) {
-            gyroSum_P += localPkts.gyro_P[i];
-            accelSum_P += localPkts.accel_P[i];
-            measAvgCount++;
+        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
+            const auto& sample = localPkts.samples[p][s];
+            if (sample.measTime == 0U) {
+                continue;
+            }
+            if (static_cast<float>(maxTimeTag - sample.measTime) * NANO2SEC <= alg.getAveragingWindow()) {
+                gyroSum_P += sample.gyro_P;
+                accelSum_P += sample.accel_P;
+                measAvgCount++;
+            }
         }
     }
 
@@ -52,44 +60,10 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const
     return out;
 }
 
-using Vec3Arr = std::array<float, 3>;
-
-inline Eigen::Vector3f toVec3(Vec3Arr const& a) { return Eigen::Vector3f{a[0], a[1], a[2]}; }
-
-struct InputData {
-    uint64_t measTime = 0U;
-    Vec3Arr gyro_P{{0.0F, 0.0F, 0.0F}};
-    Vec3Arr accel_P{{0.0F, 0.0F, 0.0F}};
-    bool isValid = false;
-};
-
-inline void regressionTestAverageMimuData(std::size_t N,
-                                          float window,
-                                          std::array<InputData, MAX_ACC_BUF_PKT> const& input) {
+inline void regressionTestAverageMimuData(float window, InputPktsData const& in) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setAveragingWindow(window);
-
-    // Clamp N to valid range
-    if (N > MAX_ACC_BUF_PKT) {
-        N = MAX_ACC_BUF_PKT;
-    }
-    // Build the algorithm input buffer (max size), but only populate first N.
-    // The rest are neutral so they cannot affect maxTimeTag or the average.
-    InputPktsData in{};
-    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        in.isValid[i] = false;
-        in.measTime[i] = 0U;
-        in.gyro_P[i] = Eigen::Vector3f::Zero();
-        in.accel_P[i] = Eigen::Vector3f::Zero();
-    }
-
-    for (std::size_t i = 0; i < N; ++i) {
-        in.isValid[i] = input[i].isValid;
-        in.measTime[i] = input[i].measTime;
-        in.gyro_P[i] = toVec3(input[i].gyro_P);
-        in.accel_P[i] = toVec3(input[i].accel_P);
-    }
 
     const OutputAverageAccelAngleVel out_alg = alg.update(in);
     const OutputAverageAccelAngleVel out_ref = referenceUpdate(in, alg);

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -8,9 +8,18 @@
 #include <gtest/gtest.h>
 
 OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const AverageMimuDataAlgorithm& alg) {
+    // Mirrors the algorithm's staleness rule: a slot is fresh only when
+    // isValid is true AND measTime is non-zero.
     uint64_t maxTimeTag = 0U;
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        maxTimeTag = std::max(localPkts.measTime[i], maxTimeTag);
+        if (localPkts.isValid[i] && localPkts.measTime[i] != 0U) {
+            maxTimeTag = std::max(localPkts.measTime[i], maxTimeTag);
+        }
+    }
+
+    OutputAverageAccelAngleVel out{};
+    if (maxTimeTag == 0U) {
+        return out;
     }
 
     Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
@@ -18,6 +27,9 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const
     uint64_t measAvgCount = 0U;
 
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        if (!localPkts.isValid[i] || localPkts.measTime[i] == 0U) {
+            continue;
+        }
         const uint64_t measTime = localPkts.measTime[i];
 
         // Rolling average with averaging window as window width or the maximum buffer size
@@ -28,7 +40,6 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const
         }
     }
 
-    OutputAverageAccelAngleVel out{};
     if (measAvgCount > 0U) {
         gyroSum_P /= static_cast<float>(measAvgCount);
         Eigen::Vector3f const gyroSum_B = alg.getDcmPltfToBdy() * gyroSum_P;

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -2,10 +2,9 @@
 #define TEST_AVERAGE_MIMU_DATA_HELPERS_H
 
 #include "averageMimuDataAlgorithm.h"
-#include "utilities/fsw/eigenSupport.h"
-#include "utilities/fsw/freestandingInvalidArgument.h"
+#include <utilities/fsw/eigenSupport.h>
+#include <utilities/fsw/freestandingInvalidArgument.h>
 
-#include <architecture/utilities/macroDefinitions.h>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -18,11 +17,11 @@
  *  via getters at each update() call. */
 class ReferenceAverager {
    public:
-    explicit ReferenceAverager(AverageMimuDataAlgorithm const& alg) : alg_(alg) {}
+    explicit ReferenceAverager(AverageMimuDataAlgorithm const& alg) : alg(alg) {}
 
     OutputAverageAccelAngleVel update(InputPktsData const& localPkts) {
         // Phase 1: ingest. Freeze prior max for the duration of this call.
-        const std::uint64_t priorMax = lastIngestedMaxMeasTime_;
+        const std::uint64_t priorMax = this->lastIngestedMaxMeasTime;
         for (auto const& packet : localPkts.packets) {
             if (!packet.isValid) {
                 continue;
@@ -32,22 +31,22 @@ class ReferenceAverager {
                 continue;
             }
 
-            ring_[insertIdx_].isValid = true;
-            ring_[insertIdx_].measTime = firstSampleTime;
-            ring_[insertIdx_].samples = packet.samples;
-            insertIdx_ = (insertIdx_ + 1U) % AverageMimuDataAlgorithm::kRingCapacity;
-            lastIngestedMaxMeasTime_ = std::max(lastIngestedMaxMeasTime_, firstSampleTime);
+            this->ring[this->insertIdx].isValid = true;
+            this->ring[this->insertIdx].measTime = firstSampleTime;
+            this->ring[this->insertIdx].samples = packet.samples;
+            this->insertIdx = (this->insertIdx + 1U) % AverageMimuDataAlgorithm::kRingCapacity;
+            this->lastIngestedMaxMeasTime = std::max(this->lastIngestedMaxMeasTime, firstSampleTime);
         }
 
         // Phase 2: max-tail-time + per-modality window filter, derived sample
         // schedule. Convert each window to ns once and compare in integer.
         const std::uint64_t gyroAveragingWindowNs =
-            static_cast<std::uint64_t>(alg_.getGyroAveragingWindow() * 1.0e9);
+            static_cast<std::uint64_t>(this->alg.getGyroAveragingWindow() * 1.0e9);
         const std::uint64_t accelAveragingWindowNs =
-            static_cast<std::uint64_t>(alg_.getAccelAveragingWindow() * 1.0e9);
+            static_cast<std::uint64_t>(this->alg.getAccelAveragingWindow() * 1.0e9);
 
         std::uint64_t maxSlotMeasTime = 0U;
-        for (auto const& slot : ring_) {
+        for (auto const& slot : this->ring) {
             if (slot.isValid && (slot.measTime > maxSlotMeasTime)) {
                 maxSlotMeasTime = slot.measTime;
             }
@@ -59,15 +58,14 @@ class ReferenceAverager {
         }
 
         const std::uint64_t maxTimeTag =
-            maxSlotMeasTime
-            + ((MAX_MIMU_SAMPLES_PER_PKT_C - 1U) * AverageMimuDataAlgorithm::kMimuSamplePeriodNs);
+            maxSlotMeasTime + ((MAX_MIMU_SAMPLES_PER_PKT_C - 1U) * AverageMimuDataAlgorithm::kMimuSamplePeriodNs);
 
         Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
         Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
         std::uint64_t gyroAvgCount = 0U;
         std::uint64_t accelAvgCount = 0U;
 
-        for (auto const& slot : ring_) {
+        for (auto const& slot : this->ring) {
             if (!slot.isValid) {
                 continue;
             }
@@ -88,11 +86,11 @@ class ReferenceAverager {
 
         if (gyroAvgCount > 0U) {
             gyroSum_P /= static_cast<float>(gyroAvgCount);
-            out.gyroOmega_B = alg_.getDcmPltfToBdy() * gyroSum_P;
+            out.gyroOmega_B = this->alg.getDcmPltfToBdy() * gyroSum_P;
         }
         if (accelAvgCount > 0U) {
             accelSum_P /= static_cast<float>(accelAvgCount);
-            out.accel_B = alg_.getDcmPltfToBdy() * accelSum_P;
+            out.accel_B = this->alg.getDcmPltfToBdy() * accelSum_P;
         }
 
         return out;
@@ -105,10 +103,10 @@ class ReferenceAverager {
         std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT_C> samples{};
     };
 
-    AverageMimuDataAlgorithm const& alg_;
-    std::array<RingPacket, AverageMimuDataAlgorithm::kRingCapacity> ring_{};
-    std::size_t insertIdx_{0U};
-    std::uint64_t lastIngestedMaxMeasTime_{0U};
+    AverageMimuDataAlgorithm const& alg;
+    std::array<RingPacket, AverageMimuDataAlgorithm::kRingCapacity> ring{};
+    std::size_t insertIdx{0U};
+    std::uint64_t lastIngestedMaxMeasTime{0U};
 };
 
 /*! @brief Fill packet `p` of `in` with the given first-sample timestamp and

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -49,6 +49,7 @@ struct InputData {
     uint64_t measTime = 0U;
     Vec3Arr gyro_P{{0.0F, 0.0F, 0.0F}};
     Vec3Arr accel_P{{0.0F, 0.0F, 0.0F}};
+    bool isValid = false;
 };
 
 inline void regressionTestAverageMimuData(std::size_t N,
@@ -66,12 +67,14 @@ inline void regressionTestAverageMimuData(std::size_t N,
     // The rest are neutral so they cannot affect maxTimeTag or the average.
     InputPktsData in{};
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.isValid[i] = false;
         in.measTime[i] = 0U;
         in.gyro_P[i] = Eigen::Vector3f::Zero();
         in.accel_P[i] = Eigen::Vector3f::Zero();
     }
 
     for (std::size_t i = 0; i < N; ++i) {
+        in.isValid[i] = input[i].isValid;
         in.measTime[i] = input[i].measTime;
         in.gyro_P[i] = toVec3(input[i].gyro_P);
         in.accel_P[i] = toVec3(input[i].accel_P);

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -14,7 +14,7 @@
 /*! @brief Independent reimplementation of AverageMimuDataAlgorithm's two-phase
  *  update used by the regression and fuzz harnesses. Holds its own ring with
  *  the same capacity as the algorithm so cross-cycle behavior matches
- *  bit-for-bit. The averagingWindow and dcm_BP are read from the algorithm
+ *  bit-for-bit. The gyroAveragingWindow and dcm_BP are read from the algorithm
  *  via getters at each update() call. */
 class ReferenceAverager {
    public:
@@ -41,8 +41,8 @@ class ReferenceAverager {
 
         // Phase 2: max-tail-time + window filter, derived sample schedule.
         // Convert the algorithm's window to ns once and compare in integer.
-        const std::uint64_t averagingWindowNs =
-            static_cast<std::uint64_t>(alg_.getAveragingWindow() * 1.0e9);
+        const std::uint64_t gyroAveragingWindowNs =
+            static_cast<std::uint64_t>(alg_.getGyroAveragingWindow() * 1.0e9);
 
         std::uint64_t maxSlotMeasTime = 0U;
         for (auto const& slot : ring_) {
@@ -71,7 +71,7 @@ class ReferenceAverager {
             for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT_C; ++s) {
                 const std::uint64_t sampleMeasTime =
                     slot.measTime + (s * AverageMimuDataAlgorithm::kMimuSamplePeriodNs);
-                if ((maxTimeTag - sampleMeasTime) <= averagingWindowNs) {
+                if ((maxTimeTag - sampleMeasTime) <= gyroAveragingWindowNs) {
                     gyroSum_P += slot.samples[s].gyro_P;
                     accelSum_P += slot.samples[s].accel_P;
                     measAvgCount++;
@@ -120,7 +120,7 @@ inline void fillPacket(InputPktsData& in,
 inline void regressionTestAverageMimuData(float window, InputPktsData const& in) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(window);
+    alg.setGyroAveragingWindow(window);
 
     ReferenceAverager ref(alg);
 
@@ -138,7 +138,7 @@ inline void regressionTestAverageMimuData(float window, InputPktsData const& in)
 inline void sequencedRegressionTestAverageMimuData(float window, std::vector<InputPktsData> const& frames) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(window);
+    alg.setGyroAveragingWindow(window);
 
     ReferenceAverager ref(alg);
 

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -8,64 +8,113 @@
 #include <architecture/utilities/macroDefinitions.h>
 #include <gtest/gtest.h>
 
-#include <cstdint>
+#include <array>
 #include <vector>
 
-OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const AverageMimuDataAlgorithm& alg) {
-    // Mirrors the algorithm's staleness rule: a sample is fresh only when its
-    // packet's isValid is true AND its measTime is non-zero.
-    uint64_t maxTimeTag = 0U;
-    for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
-        if (!localPkts.isValid[p]) {
-            continue;
+/*! @brief Independent reimplementation of AverageMimuDataAlgorithm's two-phase
+ *  update used by the regression and fuzz harnesses. Holds its own ring with
+ *  the same capacity as the algorithm so cross-cycle behavior matches
+ *  bit-for-bit. The averagingWindow and dcm_BP are read from the algorithm
+ *  via getters at each update() call. */
+class ReferenceAverager {
+   public:
+    explicit ReferenceAverager(AverageMimuDataAlgorithm const& alg) : alg_(alg) {}
+
+    OutputAverageAccelAngleVel update(InputPktsData const& localPkts) {
+        // Phase 1: ingest. Freeze prior max for the duration of this call.
+        const std::uint64_t priorMax = lastIngestedMaxMeasTime_;
+        for (auto const& packet : localPkts.packets) {
+            if (!packet.isValid) {
+                continue;
+            }
+            const std::uint64_t firstSampleTime = packet.measTime;
+            if ((firstSampleTime == 0U) || (firstSampleTime <= priorMax)) {
+                continue;
+            }
+
+            ring_[insertIdx_].isValid = true;
+            ring_[insertIdx_].measTime = firstSampleTime;
+            ring_[insertIdx_].samples = packet.samples;
+            insertIdx_ = (insertIdx_ + 1U) % AverageMimuDataAlgorithm::kRingCapacity;
+            lastIngestedMaxMeasTime_ = std::max(lastIngestedMaxMeasTime_, firstSampleTime);
         }
-        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
-            if (localPkts.samples[p][s].measTime != 0U) {
-                maxTimeTag = std::max(localPkts.samples[p][s].measTime, maxTimeTag);
+
+        // Phase 2: max-tail-time + window filter, derived sample schedule.
+        // Convert the algorithm's window to ns once and compare in integer.
+        const std::uint64_t averagingWindowNs =
+            static_cast<std::uint64_t>(alg_.getAveragingWindow() * 1.0e9);
+
+        std::uint64_t maxSlotMeasTime = 0U;
+        for (auto const& slot : ring_) {
+            if (slot.isValid && (slot.measTime > maxSlotMeasTime)) {
+                maxSlotMeasTime = slot.measTime;
             }
         }
-    }
 
-    OutputAverageAccelAngleVel out{};
-    if (maxTimeTag == 0U) {
+        OutputAverageAccelAngleVel out{};
+        if (maxSlotMeasTime == 0U) {
+            return out;
+        }
+
+        const std::uint64_t maxTimeTag =
+            maxSlotMeasTime
+            + ((MAX_MIMU_SAMPLES_PER_PKT_C - 1U) * AverageMimuDataAlgorithm::kMimuSamplePeriodNs);
+
+        Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
+        Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
+        std::uint64_t measAvgCount = 0U;
+
+        for (auto const& slot : ring_) {
+            if (!slot.isValid) {
+                continue;
+            }
+            for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT_C; ++s) {
+                const std::uint64_t sampleMeasTime =
+                    slot.measTime + (s * AverageMimuDataAlgorithm::kMimuSamplePeriodNs);
+                if ((maxTimeTag - sampleMeasTime) <= averagingWindowNs) {
+                    gyroSum_P += slot.samples[s].gyro_P;
+                    accelSum_P += slot.samples[s].accel_P;
+                    measAvgCount++;
+                }
+            }
+        }
+
+        if (measAvgCount > 0U) {
+            gyroSum_P /= static_cast<float>(measAvgCount);
+            accelSum_P /= static_cast<float>(measAvgCount);
+            out.gyroOmega_B = alg_.getDcmPltfToBdy() * gyroSum_P;
+            out.accel_B = alg_.getDcmPltfToBdy() * accelSum_P;
+        }
+
         return out;
     }
 
-    // Match the algorithm: convert window to ns once and compare integer-to-integer.
-    const std::uint64_t averagingWindowNs =
-        static_cast<std::uint64_t>(static_cast<double>(alg.getAveragingWindow()) * 1.0e9);
+   private:
+    struct RingPacket {
+        bool isValid{false};
+        std::uint64_t measTime{0U};
+        std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT_C> samples{};
+    };
 
-    Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
-    Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
-    uint64_t measAvgCount = 0U;
+    AverageMimuDataAlgorithm const& alg_;
+    std::array<RingPacket, AverageMimuDataAlgorithm::kRingCapacity> ring_{};
+    std::size_t insertIdx_{0U};
+    std::uint64_t lastIngestedMaxMeasTime_{0U};
+};
 
-    for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
-        if (!localPkts.isValid[p]) {
-            continue;
-        }
-        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
-            const auto& sample = localPkts.samples[p][s];
-            if (sample.measTime == 0U) {
-                continue;
-            }
-            if ((maxTimeTag - sample.measTime) <= averagingWindowNs) {
-                gyroSum_P += sample.gyro_P;
-                accelSum_P += sample.accel_P;
-                measAvgCount++;
-            }
-        }
+/*! @brief Fill packet `p` of `in` with the given first-sample timestamp and
+ *  per-sample gyro/accel pairs. Marks the packet valid. */
+inline void fillPacket(InputPktsData& in,
+                       std::size_t p,
+                       std::uint64_t firstSampleTimeNs,
+                       std::array<Eigen::Vector3f, MAX_MIMU_SAMPLES_PER_PKT_C> const& gyros,
+                       std::array<Eigen::Vector3f, MAX_MIMU_SAMPLES_PER_PKT_C> const& accels) {
+    in.packets[p].isValid = true;
+    in.packets[p].measTime = firstSampleTimeNs;
+    for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT_C; ++s) {
+        in.packets[p].samples[s].gyro_P = gyros[s];
+        in.packets[p].samples[s].accel_P = accels[s];
     }
-
-    if (measAvgCount > 0U) {
-        gyroSum_P /= static_cast<float>(measAvgCount);
-        Eigen::Vector3f const gyroSum_B = alg.getDcmPltfToBdy() * gyroSum_P;
-        accelSum_P /= static_cast<float>(measAvgCount);
-        Eigen::Vector3f const accelSum_B = alg.getDcmPltfToBdy() * accelSum_P;
-        out.gyroOmega_B = gyroSum_B;
-        out.accel_B = accelSum_B;
-    }
-
-    return out;
 }
 
 inline void regressionTestAverageMimuData(float window, InputPktsData const& in) {
@@ -73,24 +122,29 @@ inline void regressionTestAverageMimuData(float window, InputPktsData const& in)
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setAveragingWindow(window);
 
+    ReferenceAverager ref(alg);
+
     const OutputAverageAccelAngleVel out_alg = alg.update(in);
-    const OutputAverageAccelAngleVel out_ref = referenceUpdate(in, alg);
+    const OutputAverageAccelAngleVel out_ref = ref.update(in);
 
     EXPECT_EQ(out_alg.gyroOmega_B, out_ref.gyroOmega_B);
     EXPECT_EQ(out_alg.accel_B, out_ref.accel_B);
 }
 
-/*! @brief Drives the algorithm across a sequence of ring-buffer snapshots.
- *  For each snapshot, the algorithm output is compared against referenceUpdate
- *  to catch any drift in the staleness / window-filter logic across cycles. */
+/*! @brief Drives the algorithm and the reference across a sequence of
+ *  snapshots. Both maintain their own internal ring; the cycle-by-cycle
+ *  outputs are compared to catch any drift in the staleness / window-filter
+ *  logic across cycles or in the ingestion / overflow rules. */
 inline void sequencedRegressionTestAverageMimuData(float window, std::vector<InputPktsData> const& frames) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setAveragingWindow(window);
 
+    ReferenceAverager ref(alg);
+
     for (auto const& in : frames) {
         const OutputAverageAccelAngleVel out_alg = alg.update(in);
-        const OutputAverageAccelAngleVel out_ref = referenceUpdate(in, alg);
+        const OutputAverageAccelAngleVel out_ref = ref.update(in);
 
         EXPECT_EQ(out_alg.gyroOmega_B, out_ref.gyroOmega_B);
         EXPECT_EQ(out_alg.accel_B, out_ref.accel_B);

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -3,10 +3,12 @@
 
 #include "averageMimuDataAlgorithm.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/freestandingInvalidArgument.h"
 
 #include <architecture/utilities/macroDefinitions.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <vector>
 
 OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const AverageMimuDataAlgorithm& alg) {
@@ -29,6 +31,10 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const
         return out;
     }
 
+    // Match the algorithm: convert window to ns once and compare integer-to-integer.
+    const std::uint64_t averagingWindowNs =
+        static_cast<std::uint64_t>(static_cast<double>(alg.getAveragingWindow()) * 1.0e9);
+
     Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
     Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
     uint64_t measAvgCount = 0U;
@@ -42,7 +48,7 @@ OutputAverageAccelAngleVel referenceUpdate(InputPktsData const& localPkts, const
             if (sample.measTime == 0U) {
                 continue;
             }
-            if (static_cast<float>(maxTimeTag - sample.measTime) * NANO2SEC <= alg.getAveragingWindow()) {
+            if ((maxTimeTag - sample.measTime) <= averagingWindowNs) {
                 gyroSum_P += sample.gyro_P;
                 accelSum_P += sample.accel_P;
                 measAvgCount++;

--- a/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
+++ b/algorithms/averageMimuData/_tests/averageMimuDataTestHelpers.hpp
@@ -126,11 +126,11 @@ inline void fillPacket(InputPktsData& in,
     }
 }
 
-inline void regressionTestAverageMimuData(float window, InputPktsData const& in) {
+inline void regressionTestAverageMimuDataWindows(float gyroWindow, float accelWindow, InputPktsData const& in) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setGyroAveragingWindow(window);
-    alg.setAccelAveragingWindow(window);
+    alg.setGyroAveragingWindow(gyroWindow);
+    alg.setAccelAveragingWindow(accelWindow);
 
     ReferenceAverager ref(alg);
 
@@ -141,15 +141,21 @@ inline void regressionTestAverageMimuData(float window, InputPktsData const& in)
     EXPECT_EQ(out_alg.accel_B, out_ref.accel_B);
 }
 
+inline void regressionTestAverageMimuData(float window, InputPktsData const& in) {
+    regressionTestAverageMimuDataWindows(window, window, in);
+}
+
 /*! @brief Drives the algorithm and the reference across a sequence of
  *  snapshots. Both maintain their own internal ring; the cycle-by-cycle
  *  outputs are compared to catch any drift in the staleness / window-filter
  *  logic across cycles or in the ingestion / overflow rules. */
-inline void sequencedRegressionTestAverageMimuData(float window, std::vector<InputPktsData> const& frames) {
+inline void sequencedRegressionTestAverageMimuDataWindows(float gyroWindow,
+                                                          float accelWindow,
+                                                          std::vector<InputPktsData> const& frames) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setGyroAveragingWindow(window);
-    alg.setAccelAveragingWindow(window);
+    alg.setGyroAveragingWindow(gyroWindow);
+    alg.setAccelAveragingWindow(accelWindow);
 
     ReferenceAverager ref(alg);
 
@@ -160,6 +166,10 @@ inline void sequencedRegressionTestAverageMimuData(float window, std::vector<Inp
         EXPECT_EQ(out_alg.gyroOmega_B, out_ref.gyroOmega_B);
         EXPECT_EQ(out_alg.accel_B, out_ref.accel_B);
     }
+}
+
+inline void sequencedRegressionTestAverageMimuData(float window, std::vector<InputPktsData> const& frames) {
+    sequencedRegressionTestAverageMimuDataWindows(window, window, frames);
 }
 
 #endif

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -44,6 +44,7 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
     dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;  // 90 deg about +Z
     alg.setDcmPltfToBdy(dcm_BP);
     alg.setGyroAveragingWindow(0.035);
+    alg.setAccelAveragingWindow(0.035);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -77,6 +78,7 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
     alg.setDcmPltfToBdy(dcm_BP);
     alg.setGyroAveragingWindow(0.0);
+    alg.setAccelAveragingWindow(0.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -97,6 +99,7 @@ TEST(averageMimuDataTest, EmptyRingReturnsZero) {
     // No valid packets in the snapshot -> ring stays empty -> zero output.
     AverageMimuDataAlgorithm alg;
     alg.setGyroAveragingWindow(0.5);
+    alg.setAccelAveragingWindow(0.5);
 
     InputPktsData const in{};
     const auto [accel_B, gyroOmega_B] = alg.update(in);
@@ -110,6 +113,7 @@ TEST(averageMimuDataTest, ZeroMeasTimePacketSkipped) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(1.0);
+    alg.setAccelAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -130,6 +134,7 @@ TEST(averageMimuDataTest, InvalidPacketSkipsAllItsSamples) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(1.0);
+    alg.setAccelAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyrosLoud{};
@@ -162,6 +167,7 @@ TEST(averageMimuDataTest, AveragesAcrossMultiplePackets) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(1.0);
+    alg.setAccelAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> g0{};
@@ -191,6 +197,7 @@ TEST(averageMimuDataTest, RingBufferFillSequence) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(1.0);
+    alg.setAccelAveragingWindow(1.0);
 
     ReferenceAverager ref(alg);
 
@@ -262,6 +269,7 @@ TEST(averageMimuDataTest, StrictMonotonicDropsRepeatedSnapshot) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(1.0);
+    alg.setAccelAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -284,6 +292,7 @@ TEST(averageMimuDataTest, OverflowOverwritesOldest) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec));
+    alg.setAccelAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec));
 
     constexpr std::size_t kPacketsToFeed = AverageMimuDataAlgorithm::kRingCapacity + 2U;
     constexpr uint64_t packetSpan = kSamplesPerPkt * kPeriodNs;
@@ -323,6 +332,7 @@ TEST(averageMimuDataTest, EmptySnapshotReEmitsRingAverage) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(1.0);
+    alg.setAccelAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -346,6 +356,7 @@ TEST(averageMimuDataTest, WindowShrinkMidStream) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(1.0);
+    alg.setAccelAveragingWindow(1.0);
 
     InputPktsData in1{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gOld{};
@@ -367,6 +378,7 @@ TEST(averageMimuDataTest, WindowShrinkMidStream) {
     // Tighten window so the old packet's samples (all > 100 ms older than
     // maxTimeTag) drop out. New packet's 10 samples all qualify.
     alg.setGyroAveragingWindow(0.1);
+    alg.setAccelAveragingWindow(0.1);
     InputPktsData empty{};
     const OutputAverageAccelAngleVel out = alg.update(empty);
     EXPECT_EQ(out.gyroOmega_B, gNew[0]);
@@ -378,6 +390,7 @@ TEST(averageMimuDataTest, WindowGrowMidStream) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(0.1);
+    alg.setAccelAveragingWindow(0.1);
 
     InputPktsData in1{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gOld{};
@@ -400,6 +413,7 @@ TEST(averageMimuDataTest, WindowGrowMidStream) {
 
     // Grow window so both packets' samples qualify.
     alg.setGyroAveragingWindow(1.0);
+    alg.setAccelAveragingWindow(1.0);
     InputPktsData empty{};
     const OutputAverageAccelAngleVel out_wide = alg.update(empty);
 
@@ -412,6 +426,7 @@ TEST(averageMimuDataTest, OutOfOrderPacketDropped) {
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setGyroAveragingWindow(1.0);
+    alg.setAccelAveragingWindow(1.0);
 
     InputPktsData in1{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gOk{};

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -269,6 +269,87 @@ TEST(averageMimuDataTest, AveragesAcrossMultiplePackets) {
     EXPECT_EQ(out.accel_B, accExpected);
 }
 
+TEST(averageMimuDataTest, RingBufferFillSequence) {
+    // Drive the algorithm across multiple sequential update() calls the way a
+    // host ring buffer would: start empty, fill packet by packet, then wrap
+    // and tighten the window. Each step compares output against the
+    // hand-computed mean of the currently-fresh samples.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(10.0f);  // wide window: every fresh sample qualifies
+
+    constexpr uint64_t t_ref = SEC2NANO;
+
+    // Pre-build a deterministic 4 x MAX_MIMU_SAMPLES_PER_PKT grid of samples.
+    std::array<std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT>, MAX_MIMU_PKT> grid{};
+    for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
+        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
+            const auto offsetNs =
+                static_cast<uint64_t>(SEC2NANO * 0.001f * static_cast<float>((p * MAX_MIMU_SAMPLES_PER_PKT) + s));
+            grid[p][s].measTime = t_ref + offsetNs;
+            const float fp = static_cast<float>(p);
+            const float fs = static_cast<float>(s);
+            grid[p][s].gyro_P = Eigen::Vector3f{fp, fs, fp + fs};
+            grid[p][s].accel_P = Eigen::Vector3f{fp + 1.f, fs + 1.f, fp - fs};
+        }
+    }
+
+    InputPktsData in{};
+
+    // Step 1: empty buffer -> zero output.
+    {
+        const OutputAverageAccelAngleVel out = alg.update(in);
+        EXPECT_EQ(out.gyroOmega_B, Eigen::Vector3f::Zero());
+        EXPECT_EQ(out.accel_B, Eigen::Vector3f::Zero());
+    }
+
+    // Step 2..5: mark packets valid one at a time and fill all their samples.
+    Eigen::Vector3f gyroSum = Eigen::Vector3f::Zero();
+    Eigen::Vector3f accelSum = Eigen::Vector3f::Zero();
+    std::size_t sampleCount = 0;
+    for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
+        in.isValid[p] = true;
+        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
+            in.samples[p][s] = grid[p][s];
+            gyroSum += grid[p][s].gyro_P;
+            accelSum += grid[p][s].accel_P;
+            sampleCount++;
+        }
+        const Eigen::Vector3f gyroExpected = gyroSum / static_cast<float>(sampleCount);
+        const Eigen::Vector3f accelExpected = accelSum / static_cast<float>(sampleCount);
+        const OutputAverageAccelAngleVel out = alg.update(in);
+        EXPECT_EQ(out.gyroOmega_B, gyroExpected) << "after filling packet " << p;
+        EXPECT_EQ(out.accel_B, accelExpected) << "after filling packet " << p;
+    }
+
+    // Step 6: wrap. Overwrite packet 0[0] with a much newer sample. The new
+    // sample owns maxTimeTag; with the wide window every other fresh sample
+    // still qualifies, so the mean simply swaps the old packet 0[0] for the
+    // new one.
+    const uint64_t wrapTime = t_ref + static_cast<uint64_t>(SEC2NANO * 1.0f);
+    const Eigen::Vector3f wrapGyro{-1.f, -2.f, -3.f};
+    const Eigen::Vector3f wrapAccel{-4.f, -5.f, -6.f};
+    gyroSum = gyroSum - grid[0][0].gyro_P + wrapGyro;
+    accelSum = accelSum - grid[0][0].accel_P + wrapAccel;
+    in.samples[0][0].measTime = wrapTime;
+    in.samples[0][0].gyro_P = wrapGyro;
+    in.samples[0][0].accel_P = wrapAccel;
+    {
+        const OutputAverageAccelAngleVel out = alg.update(in);
+        EXPECT_EQ(out.gyroOmega_B, gyroSum / static_cast<float>(sampleCount));
+        EXPECT_EQ(out.accel_B, accelSum / static_cast<float>(sampleCount));
+    }
+
+    // Step 7: tighten the window so only packet 0[0] (age 0 from wrapTime)
+    // qualifies; every other sample is older by 1.0s+ which exceeds 0.1s.
+    alg.setAveragingWindow(0.1f);
+    {
+        const OutputAverageAccelAngleVel out = alg.update(in);
+        EXPECT_EQ(out.gyroOmega_B, wrapGyro);
+        EXPECT_EQ(out.accel_B, wrapAccel);
+    }
+}
+
 TEST(averageMimuDataTest, SetupTest) {
     AverageMimuDataAlgorithm alg;
 

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -71,6 +71,67 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
     EXPECT_EQ(out.accel_B, accTrue_B);
 }
 
+TEST(averageMimuDataTest, SeparateGyroAccelWindows) {
+    // One packet: 10 samples 10 ms apart (90 ms span). A wide window keeps all
+    // 10 samples; a 35 ms window keeps only samples 6..9 (ages 30/20/10/0 ms
+    // from maxTimeTag). Driving gyro and accel with different windows must make
+    // each modality average over its own sample set, independently.
+    constexpr double wide = 1.0;
+    constexpr double tight = 0.035;
+
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
+    for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
+        gyros[s] = Eigen::Vector3f{static_cast<float>(s), 2.0F * static_cast<float>(s), 3.0F * static_cast<float>(s)};
+        accels[s] = Eigen::Vector3f{4.0F, static_cast<float>(s), -static_cast<float>(s)};
+    }
+
+    // Expected means: full ring vs the 4-sample tail (samples 6..9). Summation
+    // order matches the algorithm's, so exact float equality holds.
+    Eigen::Vector3f gyroAll = Eigen::Vector3f::Zero();
+    Eigen::Vector3f accelAll = Eigen::Vector3f::Zero();
+    Eigen::Vector3f gyroTail = Eigen::Vector3f::Zero();
+    Eigen::Vector3f accelTail = Eigen::Vector3f::Zero();
+    for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
+        gyroAll += gyros[s];
+        accelAll += accels[s];
+        if (s >= 6) {
+            gyroTail += gyros[s];
+            accelTail += accels[s];
+        }
+    }
+    gyroAll /= static_cast<float>(kSamplesPerPkt);
+    accelAll /= static_cast<float>(kSamplesPerPkt);
+    gyroTail /= 4.0F;
+    accelTail /= 4.0F;
+
+    // Wide gyro window, tight accel window: gyro averages all 10, accel only 6..9.
+    {
+        AverageMimuDataAlgorithm alg;
+        alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+        alg.setGyroAveragingWindow(wide);
+        alg.setAccelAveragingWindow(tight);
+        InputPktsData in{};
+        fillPacket(in, 0, kSec2Nano, gyros, accels);
+        const auto [accel_B, gyroOmega_B] = alg.update(in);
+        EXPECT_EQ(gyroOmega_B, gyroAll);
+        EXPECT_EQ(accel_B, accelTail);
+    }
+
+    // Symmetric case: tight gyro window, wide accel window.
+    {
+        AverageMimuDataAlgorithm alg;
+        alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+        alg.setGyroAveragingWindow(tight);
+        alg.setAccelAveragingWindow(wide);
+        InputPktsData in{};
+        fillPacket(in, 0, kSec2Nano, gyros, accels);
+        const auto [accel_B, gyroOmega_B] = alg.update(in);
+        EXPECT_EQ(gyroOmega_B, gyroTail);
+        EXPECT_EQ(accel_B, accelAll);
+    }
+}
+
 TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     // window = 0 -> only the last sample (sample 9, at maxTimeTag) qualifies.
     AverageMimuDataAlgorithm alg;
@@ -242,6 +303,13 @@ TEST(averageMimuDataTest, SetupTest) {
                  fsw::invalid_argument);
     EXPECT_NO_THROW(alg.setGyroAveragingWindow(0.25));
 
+    EXPECT_THROW(alg.setAccelAveragingWindow(-0.1), fsw::invalid_argument);
+    EXPECT_NO_THROW(alg.setAccelAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec)));
+    EXPECT_THROW(alg.setAccelAveragingWindow(
+                     static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec) + 0.001),
+                 fsw::invalid_argument);
+    EXPECT_NO_THROW(alg.setAccelAveragingWindow(0.5));
+
     Eigen::Matrix3f badOrtho = Eigen::Matrix3f::Identity();
     badOrtho(0, 0) = 2.0F;
     EXPECT_THROW(alg.setDcmPltfToBdy(badOrtho), fsw::invalid_argument);
@@ -252,6 +320,7 @@ TEST(averageMimuDataTest, SetupTest) {
     EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
 
     EXPECT_DOUBLE_EQ(alg.getGyroAveragingWindow(), 0.25);
+    EXPECT_DOUBLE_EQ(alg.getAccelAveragingWindow(), 0.5);
     EXPECT_EQ(alg.getDcmPltfToBdy(), Eigen::Matrix3f::Identity());
 
     InputPktsData in{};

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -1,5 +1,6 @@
 #include "averageMimuDataTestHelpers.hpp"
 #include "utilities/fsw/freestandingInvalidArgument.h"
+#include "utilities/fsw/timeConstants.h"
 #include <gtest/gtest.h>
 
 TEST(averageMimuDataTest, RegressionTest) {
@@ -8,22 +9,22 @@ TEST(averageMimuDataTest, RegressionTest) {
     InputPktsData in{};
     in.isValid[0] = true;
 
-    constexpr uint64_t t_ref = SEC2NANO;
+    constexpr uint64_t t_ref = kSec2Nano;
 
     // Four samples within packet 0 at four distinct timestamps.
     in.samples[0][0].measTime = t_ref;
     in.samples[0][0].gyro_P = Eigen::Vector3f{0.1F, 0.3F, -0.1F};
     in.samples[0][0].accel_P = Eigen::Vector3f{0.5F, -0.2F, 2.0F};
 
-    in.samples[0][1].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.6F);
+    in.samples[0][1].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.6F);
     in.samples[0][1].gyro_P = Eigen::Vector3f{1.1F, 0.8F, 0.7F};
     in.samples[0][1].accel_P = Eigen::Vector3f{11.5F, -0.2F, 6.0F};
 
-    in.samples[0][2].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.2F);
+    in.samples[0][2].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.2F);
     in.samples[0][2].gyro_P = Eigen::Vector3f{-0.3F, -4.3F, -6.1F};
     in.samples[0][2].accel_P = Eigen::Vector3f{-0.9F, -0.2F, -2.4F};
 
-    in.samples[0][3].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.3F);
+    in.samples[0][3].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.3F);
     in.samples[0][3].gyro_P = Eigen::Vector3f{7.1F, -0.9F, -0.0F};
     in.samples[0][3].accel_P = Eigen::Vector3f{-80.5F, 0.4F, 2.8F};
 
@@ -46,11 +47,11 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
     InputPktsData in{};
     in.isValid[0] = true;
 
-    constexpr uint64_t t_ref = SEC2NANO;
+    constexpr uint64_t t_ref = kSec2Nano;
     const uint64_t t0 = t_ref;
-    const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
-    const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
-    const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
+    const uint64_t t1 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.05f);
+    const uint64_t t2 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.15f);
+    const uint64_t t3 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.30f);
 
     const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
     const Eigen::Vector3f gyro1{3.f, 2.f, 1.f};
@@ -101,11 +102,11 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     InputPktsData in{};
     in.isValid[0] = true;
 
-    constexpr uint64_t t_ref = SEC2NANO;
+    constexpr uint64_t t_ref = kSec2Nano;
     const uint64_t t0 = t_ref;  // unique max
-    const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
-    const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
-    const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
+    const uint64_t t1 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.05f);
+    const uint64_t t2 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.15f);
+    const uint64_t t3 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.30f);
 
     const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
     const Eigen::Vector3f gyro1{3.f, 2.f, 1.f};
@@ -156,7 +157,7 @@ TEST(averageMimuDataTest, FirstFillZeroMeasTimeRegression) {
 
     const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
     const Eigen::Vector3f acc0{4.f, 5.f, 6.f};
-    in.samples[0][0].measTime = SEC2NANO;
+    in.samples[0][0].measTime = kSec2Nano;
     in.samples[0][0].gyro_P = gyro0;
     in.samples[0][0].accel_P = acc0;
 
@@ -188,7 +189,7 @@ TEST(averageMimuDataTest, ValidFlagButZeroMeasTimeIsStale) {
 
     const Eigen::Vector3f gyro0{1.f, 0.f, 0.f};
     const Eigen::Vector3f acc0{0.f, 1.f, 0.f};
-    in.samples[0][0].measTime = SEC2NANO;
+    in.samples[0][0].measTime = kSec2Nano;
     in.samples[0][0].gyro_P = gyro0;
     in.samples[0][0].accel_P = acc0;
 
@@ -214,7 +215,7 @@ TEST(averageMimuDataTest, InvalidPacketSkipsAllItsSamples) {
     in.isValid[0] = false;  // valid samples but packet is invalid -> skipped
     in.isValid[1] = true;
 
-    constexpr uint64_t t_ref = SEC2NANO;
+    constexpr uint64_t t_ref = kSec2Nano;
     in.samples[0][0].measTime = t_ref;
     in.samples[0][0].gyro_P = Eigen::Vector3f{99.f, 99.f, 99.f};
     in.samples[0][0].accel_P = Eigen::Vector3f{99.f, 99.f, 99.f};
@@ -241,7 +242,7 @@ TEST(averageMimuDataTest, AveragesAcrossMultiplePackets) {
     in.isValid[0] = true;
     in.isValid[2] = true;
 
-    constexpr uint64_t t_ref = SEC2NANO;
+    constexpr uint64_t t_ref = kSec2Nano;
     const Eigen::Vector3f g_a{1.f, 0.f, 0.f};
     const Eigen::Vector3f g_b{0.f, 1.f, 0.f};
     const Eigen::Vector3f g_c{0.f, 0.f, 1.f};
@@ -253,11 +254,11 @@ TEST(averageMimuDataTest, AveragesAcrossMultiplePackets) {
     in.samples[0][0].gyro_P = g_a;
     in.samples[0][0].accel_P = a_a;
 
-    in.samples[0][5].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
+    in.samples[0][5].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.05f);
     in.samples[0][5].gyro_P = g_b;
     in.samples[0][5].accel_P = a_b;
 
-    in.samples[2][3].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.10f);
+    in.samples[2][3].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.10f);
     in.samples[2][3].gyro_P = g_c;
     in.samples[2][3].accel_P = a_c;
 
@@ -278,14 +279,14 @@ TEST(averageMimuDataTest, RingBufferFillSequence) {
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setAveragingWindow(10.0f);  // wide window: every fresh sample qualifies
 
-    constexpr uint64_t t_ref = SEC2NANO;
+    constexpr uint64_t t_ref = kSec2Nano;
 
     // Pre-build a deterministic 4 x MAX_MIMU_SAMPLES_PER_PKT grid of samples.
     std::array<std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT>, MAX_MIMU_PKT> grid{};
     for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
         for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
             const auto offsetNs =
-                static_cast<uint64_t>(SEC2NANO * 0.001f * static_cast<float>((p * MAX_MIMU_SAMPLES_PER_PKT) + s));
+                static_cast<uint64_t>(kSec2Nano * 0.001f * static_cast<float>((p * MAX_MIMU_SAMPLES_PER_PKT) + s));
             grid[p][s].measTime = t_ref + offsetNs;
             const float fp = static_cast<float>(p);
             const float fs = static_cast<float>(s);
@@ -326,7 +327,7 @@ TEST(averageMimuDataTest, RingBufferFillSequence) {
     // sample owns maxTimeTag; with the wide window every other fresh sample
     // still qualifies, so the mean simply swaps the old packet 0[0] for the
     // new one.
-    const uint64_t wrapTime = t_ref + static_cast<uint64_t>(SEC2NANO * 1.0f);
+    const uint64_t wrapTime = t_ref + static_cast<uint64_t>(kSec2Nano * 1.0f);
     const Eigen::Vector3f wrapGyro{-1.f, -2.f, -3.f};
     const Eigen::Vector3f wrapAccel{-4.f, -5.f, -6.f};
     gyroSum = gyroSum - grid[0][0].gyro_P + wrapGyro;
@@ -371,7 +372,7 @@ TEST(averageMimuDataTest, SetupTest) {
 
     InputPktsData in{};
     in.isValid[0] = true;
-    in.samples[0][0].measTime = SEC2NANO;
+    in.samples[0][0].measTime = kSec2Nano;
     in.samples[0][0].gyro_P = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
     in.samples[0][0].accel_P = Eigen::Vector3f(4.0f, 5.0f, 6.0f);
 

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -43,7 +43,7 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
     Eigen::Matrix3f dcm_BP;
     dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;  // 90 deg about +Z
     alg.setDcmPltfToBdy(dcm_BP);
-    alg.setAveragingWindow(0.035);
+    alg.setGyroAveragingWindow(0.035);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -76,7 +76,7 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     Eigen::Matrix3f dcm_BP;
     dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
     alg.setDcmPltfToBdy(dcm_BP);
-    alg.setAveragingWindow(0.0);
+    alg.setGyroAveragingWindow(0.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -96,7 +96,7 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
 TEST(averageMimuDataTest, EmptyRingReturnsZero) {
     // No valid packets in the snapshot -> ring stays empty -> zero output.
     AverageMimuDataAlgorithm alg;
-    alg.setAveragingWindow(0.5);
+    alg.setGyroAveragingWindow(0.5);
 
     InputPktsData const in{};
     const auto [accel_B, gyroOmega_B] = alg.update(in);
@@ -109,7 +109,7 @@ TEST(averageMimuDataTest, ZeroMeasTimePacketSkipped) {
     // A packet with isValid=true but measTime=0 is dropped at ingest.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0);
+    alg.setGyroAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -129,7 +129,7 @@ TEST(averageMimuDataTest, InvalidPacketSkipsAllItsSamples) {
     // isValid=false -> packet skipped entirely even if measTime / samples set.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0);
+    alg.setGyroAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyrosLoud{};
@@ -161,7 +161,7 @@ TEST(averageMimuDataTest, AveragesAcrossMultiplePackets) {
     // Two valid packets ingested in one snapshot, wide window includes all.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0);
+    alg.setGyroAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> g0{};
@@ -190,7 +190,7 @@ TEST(averageMimuDataTest, RingBufferFillSequence) {
     // overflow into the wrap. Compares against the reference each cycle.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0);
+    alg.setGyroAveragingWindow(1.0);
 
     ReferenceAverager ref(alg);
 
@@ -228,12 +228,12 @@ TEST(averageMimuDataTest, RingBufferFillSequence) {
 TEST(averageMimuDataTest, SetupTest) {
     AverageMimuDataAlgorithm alg;
 
-    EXPECT_THROW(alg.setAveragingWindow(-0.1), fsw::invalid_argument);
-    EXPECT_NO_THROW(alg.setAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec)));
-    EXPECT_THROW(alg.setAveragingWindow(
+    EXPECT_THROW(alg.setGyroAveragingWindow(-0.1), fsw::invalid_argument);
+    EXPECT_NO_THROW(alg.setGyroAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec)));
+    EXPECT_THROW(alg.setGyroAveragingWindow(
                      static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec) + 0.001),
                  fsw::invalid_argument);
-    EXPECT_NO_THROW(alg.setAveragingWindow(0.25));
+    EXPECT_NO_THROW(alg.setGyroAveragingWindow(0.25));
 
     Eigen::Matrix3f badOrtho = Eigen::Matrix3f::Identity();
     badOrtho(0, 0) = 2.0F;
@@ -244,7 +244,7 @@ TEST(averageMimuDataTest, SetupTest) {
     EXPECT_THROW(alg.setDcmPltfToBdy(badDet), fsw::invalid_argument);
     EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
 
-    EXPECT_DOUBLE_EQ(alg.getAveragingWindow(), 0.25);
+    EXPECT_DOUBLE_EQ(alg.getGyroAveragingWindow(), 0.25);
     EXPECT_EQ(alg.getDcmPltfToBdy(), Eigen::Matrix3f::Identity());
 
     InputPktsData in{};
@@ -261,7 +261,7 @@ TEST(averageMimuDataTest, StrictMonotonicDropsRepeatedSnapshot) {
     // Re-feeding the exact same snapshot must not double-count.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0);
+    alg.setGyroAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -283,7 +283,7 @@ TEST(averageMimuDataTest, OverflowOverwritesOldest) {
     // Drive kRingCapacity + 2 monotonically-newer single-packet snapshots.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec));
+    alg.setGyroAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec));
 
     constexpr std::size_t kPacketsToFeed = AverageMimuDataAlgorithm::kRingCapacity + 2U;
     constexpr uint64_t packetSpan = kSamplesPerPkt * kPeriodNs;
@@ -322,7 +322,7 @@ TEST(averageMimuDataTest, EmptySnapshotReEmitsRingAverage) {
     // average without ingesting anything new.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0);
+    alg.setGyroAveragingWindow(1.0);
 
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
@@ -345,7 +345,7 @@ TEST(averageMimuDataTest, WindowShrinkMidStream) {
     // the newer packet over the same ring contents.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0);
+    alg.setGyroAveragingWindow(1.0);
 
     InputPktsData in1{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gOld{};
@@ -366,7 +366,7 @@ TEST(averageMimuDataTest, WindowShrinkMidStream) {
 
     // Tighten window so the old packet's samples (all > 100 ms older than
     // maxTimeTag) drop out. New packet's 10 samples all qualify.
-    alg.setAveragingWindow(0.1);
+    alg.setGyroAveragingWindow(0.1);
     InputPktsData empty{};
     const OutputAverageAccelAngleVel out = alg.update(empty);
     EXPECT_EQ(out.gyroOmega_B, gNew[0]);
@@ -377,7 +377,7 @@ TEST(averageMimuDataTest, WindowGrowMidStream) {
     // Dual of WindowShrinkMidStream.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(0.1);
+    alg.setGyroAveragingWindow(0.1);
 
     InputPktsData in1{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gOld{};
@@ -399,7 +399,7 @@ TEST(averageMimuDataTest, WindowGrowMidStream) {
     EXPECT_EQ(out_tight.accel_B, aNew[0]);
 
     // Grow window so both packets' samples qualify.
-    alg.setAveragingWindow(1.0);
+    alg.setGyroAveragingWindow(1.0);
     InputPktsData empty{};
     const OutputAverageAccelAngleVel out_wide = alg.update(empty);
 
@@ -411,7 +411,7 @@ TEST(averageMimuDataTest, OutOfOrderPacketDropped) {
     // A packet whose measTime <= the prior max is dropped at ingest.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0);
+    alg.setGyroAveragingWindow(1.0);
 
     InputPktsData in1{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gOk{};

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -12,21 +12,25 @@ TEST(averageMimuDataTest, RegressionTest) {
     constexpr uint64_t t_ref = SEC2NANO;
 
     // Packet 0 (newest)
+    input[0].isValid = true;
     input[0].measTime = t_ref;
     input[0].gyro_P = Vec3Arr{0.1F, 0.3F, -0.1F};
     input[0].accel_P = Vec3Arr{0.5F, -0.2F, 2.0F};
 
     // Packet 1 (older by 0.6s)
+    input[1].isValid = true;
     input[1].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.6F);
     input[1].gyro_P = Vec3Arr{1.1F, 0.8F, 0.7F};
     input[1].accel_P = Vec3Arr{11.5F, -0.2F, 6.0F};
 
     // Packet 2 (older by 0.2s)
+    input[2].isValid = true;
     input[2].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.2F);
     input[2].gyro_P = Vec3Arr{-0.3F, -4.3F, -6.1F};
     input[2].accel_P = Vec3Arr{-0.9F, -0.2F, -2.4F};
 
     // Packet 3 (older by 0.3s)
+    input[3].isValid = true;
     input[3].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.3F);
     input[3].gyro_P = Vec3Arr{7.1F, -0.9F, -0.0F};
     input[3].accel_P = Vec3Arr{-80.5F, 0.4F, 2.8F};
@@ -61,6 +65,7 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
 
     // zero everything (Eigen::Vector3f default in std::array is uninitialized)
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.isValid[i] = false;
         in.measTime[i] = 0U;
         in.gyro_P[i] = Eigen::Vector3f::Zero();
         in.accel_P[i] = Eigen::Vector3f::Zero();
@@ -87,15 +92,19 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
     const Eigen::Vector3f acc3{8.f, 8.f, 8.f};  // excluded by averagingWindow
 
     // Put packets in the first few slots
+    in.isValid[0] = true;
     in.measTime[0] = t0;
     in.gyro_P[0] = gyro0;
     in.accel_P[0] = acc0;
+    in.isValid[1] = true;
     in.measTime[1] = t1;
     in.gyro_P[1] = gyro1;
     in.accel_P[1] = acc1;
+    in.isValid[2] = true;
     in.measTime[2] = t2;
     in.gyro_P[2] = gyro2;
     in.accel_P[2] = acc2;
+    in.isValid[3] = true;
     in.measTime[3] = t3;
     in.gyro_P[3] = gyro3;
     in.accel_P[3] = acc3;
@@ -140,6 +149,7 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     InputPktsData in{};
 
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.isValid[i] = false;
         in.measTime[i] = 0U;
         in.gyro_P[i] = Eigen::Vector3f::Zero();
         in.accel_P[i] = Eigen::Vector3f::Zero();
@@ -163,15 +173,19 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
     const Eigen::Vector3f acc3{8.f, 8.f, 8.f};
 
+    in.isValid[0] = true;
     in.measTime[0] = t0;
     in.gyro_P[0] = gyro0;
     in.accel_P[0] = acc0;
+    in.isValid[1] = true;
     in.measTime[1] = t1;
     in.gyro_P[1] = gyro1;
     in.accel_P[1] = acc1;
+    in.isValid[2] = true;
     in.measTime[2] = t2;
     in.gyro_P[2] = gyro2;
     in.accel_P[2] = acc2;
+    in.isValid[3] = true;
     in.measTime[3] = t3;
     in.gyro_P[3] = gyro3;
     in.accel_P[3] = acc3;
@@ -215,12 +229,14 @@ TEST(averageMimuDataTest, SetupTest) {
     // 3) update() should not throw for a basic input
     InputPktsData in{};
     for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
+        in.isValid[i] = false;
         in.measTime[i] = 0U;
         in.gyro_P[i] = Eigen::Vector3f::Zero();
         in.accel_P[i] = Eigen::Vector3f::Zero();
     }
 
     // Add one non-zero packet so we exercise the averaging path
+    in.isValid[0] = true;
     in.measTime[0] = SEC2NANO;
     in.gyro_P[0] = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
     in.accel_P[0] = Eigen::Vector3f(4.0f, 5.0f, 6.0f);

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -3,173 +3,100 @@
 #include "utilities/fsw/timeConstants.h"
 #include <gtest/gtest.h>
 
+#include <array>
+
+namespace {
+
+// Sample period in nanoseconds (10 ms at 100 Hz).
+constexpr std::uint64_t kPeriodNs = AverageMimuDataAlgorithm::kMimuSamplePeriodNs;
+constexpr std::size_t kSamplesPerPkt = MAX_MIMU_SAMPLES_PER_PKT_C;
+
+// Build a 10-element gyro array where sample s = base + s * step.
+inline std::array<Eigen::Vector3f, kSamplesPerPkt>
+makeRamp(Eigen::Vector3f const& base, Eigen::Vector3f const& step) {
+    std::array<Eigen::Vector3f, kSamplesPerPkt> out{};
+    for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
+        out[s] = base + (static_cast<float>(s) * step);
+    }
+    return out;
+}
+
+}  // namespace
+
 TEST(averageMimuDataTest, RegressionTest) {
+    // Single packet, wide window so every sample qualifies. Compare
+    // algorithm vs independent reference.
     constexpr float windowSec = 0.5F;
 
     InputPktsData in{};
-    in.isValid[0] = true;
-
-    constexpr uint64_t t_ref = kSec2Nano;
-
-    // Four samples within packet 0 at four distinct timestamps.
-    in.samples[0][0].measTime = t_ref;
-    in.samples[0][0].gyro_P = Eigen::Vector3f{0.1F, 0.3F, -0.1F};
-    in.samples[0][0].accel_P = Eigen::Vector3f{0.5F, -0.2F, 2.0F};
-
-    in.samples[0][1].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.6F);
-    in.samples[0][1].gyro_P = Eigen::Vector3f{1.1F, 0.8F, 0.7F};
-    in.samples[0][1].accel_P = Eigen::Vector3f{11.5F, -0.2F, 6.0F};
-
-    in.samples[0][2].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.2F);
-    in.samples[0][2].gyro_P = Eigen::Vector3f{-0.3F, -4.3F, -6.1F};
-    in.samples[0][2].accel_P = Eigen::Vector3f{-0.9F, -0.2F, -2.4F};
-
-    in.samples[0][3].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.3F);
-    in.samples[0][3].gyro_P = Eigen::Vector3f{7.1F, -0.9F, -0.0F};
-    in.samples[0][3].accel_P = Eigen::Vector3f{-80.5F, 0.4F, 2.8F};
+    const auto gyros = makeRamp(Eigen::Vector3f{0.1F, 0.3F, -0.1F}, Eigen::Vector3f{1.F, -0.2F, 0.05F});
+    const auto accels = makeRamp(Eigen::Vector3f{0.5F, -0.2F, 2.0F}, Eigen::Vector3f{-0.1F, 0.4F, -0.2F});
+    fillPacket(in, 0, kSec2Nano, gyros, accels);
 
     regressionTestAverageMimuData(windowSec, in);
 }
 
 TEST(averageMimuDataTest, PropertyKnownSolution) {
+    // DCM rotation + tight window. Window 35 ms keeps samples 6..9 of the
+    // single packet (ages 30, 20, 10, 0 ms within the packet's 90 ms span).
     AverageMimuDataAlgorithm alg;
-
-    // 90 deg rotation about +Z
     Eigen::Matrix3f dcm_BP;
-    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
-
+    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;  // 90 deg about +Z
     alg.setDcmPltfToBdy(dcm_BP);
-
-    // Window 0.26s -> ages 0.00, 0.05, 0.15 included; 0.30 excluded.
-    constexpr float window = 0.26f;
-    alg.setAveragingWindow(window);
+    alg.setAveragingWindow(0.035);
 
     InputPktsData in{};
-    in.isValid[0] = true;
-
-    constexpr uint64_t t_ref = kSec2Nano;
-    const uint64_t t0 = t_ref;
-    const uint64_t t1 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.05f);
-    const uint64_t t2 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.15f);
-    const uint64_t t3 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.30f);
-
-    const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
-    const Eigen::Vector3f gyro1{3.f, 2.f, 1.f};
-    const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
-    const Eigen::Vector3f gyro3{9.f, 9.f, 9.f};  // excluded by averagingWindow
-
-    const Eigen::Vector3f acc0{4.f, 0.f, 0.f};
-    const Eigen::Vector3f acc1{0.f, 4.f, 0.f};
-    const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
-    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};  // excluded by averagingWindow
-
-    // Four samples within packet 0; samples 4..9 left zero (stale, measTime=0).
-    in.samples[0][0].measTime = t0;
-    in.samples[0][0].gyro_P = gyro0;
-    in.samples[0][0].accel_P = acc0;
-    in.samples[0][1].measTime = t1;
-    in.samples[0][1].gyro_P = gyro1;
-    in.samples[0][1].accel_P = acc1;
-    in.samples[0][2].measTime = t2;
-    in.samples[0][2].gyro_P = gyro2;
-    in.samples[0][2].accel_P = acc2;
-    in.samples[0][3].measTime = t3;
-    in.samples[0][3].gyro_P = gyro3;
-    in.samples[0][3].accel_P = acc3;
-
-    const OutputAverageAccelAngleVel out_alg = alg.update(in);
-
-    const Eigen::Vector3f gyroMean_P = (gyro0 + gyro1 + gyro2) / 3.f;
-    const Eigen::Vector3f accMean_P = (acc0 + acc1 + acc2) / 3.f;
-
-    const Eigen::Vector3f gyroTrue_B = dcm_BP * gyroMean_P;
-    const Eigen::Vector3f accTrue_B = dcm_BP * accMean_P;
-
-    EXPECT_EQ(out_alg.gyroOmega_B, gyroTrue_B);
-    EXPECT_EQ(out_alg.accel_B, accTrue_B);
-}
-
-TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
-    AverageMimuDataAlgorithm alg;
-
-    Eigen::Matrix3f dcm_BP;
-    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
-    alg.setDcmPltfToBdy(dcm_BP);
-
-    // averagingWindow = 0 => only the sample(s) at maxTimeTag.
-    alg.setAveragingWindow(0.0f);
-
-    InputPktsData in{};
-    in.isValid[0] = true;
-
-    constexpr uint64_t t_ref = kSec2Nano;
-    const uint64_t t0 = t_ref;  // unique max
-    const uint64_t t1 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.05f);
-    const uint64_t t2 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.15f);
-    const uint64_t t3 = t_ref - static_cast<uint64_t>(kSec2Nano * 0.30f);
-
-    const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
-    const Eigen::Vector3f gyro1{3.f, 2.f, 1.f};
-    const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
-    const Eigen::Vector3f gyro3{9.f, 9.f, 9.f};
-
-    const Eigen::Vector3f acc0{4.f, 0.f, 0.f};
-    const Eigen::Vector3f acc1{0.f, 4.f, 0.f};
-    const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
-    const Eigen::Vector3f acc3{8.f, 8.f, 8.f};
-
-    in.samples[0][0].measTime = t0;
-    in.samples[0][0].gyro_P = gyro0;
-    in.samples[0][0].accel_P = acc0;
-    in.samples[0][1].measTime = t1;
-    in.samples[0][1].gyro_P = gyro1;
-    in.samples[0][1].accel_P = acc1;
-    in.samples[0][2].measTime = t2;
-    in.samples[0][2].gyro_P = gyro2;
-    in.samples[0][2].accel_P = acc2;
-    in.samples[0][3].measTime = t3;
-    in.samples[0][3].gyro_P = gyro3;
-    in.samples[0][3].accel_P = acc3;
-
-    const OutputAverageAccelAngleVel out_alg = alg.update(in);
-
-    const Eigen::Vector3f gyroTrue_B = dcm_BP * gyro0;
-    const Eigen::Vector3f accTrue_B = dcm_BP * acc0;
-
-    EXPECT_EQ(out_alg.gyroOmega_B, gyroTrue_B);
-    EXPECT_EQ(out_alg.accel_B, accTrue_B);
-}
-
-TEST(averageMimuDataTest, FirstFillZeroMeasTimeRegression) {
-    // Regression: zero-init ring-buffer slots must not pollute the output.
-    // One valid sample in packet 0[0]; everything else is stale by either
-    // !isValid or measTime==0.
-    AverageMimuDataAlgorithm alg;
-
-    Eigen::Matrix3f dcm_BP;
-    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
-    alg.setDcmPltfToBdy(dcm_BP);
-    alg.setAveragingWindow(1.0f);  // wide window: stale slots would otherwise pass
-
-    InputPktsData in{};
-    in.isValid[0] = true;
-    // Packets 1..3 left isValid=false; samples 0[1..9] left measTime=0.
-
-    const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
-    const Eigen::Vector3f acc0{4.f, 5.f, 6.f};
-    in.samples[0][0].measTime = kSec2Nano;
-    in.samples[0][0].gyro_P = gyro0;
-    in.samples[0][0].accel_P = acc0;
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
+    for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
+        gyros[s] = Eigen::Vector3f{static_cast<float>(s), 2.f * static_cast<float>(s), 3.f * static_cast<float>(s)};
+        accels[s] = Eigen::Vector3f{4.f, static_cast<float>(s), 0.f};
+    }
+    fillPacket(in, 0, kSec2Nano, gyros, accels);
 
     const OutputAverageAccelAngleVel out = alg.update(in);
 
-    EXPECT_EQ(out.gyroOmega_B, dcm_BP * gyro0);
-    EXPECT_EQ(out.accel_B, dcm_BP * acc0);
+    // Samples 6..9 qualify (ages 30, 20, 10, 0 ms from maxTimeTag = first + 90ms).
+    Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
+    Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
+    for (std::size_t s = 6; s < kSamplesPerPkt; ++s) {
+        gyroSum_P += gyros[s];
+        accelSum_P += accels[s];
+    }
+    const Eigen::Vector3f gyroTrue_B = dcm_BP * (gyroSum_P / 4.F);
+    const Eigen::Vector3f accTrue_B = dcm_BP * (accelSum_P / 4.F);
+
+    EXPECT_EQ(out.gyroOmega_B, gyroTrue_B);
+    EXPECT_EQ(out.accel_B, accTrue_B);
 }
 
-TEST(averageMimuDataTest, NoValidPacketsReturnsZero) {
+TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
+    // window = 0 -> only the last sample (sample 9, at maxTimeTag) qualifies.
     AverageMimuDataAlgorithm alg;
-    alg.setAveragingWindow(0.5f);
+    Eigen::Matrix3f dcm_BP;
+    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
+    alg.setDcmPltfToBdy(dcm_BP);
+    alg.setAveragingWindow(0.0);
+
+    InputPktsData in{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
+    for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
+        gyros[s] = Eigen::Vector3f{static_cast<float>(s + 1), 2.f, 3.f};
+        accels[s] = Eigen::Vector3f{4.f, static_cast<float>(s + 1), 0.f};
+    }
+    fillPacket(in, 0, kSec2Nano, gyros, accels);
+
+    const OutputAverageAccelAngleVel out = alg.update(in);
+
+    EXPECT_EQ(out.gyroOmega_B, dcm_BP * gyros[9]);
+    EXPECT_EQ(out.accel_B, dcm_BP * accels[9]);
+}
+
+TEST(averageMimuDataTest, EmptyRingReturnsZero) {
+    // No valid packets in the snapshot -> ring stays empty -> zero output.
+    AverageMimuDataAlgorithm alg;
+    alg.setAveragingWindow(0.5);
 
     InputPktsData const in{};
     const auto [accel_B, gyroOmega_B] = alg.update(in);
@@ -178,203 +105,330 @@ TEST(averageMimuDataTest, NoValidPacketsReturnsZero) {
     EXPECT_EQ(accel_B, Eigen::Vector3f::Zero());
 }
 
-TEST(averageMimuDataTest, ValidFlagButZeroMeasTimeIsStale) {
-    // A sample with measTime=0 within a fresh packet is treated as stale.
+TEST(averageMimuDataTest, ZeroMeasTimePacketSkipped) {
+    // A packet with isValid=true but measTime=0 is dropped at ingest.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0f);
+    alg.setAveragingWindow(1.0);
 
     InputPktsData in{};
-    in.isValid[0] = true;
-
-    const Eigen::Vector3f gyro0{1.f, 0.f, 0.f};
-    const Eigen::Vector3f acc0{0.f, 1.f, 0.f};
-    in.samples[0][0].measTime = kSec2Nano;
-    in.samples[0][0].gyro_P = gyro0;
-    in.samples[0][0].accel_P = acc0;
-
-    // Sample 0[1]: non-zero data but measTime=0 -> must be skipped.
-    in.samples[0][1].measTime = 0U;
-    in.samples[0][1].gyro_P = Eigen::Vector3f{9.f, 9.f, 9.f};
-    in.samples[0][1].accel_P = Eigen::Vector3f{9.f, 9.f, 9.f};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
+    for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
+        gyros[s] = Eigen::Vector3f{1.f, 2.f, 3.f};
+        accels[s] = Eigen::Vector3f{4.f, 5.f, 6.f};
+    }
+    fillPacket(in, 0, 0U, gyros, accels);  // measTime=0 -> skipped
 
     const OutputAverageAccelAngleVel out = alg.update(in);
-
-    EXPECT_EQ(out.gyroOmega_B, gyro0);
-    EXPECT_EQ(out.accel_B, acc0);
+    EXPECT_EQ(out.gyroOmega_B, Eigen::Vector3f::Zero());
+    EXPECT_EQ(out.accel_B, Eigen::Vector3f::Zero());
 }
 
 TEST(averageMimuDataTest, InvalidPacketSkipsAllItsSamples) {
-    // A packet with isValid=false must be skipped even if its samples have
-    // non-zero measTime. Only packet 1's samples should drive the output.
+    // isValid=false -> packet skipped entirely even if measTime / samples set.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(10.0f);
+    alg.setAveragingWindow(1.0);
 
     InputPktsData in{};
-    in.isValid[0] = false;  // valid samples but packet is invalid -> skipped
-    in.isValid[1] = true;
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gyrosLoud{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> accelsLoud{};
+    gyrosLoud.fill(Eigen::Vector3f{99.f, 99.f, 99.f});
+    accelsLoud.fill(Eigen::Vector3f{99.f, 99.f, 99.f});
 
-    constexpr uint64_t t_ref = kSec2Nano;
-    in.samples[0][0].measTime = t_ref;
-    in.samples[0][0].gyro_P = Eigen::Vector3f{99.f, 99.f, 99.f};
-    in.samples[0][0].accel_P = Eigen::Vector3f{99.f, 99.f, 99.f};
+    // Packet 0: data set but isValid stays false.
+    in.packets[0].isValid = false;
+    in.packets[0].measTime = kSec2Nano;
+    for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
+        in.packets[0].samples[s].gyro_P = gyrosLoud[s];
+        in.packets[0].samples[s].accel_P = accelsLoud[s];
+    }
 
-    const Eigen::Vector3f gyro_pkt1{1.f, 1.f, 1.f};
-    const Eigen::Vector3f acc_pkt1{2.f, 2.f, 2.f};
-    in.samples[1][0].measTime = t_ref + 100U;
-    in.samples[1][0].gyro_P = gyro_pkt1;
-    in.samples[1][0].accel_P = acc_pkt1;
+    // Packet 1: valid; flat ramp.
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gyrosQuiet{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> accelsQuiet{};
+    gyrosQuiet.fill(Eigen::Vector3f{1.f, 1.f, 1.f});
+    accelsQuiet.fill(Eigen::Vector3f{2.f, 2.f, 2.f});
+    fillPacket(in, 1, kSec2Nano + 100U, gyrosQuiet, accelsQuiet);
 
     const OutputAverageAccelAngleVel out = alg.update(in);
-
-    EXPECT_EQ(out.gyroOmega_B, gyro_pkt1);
-    EXPECT_EQ(out.accel_B, acc_pkt1);
+    EXPECT_EQ(out.gyroOmega_B, gyrosQuiet[0]);
+    EXPECT_EQ(out.accel_B, accelsQuiet[0]);
 }
 
 TEST(averageMimuDataTest, AveragesAcrossMultiplePackets) {
-    // Three samples spread across two valid packets are averaged equally.
+    // Two valid packets ingested in one snapshot, wide window includes all.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(1.0f);  // wide window includes all
+    alg.setAveragingWindow(1.0);
 
     InputPktsData in{};
-    in.isValid[0] = true;
-    in.isValid[2] = true;
+    std::array<Eigen::Vector3f, kSamplesPerPkt> g0{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> a0{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> g2{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> a2{};
+    g0.fill(Eigen::Vector3f{1.f, 0.f, 0.f});
+    a0.fill(Eigen::Vector3f{1.f, 1.f, 0.f});
+    g2.fill(Eigen::Vector3f{0.f, 1.f, 0.f});
+    a2.fill(Eigen::Vector3f{0.f, 1.f, 1.f});
 
-    constexpr uint64_t t_ref = kSec2Nano;
-    const Eigen::Vector3f g_a{1.f, 0.f, 0.f};
-    const Eigen::Vector3f g_b{0.f, 1.f, 0.f};
-    const Eigen::Vector3f g_c{0.f, 0.f, 1.f};
-    const Eigen::Vector3f a_a{1.f, 1.f, 0.f};
-    const Eigen::Vector3f a_b{0.f, 1.f, 1.f};
-    const Eigen::Vector3f a_c{1.f, 0.f, 1.f};
-
-    in.samples[0][0].measTime = t_ref;
-    in.samples[0][0].gyro_P = g_a;
-    in.samples[0][0].accel_P = a_a;
-
-    in.samples[0][5].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.05f);
-    in.samples[0][5].gyro_P = g_b;
-    in.samples[0][5].accel_P = a_b;
-
-    in.samples[2][3].measTime = t_ref - static_cast<uint64_t>(kSec2Nano * 0.10f);
-    in.samples[2][3].gyro_P = g_c;
-    in.samples[2][3].accel_P = a_c;
+    // Packet 0 at t_ref, packet 2 one packet-span later so both fit in the 1 s window.
+    fillPacket(in, 0, kSec2Nano, g0, a0);
+    fillPacket(in, 2, kSec2Nano + (kPeriodNs * kSamplesPerPkt), g2, a2);
 
     const OutputAverageAccelAngleVel out = alg.update(in);
 
-    const Eigen::Vector3f gyroExpected = (g_a + g_b + g_c) / 3.f;
-    const Eigen::Vector3f accExpected = (a_a + a_b + a_c) / 3.f;
+    const Eigen::Vector3f gyroExpected = (g0[0] + g2[0]) / 2.f;
+    const Eigen::Vector3f accExpected = (a0[0] + a2[0]) / 2.f;
     EXPECT_EQ(out.gyroOmega_B, gyroExpected);
     EXPECT_EQ(out.accel_B, accExpected);
 }
 
 TEST(averageMimuDataTest, RingBufferFillSequence) {
-    // Drive the algorithm across multiple sequential update() calls the way a
-    // host ring buffer would: start empty, fill packet by packet, then wrap
-    // and tighten the window. Each step compares output against the
-    // hand-computed mean of the currently-fresh samples.
+    // Walk the algorithm-owned ring: empty -> fill one packet per cycle ->
+    // overflow into the wrap. Compares against the reference each cycle.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
-    alg.setAveragingWindow(10.0f);  // wide window: every fresh sample qualifies
+    alg.setAveragingWindow(1.0);
 
-    constexpr uint64_t t_ref = kSec2Nano;
+    ReferenceAverager ref(alg);
 
-    // Pre-build a deterministic 4 x MAX_MIMU_SAMPLES_PER_PKT grid of samples.
-    std::array<std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT>, MAX_MIMU_PKT> grid{};
-    for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
-        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
-            const auto offsetNs =
-                static_cast<uint64_t>(kSec2Nano * 0.001f * static_cast<float>((p * MAX_MIMU_SAMPLES_PER_PKT) + s));
-            grid[p][s].measTime = t_ref + offsetNs;
-            const float fp = static_cast<float>(p);
-            const float fs = static_cast<float>(s);
-            grid[p][s].gyro_P = Eigen::Vector3f{fp, fs, fp + fs};
-            grid[p][s].accel_P = Eigen::Vector3f{fp + 1.f, fs + 1.f, fp - fs};
-        }
-    }
-
-    InputPktsData in{};
+    constexpr uint64_t t_base = kSec2Nano;
+    constexpr uint64_t packetSpan = kSamplesPerPkt * kPeriodNs;
 
     // Step 1: empty buffer -> zero output.
     {
-        const OutputAverageAccelAngleVel out = alg.update(in);
-        EXPECT_EQ(out.gyroOmega_B, Eigen::Vector3f::Zero());
-        EXPECT_EQ(out.accel_B, Eigen::Vector3f::Zero());
+        InputPktsData in{};
+        const OutputAverageAccelAngleVel out_alg = alg.update(in);
+        const OutputAverageAccelAngleVel out_ref = ref.update(in);
+        EXPECT_EQ(out_alg.gyroOmega_B, Eigen::Vector3f::Zero());
+        EXPECT_EQ(out_alg.gyroOmega_B, out_ref.gyroOmega_B);
+        EXPECT_EQ(out_alg.accel_B, out_ref.accel_B);
     }
 
-    // Step 2..5: mark packets valid one at a time and fill all their samples.
-    Eigen::Vector3f gyroSum = Eigen::Vector3f::Zero();
-    Eigen::Vector3f accelSum = Eigen::Vector3f::Zero();
-    std::size_t sampleCount = 0;
-    for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
-        in.isValid[p] = true;
-        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
-            in.samples[p][s] = grid[p][s];
-            gyroSum += grid[p][s].gyro_P;
-            accelSum += grid[p][s].accel_P;
-            sampleCount++;
+    // Step 2..5: ingest one new packet per cycle by advancing measTime.
+    for (std::size_t cycle = 0; cycle < 4; ++cycle) {
+        InputPktsData in{};
+        std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
+        std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
+        for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
+            const float v = static_cast<float>((cycle * kSamplesPerPkt) + s);
+            gyros[s] = Eigen::Vector3f{v, v + 1.f, v + 2.f};
+            accels[s] = Eigen::Vector3f{v + 0.5f, v + 1.5f, v + 2.5f};
         }
-        const Eigen::Vector3f gyroExpected = gyroSum / static_cast<float>(sampleCount);
-        const Eigen::Vector3f accelExpected = accelSum / static_cast<float>(sampleCount);
-        const OutputAverageAccelAngleVel out = alg.update(in);
-        EXPECT_EQ(out.gyroOmega_B, gyroExpected) << "after filling packet " << p;
-        EXPECT_EQ(out.accel_B, accelExpected) << "after filling packet " << p;
-    }
-
-    // Step 6: wrap. Overwrite packet 0[0] with a much newer sample. The new
-    // sample owns maxTimeTag; with the wide window every other fresh sample
-    // still qualifies, so the mean simply swaps the old packet 0[0] for the
-    // new one.
-    const uint64_t wrapTime = t_ref + static_cast<uint64_t>(kSec2Nano * 1.0f);
-    const Eigen::Vector3f wrapGyro{-1.f, -2.f, -3.f};
-    const Eigen::Vector3f wrapAccel{-4.f, -5.f, -6.f};
-    gyroSum = gyroSum - grid[0][0].gyro_P + wrapGyro;
-    accelSum = accelSum - grid[0][0].accel_P + wrapAccel;
-    in.samples[0][0].measTime = wrapTime;
-    in.samples[0][0].gyro_P = wrapGyro;
-    in.samples[0][0].accel_P = wrapAccel;
-    {
-        const OutputAverageAccelAngleVel out = alg.update(in);
-        EXPECT_EQ(out.gyroOmega_B, gyroSum / static_cast<float>(sampleCount));
-        EXPECT_EQ(out.accel_B, accelSum / static_cast<float>(sampleCount));
-    }
-
-    // Step 7: tighten the window so only packet 0[0] (age 0 from wrapTime)
-    // qualifies; every other sample is older by 1.0s+ which exceeds 0.1s.
-    alg.setAveragingWindow(0.1f);
-    {
-        const OutputAverageAccelAngleVel out = alg.update(in);
-        EXPECT_EQ(out.gyroOmega_B, wrapGyro);
-        EXPECT_EQ(out.accel_B, wrapAccel);
+        fillPacket(in, 0, t_base + (cycle * packetSpan), gyros, accels);
+        const OutputAverageAccelAngleVel out_alg = alg.update(in);
+        const OutputAverageAccelAngleVel out_ref = ref.update(in);
+        EXPECT_EQ(out_alg.gyroOmega_B, out_ref.gyroOmega_B) << "cycle " << cycle;
+        EXPECT_EQ(out_alg.accel_B, out_ref.accel_B) << "cycle " << cycle;
     }
 }
 
 TEST(averageMimuDataTest, SetupTest) {
     AverageMimuDataAlgorithm alg;
 
-    // 1) Setters should not throw
     EXPECT_THROW(alg.setAveragingWindow(-0.1), fsw::invalid_argument);
-    EXPECT_NO_THROW(alg.setAveragingWindow(0.25f));
+    EXPECT_NO_THROW(alg.setAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec)));
+    EXPECT_THROW(alg.setAveragingWindow(
+                     static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec) + 0.001),
+                 fsw::invalid_argument);
+    EXPECT_NO_THROW(alg.setAveragingWindow(0.25));
 
     Eigen::Matrix3f badOrtho = Eigen::Matrix3f::Identity();
     badOrtho(0, 0) = 2.0F;
     EXPECT_THROW(alg.setDcmPltfToBdy(badOrtho), fsw::invalid_argument);
-    // det = -1 (reflection), orthonormal but not a proper rotation
+
     Eigen::Matrix3f badDet = Eigen::Matrix3f::Identity();
     badDet(0, 0) = -1.0F;
     EXPECT_THROW(alg.setDcmPltfToBdy(badDet), fsw::invalid_argument);
     EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
 
-    EXPECT_EQ(alg.getAveragingWindow(), 0.25f);
+    EXPECT_DOUBLE_EQ(alg.getAveragingWindow(), 0.25);
     EXPECT_EQ(alg.getDcmPltfToBdy(), Eigen::Matrix3f::Identity());
 
     InputPktsData in{};
-    in.isValid[0] = true;
-    in.samples[0][0].measTime = kSec2Nano;
-    in.samples[0][0].gyro_P = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
-    in.samples[0][0].accel_P = Eigen::Vector3f(4.0f, 5.0f, 6.0f);
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
+    gyros.fill(Eigen::Vector3f{1.0f, 2.0f, 3.0f});
+    accels.fill(Eigen::Vector3f{4.0f, 5.0f, 6.0f});
+    fillPacket(in, 0, kSec2Nano, gyros, accels);
 
     EXPECT_NO_THROW((void)alg.update(in));
+}
+
+TEST(averageMimuDataTest, StrictMonotonicDropsRepeatedSnapshot) {
+    // Re-feeding the exact same snapshot must not double-count.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(1.0);
+
+    InputPktsData in{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
+    gyros.fill(Eigen::Vector3f{1.f, 2.f, 3.f});
+    accels.fill(Eigen::Vector3f{4.f, 5.f, 6.f});
+    fillPacket(in, 0, kSec2Nano, gyros, accels);
+
+    const OutputAverageAccelAngleVel out_first = alg.update(in);
+    const OutputAverageAccelAngleVel out_second = alg.update(in);
+
+    EXPECT_EQ(out_first.gyroOmega_B, gyros[0]);
+    EXPECT_EQ(out_first.accel_B, accels[0]);
+    EXPECT_EQ(out_second.gyroOmega_B, out_first.gyroOmega_B);
+    EXPECT_EQ(out_second.accel_B, out_first.accel_B);
+}
+
+TEST(averageMimuDataTest, OverflowOverwritesOldest) {
+    // Drive kRingCapacity + 2 monotonically-newer single-packet snapshots.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec));
+
+    constexpr std::size_t kPacketsToFeed = AverageMimuDataAlgorithm::kRingCapacity + 2U;
+    constexpr uint64_t packetSpan = kSamplesPerPkt * kPeriodNs;
+    constexpr uint64_t t_base = kSec2Nano;
+
+    Eigen::Vector3f gyroSumRetained = Eigen::Vector3f::Zero();
+    Eigen::Vector3f accelSumRetained = Eigen::Vector3f::Zero();
+    std::size_t retainedCount = 0;
+    OutputAverageAccelAngleVel finalOut{};
+
+    for (std::size_t i = 0; i < kPacketsToFeed; ++i) {
+        InputPktsData in{};
+        std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
+        std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
+        for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
+            const float fi = static_cast<float>(i);
+            const float fs = static_cast<float>(s);
+            gyros[s] = Eigen::Vector3f{fi, fs, fi + fs};
+            accels[s] = Eigen::Vector3f{fi - fs, fi + 1.f, fs + 1.f};
+            if (i >= kPacketsToFeed - AverageMimuDataAlgorithm::kRingCapacity) {
+                gyroSumRetained += gyros[s];
+                accelSumRetained += accels[s];
+                retainedCount++;
+            }
+        }
+        fillPacket(in, 0, t_base + (i * packetSpan), gyros, accels);
+        finalOut = alg.update(in);
+    }
+
+    EXPECT_EQ(finalOut.gyroOmega_B, gyroSumRetained / static_cast<float>(retainedCount));
+    EXPECT_EQ(finalOut.accel_B, accelSumRetained / static_cast<float>(retainedCount));
+}
+
+TEST(averageMimuDataTest, EmptySnapshotReEmitsRingAverage) {
+    // After ingesting a packet, an empty snapshot must re-emit the same
+    // average without ingesting anything new.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(1.0);
+
+    InputPktsData in{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
+    gyros.fill(Eigen::Vector3f{1.f, -2.f, 3.f});
+    accels.fill(Eigen::Vector3f{4.f, -5.f, 6.f});
+    fillPacket(in, 0, kSec2Nano, gyros, accels);
+    const OutputAverageAccelAngleVel out_first = alg.update(in);
+
+    InputPktsData empty{};
+    const OutputAverageAccelAngleVel out_second = alg.update(empty);
+
+    EXPECT_EQ(out_second.gyroOmega_B, out_first.gyroOmega_B);
+    EXPECT_EQ(out_second.accel_B, out_first.accel_B);
+}
+
+TEST(averageMimuDataTest, WindowShrinkMidStream) {
+    // Ingest two packets spaced > 100 ms apart with a wide window; tighten the
+    // window so the older packet's samples fall outside; output reflects only
+    // the newer packet over the same ring contents.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(1.0);
+
+    InputPktsData in1{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gOld{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> aOld{};
+    gOld.fill(Eigen::Vector3f{2.f, 4.f, 6.f});
+    aOld.fill(Eigen::Vector3f{8.f, 10.f, 12.f});
+    fillPacket(in1, 0, kSec2Nano, gOld, aOld);
+    (void)alg.update(in1);
+
+    InputPktsData in2{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gNew{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> aNew{};
+    gNew.fill(Eigen::Vector3f{1.f, 3.f, 5.f});
+    aNew.fill(Eigen::Vector3f{7.f, 9.f, 11.f});
+    // 500 ms later: still within wide window for now.
+    fillPacket(in2, 0, kSec2Nano + (50U * kPeriodNs), gNew, aNew);
+    (void)alg.update(in2);
+
+    // Tighten window so the old packet's samples (all > 100 ms older than
+    // maxTimeTag) drop out. New packet's 10 samples all qualify.
+    alg.setAveragingWindow(0.1);
+    InputPktsData empty{};
+    const OutputAverageAccelAngleVel out = alg.update(empty);
+    EXPECT_EQ(out.gyroOmega_B, gNew[0]);
+    EXPECT_EQ(out.accel_B, aNew[0]);
+}
+
+TEST(averageMimuDataTest, WindowGrowMidStream) {
+    // Dual of WindowShrinkMidStream.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(0.1);
+
+    InputPktsData in1{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gOld{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> aOld{};
+    gOld.fill(Eigen::Vector3f{1.f, 1.f, 1.f});
+    aOld.fill(Eigen::Vector3f{2.f, 2.f, 2.f});
+    fillPacket(in1, 0, kSec2Nano, gOld, aOld);
+    (void)alg.update(in1);
+
+    InputPktsData in2{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gNew{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> aNew{};
+    gNew.fill(Eigen::Vector3f{3.f, 3.f, 3.f});
+    aNew.fill(Eigen::Vector3f{4.f, 4.f, 4.f});
+    fillPacket(in2, 0, kSec2Nano + (50U * kPeriodNs), gNew, aNew);
+    const OutputAverageAccelAngleVel out_tight = alg.update(in2);
+
+    EXPECT_EQ(out_tight.gyroOmega_B, gNew[0]);
+    EXPECT_EQ(out_tight.accel_B, aNew[0]);
+
+    // Grow window so both packets' samples qualify.
+    alg.setAveragingWindow(1.0);
+    InputPktsData empty{};
+    const OutputAverageAccelAngleVel out_wide = alg.update(empty);
+
+    EXPECT_EQ(out_wide.gyroOmega_B, (gOld[0] + gNew[0]) / 2.f);
+    EXPECT_EQ(out_wide.accel_B, (aOld[0] + aNew[0]) / 2.f);
+}
+
+TEST(averageMimuDataTest, OutOfOrderPacketDropped) {
+    // A packet whose measTime <= the prior max is dropped at ingest.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(1.0);
+
+    InputPktsData in1{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gOk{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> aOk{};
+    gOk.fill(Eigen::Vector3f{5.f, 6.f, 7.f});
+    aOk.fill(Eigen::Vector3f{8.f, 9.f, 10.f});
+    fillPacket(in1, 0, kSec2Nano, gOk, aOk);
+    (void)alg.update(in1);
+
+    InputPktsData in2{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> gLoud{};
+    std::array<Eigen::Vector3f, kSamplesPerPkt> aLoud{};
+    gLoud.fill(Eigen::Vector3f{99.f, 99.f, 99.f});
+    aLoud.fill(Eigen::Vector3f{99.f, 99.f, 99.f});
+    fillPacket(in2, 0, kSec2Nano - (10U * kPeriodNs), gLoud, aLoud);
+    const OutputAverageAccelAngleVel out = alg.update(in2);
+
+    EXPECT_EQ(out.gyroOmega_B, gOk[0]);
+    EXPECT_EQ(out.accel_B, aOk[0]);
 }

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -3,84 +3,55 @@
 #include <gtest/gtest.h>
 
 TEST(averageMimuDataTest, RegressionTest) {
-    constexpr std::size_t N = 4U;
     constexpr float windowSec = 0.5F;
 
-    std::array<InputData, MAX_ACC_BUF_PKT> input{};
+    InputPktsData in{};
+    in.isValid[0] = true;
 
-    // Optional: set a reference time (like before)
     constexpr uint64_t t_ref = SEC2NANO;
 
-    // Packet 0 (newest)
-    input[0].isValid = true;
-    input[0].measTime = t_ref;
-    input[0].gyro_P = Vec3Arr{0.1F, 0.3F, -0.1F};
-    input[0].accel_P = Vec3Arr{0.5F, -0.2F, 2.0F};
+    // Four samples within packet 0 at four distinct timestamps.
+    in.samples[0][0].measTime = t_ref;
+    in.samples[0][0].gyro_P = Eigen::Vector3f{0.1F, 0.3F, -0.1F};
+    in.samples[0][0].accel_P = Eigen::Vector3f{0.5F, -0.2F, 2.0F};
 
-    // Packet 1 (older by 0.6s)
-    input[1].isValid = true;
-    input[1].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.6F);
-    input[1].gyro_P = Vec3Arr{1.1F, 0.8F, 0.7F};
-    input[1].accel_P = Vec3Arr{11.5F, -0.2F, 6.0F};
+    in.samples[0][1].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.6F);
+    in.samples[0][1].gyro_P = Eigen::Vector3f{1.1F, 0.8F, 0.7F};
+    in.samples[0][1].accel_P = Eigen::Vector3f{11.5F, -0.2F, 6.0F};
 
-    // Packet 2 (older by 0.2s)
-    input[2].isValid = true;
-    input[2].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.2F);
-    input[2].gyro_P = Vec3Arr{-0.3F, -4.3F, -6.1F};
-    input[2].accel_P = Vec3Arr{-0.9F, -0.2F, -2.4F};
+    in.samples[0][2].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.2F);
+    in.samples[0][2].gyro_P = Eigen::Vector3f{-0.3F, -4.3F, -6.1F};
+    in.samples[0][2].accel_P = Eigen::Vector3f{-0.9F, -0.2F, -2.4F};
 
-    // Packet 3 (older by 0.3s)
-    input[3].isValid = true;
-    input[3].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.3F);
-    input[3].gyro_P = Vec3Arr{7.1F, -0.9F, -0.0F};
-    input[3].accel_P = Vec3Arr{-80.5F, 0.4F, 2.8F};
+    in.samples[0][3].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.3F);
+    in.samples[0][3].gyro_P = Eigen::Vector3f{7.1F, -0.9F, -0.0F};
+    in.samples[0][3].accel_P = Eigen::Vector3f{-80.5F, 0.4F, 2.8F};
 
-    regressionTestAverageMimuData(N, windowSec, input);
+    regressionTestAverageMimuData(windowSec, in);
 }
 
 TEST(averageMimuDataTest, PropertyKnownSolution) {
-    // -----------------------
-    // Fixed algorithm settings
-    // -----------------------
     AverageMimuDataAlgorithm alg;
 
-    // 90 deg rotation about +Z:
-    // [ 0 -1  0
-    //   1  0  0
-    //   0  0  1 ]
+    // 90 deg rotation about +Z
     Eigen::Matrix3f dcm_BP;
     dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
 
     alg.setDcmPltfToBdy(dcm_BP);
 
-    // Time window (seconds)
-    // Choose 0.26 so ages 0.00, 0.05, 0.15 are included; 0.30 excluded
+    // Window 0.26s -> ages 0.00, 0.05, 0.15 included; 0.30 excluded.
     constexpr float window = 0.26f;
     alg.setAveragingWindow(window);
 
-    // -----------------------
-    // Fixed synthetic packets (DIRECT)
-    // -----------------------
-    InputPktsData in{};  // <-- directly build unpacked input
+    InputPktsData in{};
+    in.isValid[0] = true;
 
-    // zero everything (Eigen::Vector3f default in std::array is uninitialized)
-    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        in.isValid[i] = false;
-        in.measTime[i] = 0U;
-        in.gyro_P[i] = Eigen::Vector3f::Zero();
-        in.accel_P[i] = Eigen::Vector3f::Zero();
-    }
-
-    // Reference time = 1.0s (ns)
     constexpr uint64_t t_ref = SEC2NANO;
-
-    // Ages in seconds: 0.00, 0.05, 0.15, 0.30 (cleanly away from boundary)
     const uint64_t t0 = t_ref;
     const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
     const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
     const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
 
-    // Choose easy vectors so the mean is simple.
     const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
     const Eigen::Vector3f gyro1{3.f, 2.f, 1.f};
     const Eigen::Vector3f gyro2{-1.f, 0.f, 2.f};
@@ -91,35 +62,22 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
     const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
     const Eigen::Vector3f acc3{8.f, 8.f, 8.f};  // excluded by averagingWindow
 
-    // Put packets in the first few slots
-    in.isValid[0] = true;
-    in.measTime[0] = t0;
-    in.gyro_P[0] = gyro0;
-    in.accel_P[0] = acc0;
-    in.isValid[1] = true;
-    in.measTime[1] = t1;
-    in.gyro_P[1] = gyro1;
-    in.accel_P[1] = acc1;
-    in.isValid[2] = true;
-    in.measTime[2] = t2;
-    in.gyro_P[2] = gyro2;
-    in.accel_P[2] = acc2;
-    in.isValid[3] = true;
-    in.measTime[3] = t3;
-    in.gyro_P[3] = gyro3;
-    in.accel_P[3] = acc3;
+    // Four samples within packet 0; samples 4..9 left zero (stale, measTime=0).
+    in.samples[0][0].measTime = t0;
+    in.samples[0][0].gyro_P = gyro0;
+    in.samples[0][0].accel_P = acc0;
+    in.samples[0][1].measTime = t1;
+    in.samples[0][1].gyro_P = gyro1;
+    in.samples[0][1].accel_P = acc1;
+    in.samples[0][2].measTime = t2;
+    in.samples[0][2].gyro_P = gyro2;
+    in.samples[0][2].accel_P = acc2;
+    in.samples[0][3].measTime = t3;
+    in.samples[0][3].gyro_P = gyro3;
+    in.samples[0][3].accel_P = acc3;
 
-    // -----------------------
-    // Run algorithm under test
-    // -----------------------
     const OutputAverageAccelAngleVel out_alg = alg.update(in);
 
-    // -----------------------
-    // True known solution:
-    // include packets 0,1,2 only (ages 0, 0.05, 0.15 < 0.26)
-    // mean_P = (v0 + v1 + v2) / 3
-    // out_B = dcm_BP * mean_P
-    // -----------------------
     const Eigen::Vector3f gyroMean_P = (gyro0 + gyro1 + gyro2) / 3.f;
     const Eigen::Vector3f accMean_P = (acc0 + acc1 + acc2) / 3.f;
 
@@ -131,34 +89,20 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
 }
 
 TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
-    // -----------------------
-    // Fixed algorithm settings
-    // -----------------------
     AverageMimuDataAlgorithm alg;
 
     Eigen::Matrix3f dcm_BP;
     dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
     alg.setDcmPltfToBdy(dcm_BP);
 
-    // averagingWindow = 0 => should pick the packet(s) at maxTimeTag
+    // averagingWindow = 0 => only the sample(s) at maxTimeTag.
     alg.setAveragingWindow(0.0f);
 
-    // -----------------------
-    // Fixed synthetic packets (DIRECT)
-    // -----------------------
     InputPktsData in{};
-
-    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        in.isValid[i] = false;
-        in.measTime[i] = 0U;
-        in.gyro_P[i] = Eigen::Vector3f::Zero();
-        in.accel_P[i] = Eigen::Vector3f::Zero();
-    }
+    in.isValid[0] = true;
 
     constexpr uint64_t t_ref = SEC2NANO;
-
-    // Make packet 0 the unique maxTimeTag
-    const uint64_t t0 = t_ref;  // max
+    const uint64_t t0 = t_ref;  // unique max
     const uint64_t t1 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
     const uint64_t t2 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.15f);
     const uint64_t t3 = t_ref - static_cast<uint64_t>(SEC2NANO * 0.30f);
@@ -173,33 +117,21 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     const Eigen::Vector3f acc2{0.f, 0.f, 4.f};
     const Eigen::Vector3f acc3{8.f, 8.f, 8.f};
 
-    in.isValid[0] = true;
-    in.measTime[0] = t0;
-    in.gyro_P[0] = gyro0;
-    in.accel_P[0] = acc0;
-    in.isValid[1] = true;
-    in.measTime[1] = t1;
-    in.gyro_P[1] = gyro1;
-    in.accel_P[1] = acc1;
-    in.isValid[2] = true;
-    in.measTime[2] = t2;
-    in.gyro_P[2] = gyro2;
-    in.accel_P[2] = acc2;
-    in.isValid[3] = true;
-    in.measTime[3] = t3;
-    in.gyro_P[3] = gyro3;
-    in.accel_P[3] = acc3;
+    in.samples[0][0].measTime = t0;
+    in.samples[0][0].gyro_P = gyro0;
+    in.samples[0][0].accel_P = acc0;
+    in.samples[0][1].measTime = t1;
+    in.samples[0][1].gyro_P = gyro1;
+    in.samples[0][1].accel_P = acc1;
+    in.samples[0][2].measTime = t2;
+    in.samples[0][2].gyro_P = gyro2;
+    in.samples[0][2].accel_P = acc2;
+    in.samples[0][3].measTime = t3;
+    in.samples[0][3].gyro_P = gyro3;
+    in.samples[0][3].accel_P = acc3;
 
-    // -----------------------
-    // Run algorithm under test
-    // -----------------------
     const OutputAverageAccelAngleVel out_alg = alg.update(in);
 
-    // -----------------------
-    // True known solution (averagingWindow = 0):
-    // use ONLY the packet with maxTimeTag (packet 0 here)
-    // out_B = dcm_BP * v0
-    // -----------------------
     const Eigen::Vector3f gyroTrue_B = dcm_BP * gyro0;
     const Eigen::Vector3f accTrue_B = dcm_BP * acc0;
 
@@ -208,27 +140,25 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
 }
 
 TEST(averageMimuDataTest, FirstFillZeroMeasTimeRegression) {
-    // Regression: before the staleness rule was introduced, unfilled ring-buffer
-    // slots (isValid=false, measTime=0) polluted the average because the
-    // algorithm iterated over every slot. With a single valid packet in slot 0,
-    // the output must equal dcm_BP * slot0 -- not slot0 divided by the buffer
-    // size.
+    // Regression: zero-init ring-buffer slots must not pollute the output.
+    // One valid sample in packet 0[0]; everything else is stale by either
+    // !isValid or measTime==0.
     AverageMimuDataAlgorithm alg;
 
     Eigen::Matrix3f dcm_BP;
     dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
     alg.setDcmPltfToBdy(dcm_BP);
-    alg.setAveragingWindow(1.0f);  // wide enough that zero-measTime slots would
-                                   // otherwise slip through the window filter
+    alg.setAveragingWindow(1.0f);  // wide window: stale slots would otherwise pass
 
-    InputPktsData in{};  // zero-init: all isValid=false, measTime=0
+    InputPktsData in{};
+    in.isValid[0] = true;
+    // Packets 1..3 left isValid=false; samples 0[1..9] left measTime=0.
 
     const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
     const Eigen::Vector3f acc0{4.f, 5.f, 6.f};
-    in.isValid[0] = true;
-    in.measTime[0] = SEC2NANO;
-    in.gyro_P[0] = gyro0;
-    in.accel_P[0] = acc0;
+    in.samples[0][0].measTime = SEC2NANO;
+    in.samples[0][0].gyro_P = gyro0;
+    in.samples[0][0].accel_P = acc0;
 
     const OutputAverageAccelAngleVel out = alg.update(in);
 
@@ -237,7 +167,6 @@ TEST(averageMimuDataTest, FirstFillZeroMeasTimeRegression) {
 }
 
 TEST(averageMimuDataTest, NoValidPacketsReturnsZero) {
-    // All slots default-initialized (isValid=false, measTime=0) -> zero output.
     AverageMimuDataAlgorithm alg;
     alg.setAveragingWindow(0.5f);
 
@@ -249,25 +178,24 @@ TEST(averageMimuDataTest, NoValidPacketsReturnsZero) {
 }
 
 TEST(averageMimuDataTest, ValidFlagButZeroMeasTimeIsStale) {
-    // A slot with isValid=true but measTime=0 is treated as stale (unfilled).
-    // The only fresh slot is slot 0, so the output must equal dcm_BP * slot0.
+    // A sample with measTime=0 within a fresh packet is treated as stale.
     AverageMimuDataAlgorithm alg;
     alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
     alg.setAveragingWindow(1.0f);
 
     InputPktsData in{};
+    in.isValid[0] = true;
+
     const Eigen::Vector3f gyro0{1.f, 0.f, 0.f};
     const Eigen::Vector3f acc0{0.f, 1.f, 0.f};
-    in.isValid[0] = true;
-    in.measTime[0] = SEC2NANO;
-    in.gyro_P[0] = gyro0;
-    in.accel_P[0] = acc0;
+    in.samples[0][0].measTime = SEC2NANO;
+    in.samples[0][0].gyro_P = gyro0;
+    in.samples[0][0].accel_P = acc0;
 
-    // Slot 1: isValid=true but measTime=0 -> must be skipped.
-    in.isValid[1] = true;
-    in.measTime[1] = 0U;
-    in.gyro_P[1] = Eigen::Vector3f{9.f, 9.f, 9.f};
-    in.accel_P[1] = Eigen::Vector3f{9.f, 9.f, 9.f};
+    // Sample 0[1]: non-zero data but measTime=0 -> must be skipped.
+    in.samples[0][1].measTime = 0U;
+    in.samples[0][1].gyro_P = Eigen::Vector3f{9.f, 9.f, 9.f};
+    in.samples[0][1].accel_P = Eigen::Vector3f{9.f, 9.f, 9.f};
 
     const OutputAverageAccelAngleVel out = alg.update(in);
 
@@ -275,12 +203,79 @@ TEST(averageMimuDataTest, ValidFlagButZeroMeasTimeIsStale) {
     EXPECT_EQ(out.accel_B, acc0);
 }
 
+TEST(averageMimuDataTest, InvalidPacketSkipsAllItsSamples) {
+    // A packet with isValid=false must be skipped even if its samples have
+    // non-zero measTime. Only packet 1's samples should drive the output.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(10.0f);
+
+    InputPktsData in{};
+    in.isValid[0] = false;  // valid samples but packet is invalid -> skipped
+    in.isValid[1] = true;
+
+    constexpr uint64_t t_ref = SEC2NANO;
+    in.samples[0][0].measTime = t_ref;
+    in.samples[0][0].gyro_P = Eigen::Vector3f{99.f, 99.f, 99.f};
+    in.samples[0][0].accel_P = Eigen::Vector3f{99.f, 99.f, 99.f};
+
+    const Eigen::Vector3f gyro_pkt1{1.f, 1.f, 1.f};
+    const Eigen::Vector3f acc_pkt1{2.f, 2.f, 2.f};
+    in.samples[1][0].measTime = t_ref + 100U;
+    in.samples[1][0].gyro_P = gyro_pkt1;
+    in.samples[1][0].accel_P = acc_pkt1;
+
+    const OutputAverageAccelAngleVel out = alg.update(in);
+
+    EXPECT_EQ(out.gyroOmega_B, gyro_pkt1);
+    EXPECT_EQ(out.accel_B, acc_pkt1);
+}
+
+TEST(averageMimuDataTest, AveragesAcrossMultiplePackets) {
+    // Three samples spread across two valid packets are averaged equally.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(1.0f);  // wide window includes all
+
+    InputPktsData in{};
+    in.isValid[0] = true;
+    in.isValid[2] = true;
+
+    constexpr uint64_t t_ref = SEC2NANO;
+    const Eigen::Vector3f g_a{1.f, 0.f, 0.f};
+    const Eigen::Vector3f g_b{0.f, 1.f, 0.f};
+    const Eigen::Vector3f g_c{0.f, 0.f, 1.f};
+    const Eigen::Vector3f a_a{1.f, 1.f, 0.f};
+    const Eigen::Vector3f a_b{0.f, 1.f, 1.f};
+    const Eigen::Vector3f a_c{1.f, 0.f, 1.f};
+
+    in.samples[0][0].measTime = t_ref;
+    in.samples[0][0].gyro_P = g_a;
+    in.samples[0][0].accel_P = a_a;
+
+    in.samples[0][5].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.05f);
+    in.samples[0][5].gyro_P = g_b;
+    in.samples[0][5].accel_P = a_b;
+
+    in.samples[2][3].measTime = t_ref - static_cast<uint64_t>(SEC2NANO * 0.10f);
+    in.samples[2][3].gyro_P = g_c;
+    in.samples[2][3].accel_P = a_c;
+
+    const OutputAverageAccelAngleVel out = alg.update(in);
+
+    const Eigen::Vector3f gyroExpected = (g_a + g_b + g_c) / 3.f;
+    const Eigen::Vector3f accExpected = (a_a + a_b + a_c) / 3.f;
+    EXPECT_EQ(out.gyroOmega_B, gyroExpected);
+    EXPECT_EQ(out.accel_B, accExpected);
+}
+
 TEST(averageMimuDataTest, SetupTest) {
     AverageMimuDataAlgorithm alg;
+
     // 1) Setters should not throw
     EXPECT_THROW(alg.setAveragingWindow(-0.1), fsw::invalid_argument);
     EXPECT_NO_THROW(alg.setAveragingWindow(0.25f));
-    // Not orthonormal (scaling matrix), det != 1 as well
+
     Eigen::Matrix3f badOrtho = Eigen::Matrix3f::Identity();
     badOrtho(0, 0) = 2.0F;
     EXPECT_THROW(alg.setDcmPltfToBdy(badOrtho), fsw::invalid_argument);
@@ -290,24 +285,14 @@ TEST(averageMimuDataTest, SetupTest) {
     EXPECT_THROW(alg.setDcmPltfToBdy(badDet), fsw::invalid_argument);
     EXPECT_NO_THROW(alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity()));
 
-    // 2) Round-trip expectations
     EXPECT_EQ(alg.getAveragingWindow(), 0.25f);
     EXPECT_EQ(alg.getDcmPltfToBdy(), Eigen::Matrix3f::Identity());
 
-    // 3) update() should not throw for a basic input
     InputPktsData in{};
-    for (std::size_t i = 0; i < MAX_ACC_BUF_PKT; ++i) {
-        in.isValid[i] = false;
-        in.measTime[i] = 0U;
-        in.gyro_P[i] = Eigen::Vector3f::Zero();
-        in.accel_P[i] = Eigen::Vector3f::Zero();
-    }
-
-    // Add one non-zero packet so we exercise the averaging path
     in.isValid[0] = true;
-    in.measTime[0] = SEC2NANO;
-    in.gyro_P[0] = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
-    in.accel_P[0] = Eigen::Vector3f(4.0f, 5.0f, 6.0f);
+    in.samples[0][0].measTime = SEC2NANO;
+    in.samples[0][0].gyro_P = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
+    in.samples[0][0].accel_P = Eigen::Vector3f(4.0f, 5.0f, 6.0f);
 
     EXPECT_NO_THROW((void)alg.update(in));
 }

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -1,26 +1,23 @@
 #include "averageMimuDataTestHelpers.hpp"
-#include "utilities/fsw/freestandingInvalidArgument.h"
-#include "utilities/fsw/timeConstants.h"
 #include <gtest/gtest.h>
+#include <utilities/fsw/freestandingInvalidArgument.h>
+#include <utilities/fsw/timeConstants.h>
 
 #include <array>
 
 namespace {
-
 // Sample period in nanoseconds (10 ms at 100 Hz).
 constexpr std::uint64_t kPeriodNs = AverageMimuDataAlgorithm::kMimuSamplePeriodNs;
 constexpr std::size_t kSamplesPerPkt = MAX_MIMU_SAMPLES_PER_PKT_C;
 
 // Build a 10-element gyro array where sample s = base + s * step.
-inline std::array<Eigen::Vector3f, kSamplesPerPkt>
-makeRamp(Eigen::Vector3f const& base, Eigen::Vector3f const& step) {
+inline std::array<Eigen::Vector3f, kSamplesPerPkt> makeRamp(Eigen::Vector3f const& base, Eigen::Vector3f const& step) {
     std::array<Eigen::Vector3f, kSamplesPerPkt> out{};
     for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
-        out[s] = base + (static_cast<float>(s) * step);
+        out.at(s) = base + (static_cast<float>(s) * step);
     }
     return out;
 }
-
 }  // namespace
 
 TEST(averageMimuDataTest, RegressionTest) {
@@ -41,7 +38,7 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
     // single packet (ages 30, 20, 10, 0 ms within the packet's 90 ms span).
     AverageMimuDataAlgorithm alg;
     Eigen::Matrix3f dcm_BP;
-    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;  // 90 deg about +Z
+    dcm_BP << 0.0F, -1.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F;  // 90 deg about +Z
     alg.setDcmPltfToBdy(dcm_BP);
     alg.setGyroAveragingWindow(0.035);
     alg.setAccelAveragingWindow(0.035);
@@ -50,12 +47,12 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
     for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
-        gyros[s] = Eigen::Vector3f{static_cast<float>(s), 2.f * static_cast<float>(s), 3.f * static_cast<float>(s)};
-        accels[s] = Eigen::Vector3f{4.f, static_cast<float>(s), 0.f};
+        gyros[s] = Eigen::Vector3f{static_cast<float>(s), 2.0F * static_cast<float>(s), 3.0F * static_cast<float>(s)};
+        accels[s] = Eigen::Vector3f{4.0F, static_cast<float>(s), 0.0F};
     }
     fillPacket(in, 0, kSec2Nano, gyros, accels);
 
-    const OutputAverageAccelAngleVel out = alg.update(in);
+    const auto [accel_B, gyroOmega_B] = alg.update(in);
 
     // Samples 6..9 qualify (ages 30, 20, 10, 0 ms from maxTimeTag = first + 90ms).
     Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
@@ -64,11 +61,11 @@ TEST(averageMimuDataTest, PropertyKnownSolution) {
         gyroSum_P += gyros[s];
         accelSum_P += accels[s];
     }
-    const Eigen::Vector3f gyroTrue_B = dcm_BP * (gyroSum_P / 4.F);
-    const Eigen::Vector3f accTrue_B = dcm_BP * (accelSum_P / 4.F);
+    const Eigen::Vector3f gyroTrue_B = dcm_BP * (gyroSum_P / 4.0F);
+    const Eigen::Vector3f accTrue_B = dcm_BP * (accelSum_P / 4.0F);
 
-    EXPECT_EQ(out.gyroOmega_B, gyroTrue_B);
-    EXPECT_EQ(out.accel_B, accTrue_B);
+    EXPECT_EQ(gyroOmega_B, gyroTrue_B);
+    EXPECT_EQ(accel_B, accTrue_B);
 }
 
 TEST(averageMimuDataTest, SeparateGyroAccelWindows) {
@@ -136,7 +133,7 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     // window = 0 -> only the last sample (sample 9, at maxTimeTag) qualifies.
     AverageMimuDataAlgorithm alg;
     Eigen::Matrix3f dcm_BP;
-    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
+    dcm_BP << 0.0F, -1.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F;
     alg.setDcmPltfToBdy(dcm_BP);
     alg.setGyroAveragingWindow(0.0);
     alg.setAccelAveragingWindow(0.0);
@@ -145,15 +142,15 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
     for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
-        gyros[s] = Eigen::Vector3f{static_cast<float>(s + 1), 2.f, 3.f};
-        accels[s] = Eigen::Vector3f{4.f, static_cast<float>(s + 1), 0.f};
+        gyros[s] = Eigen::Vector3f{static_cast<float>(s + 1), 2.0F, 3.0F};
+        accels[s] = Eigen::Vector3f{4.0F, static_cast<float>(s + 1), 0.0F};
     }
     fillPacket(in, 0, kSec2Nano, gyros, accels);
 
-    const OutputAverageAccelAngleVel out = alg.update(in);
+    const auto [accel_B, gyroOmega_B] = alg.update(in);
 
-    EXPECT_EQ(out.gyroOmega_B, dcm_BP * gyros[9]);
-    EXPECT_EQ(out.accel_B, dcm_BP * accels[9]);
+    EXPECT_EQ(gyroOmega_B, dcm_BP * gyros[9]);
+    EXPECT_EQ(accel_B, dcm_BP * accels[9]);
 }
 
 TEST(averageMimuDataTest, EmptyRingReturnsZero) {
@@ -180,14 +177,14 @@ TEST(averageMimuDataTest, ZeroMeasTimePacketSkipped) {
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
     for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
-        gyros[s] = Eigen::Vector3f{1.f, 2.f, 3.f};
-        accels[s] = Eigen::Vector3f{4.f, 5.f, 6.f};
+        gyros[s] = Eigen::Vector3f{1.0F, 2.0F, 3.0F};
+        accels[s] = Eigen::Vector3f{4.0F, 5.0F, 6.0F};
     }
     fillPacket(in, 0, 0U, gyros, accels);  // measTime=0 -> skipped
 
-    const OutputAverageAccelAngleVel out = alg.update(in);
-    EXPECT_EQ(out.gyroOmega_B, Eigen::Vector3f::Zero());
-    EXPECT_EQ(out.accel_B, Eigen::Vector3f::Zero());
+    const auto [accel_B, gyroOmega_B] = alg.update(in);
+    EXPECT_EQ(gyroOmega_B, Eigen::Vector3f::Zero());
+    EXPECT_EQ(accel_B, Eigen::Vector3f::Zero());
 }
 
 TEST(averageMimuDataTest, InvalidPacketSkipsAllItsSamples) {
@@ -200,8 +197,8 @@ TEST(averageMimuDataTest, InvalidPacketSkipsAllItsSamples) {
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyrosLoud{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> accelsLoud{};
-    gyrosLoud.fill(Eigen::Vector3f{99.f, 99.f, 99.f});
-    accelsLoud.fill(Eigen::Vector3f{99.f, 99.f, 99.f});
+    gyrosLoud.fill(Eigen::Vector3f{99.0F, 99.0F, 99.0F});
+    accelsLoud.fill(Eigen::Vector3f{99.0F, 99.0F, 99.0F});
 
     // Packet 0: data set but isValid stays false.
     in.packets[0].isValid = false;
@@ -214,13 +211,13 @@ TEST(averageMimuDataTest, InvalidPacketSkipsAllItsSamples) {
     // Packet 1: valid; flat ramp.
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyrosQuiet{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> accelsQuiet{};
-    gyrosQuiet.fill(Eigen::Vector3f{1.f, 1.f, 1.f});
-    accelsQuiet.fill(Eigen::Vector3f{2.f, 2.f, 2.f});
+    gyrosQuiet.fill(Eigen::Vector3f{1.0F, 1.0F, 1.0F});
+    accelsQuiet.fill(Eigen::Vector3f{2.0F, 2.0F, 2.0F});
     fillPacket(in, 1, kSec2Nano + 100U, gyrosQuiet, accelsQuiet);
 
-    const OutputAverageAccelAngleVel out = alg.update(in);
-    EXPECT_EQ(out.gyroOmega_B, gyrosQuiet[0]);
-    EXPECT_EQ(out.accel_B, accelsQuiet[0]);
+    const auto [accel_B, gyroOmega_B] = alg.update(in);
+    EXPECT_EQ(gyroOmega_B, gyrosQuiet[0]);
+    EXPECT_EQ(accel_B, accelsQuiet[0]);
 }
 
 TEST(averageMimuDataTest, AveragesAcrossMultiplePackets) {
@@ -235,21 +232,21 @@ TEST(averageMimuDataTest, AveragesAcrossMultiplePackets) {
     std::array<Eigen::Vector3f, kSamplesPerPkt> a0{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> g2{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> a2{};
-    g0.fill(Eigen::Vector3f{1.f, 0.f, 0.f});
-    a0.fill(Eigen::Vector3f{1.f, 1.f, 0.f});
-    g2.fill(Eigen::Vector3f{0.f, 1.f, 0.f});
-    a2.fill(Eigen::Vector3f{0.f, 1.f, 1.f});
+    g0.fill(Eigen::Vector3f{1.0F, 0.0F, 0.0F});
+    a0.fill(Eigen::Vector3f{1.0F, 1.0F, 0.0F});
+    g2.fill(Eigen::Vector3f{0.0F, 1.0F, 0.0F});
+    a2.fill(Eigen::Vector3f{0.0F, 1.0F, 1.0F});
 
     // Packet 0 at t_ref, packet 2 one packet-span later so both fit in the 1 s window.
     fillPacket(in, 0, kSec2Nano, g0, a0);
     fillPacket(in, 2, kSec2Nano + (kPeriodNs * kSamplesPerPkt), g2, a2);
 
-    const OutputAverageAccelAngleVel out = alg.update(in);
+    const auto [accel_B, gyroOmega_B] = alg.update(in);
 
-    const Eigen::Vector3f gyroExpected = (g0[0] + g2[0]) / 2.f;
-    const Eigen::Vector3f accExpected = (a0[0] + a2[0]) / 2.f;
-    EXPECT_EQ(out.gyroOmega_B, gyroExpected);
-    EXPECT_EQ(out.accel_B, accExpected);
+    const Eigen::Vector3f gyroExpected = (g0[0] + g2[0]) / 2.0F;
+    const Eigen::Vector3f accExpected = (a0[0] + a2[0]) / 2.0F;
+    EXPECT_EQ(gyroOmega_B, gyroExpected);
+    EXPECT_EQ(accel_B, accExpected);
 }
 
 TEST(averageMimuDataTest, RingBufferFillSequence) {
@@ -267,7 +264,7 @@ TEST(averageMimuDataTest, RingBufferFillSequence) {
 
     // Step 1: empty buffer -> zero output.
     {
-        InputPktsData in{};
+        const InputPktsData in{};
         const OutputAverageAccelAngleVel out_alg = alg.update(in);
         const OutputAverageAccelAngleVel out_ref = ref.update(in);
         EXPECT_EQ(out_alg.gyroOmega_B, Eigen::Vector3f::Zero());
@@ -281,9 +278,9 @@ TEST(averageMimuDataTest, RingBufferFillSequence) {
         std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
         std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
         for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
-            const float v = static_cast<float>((cycle * kSamplesPerPkt) + s);
-            gyros[s] = Eigen::Vector3f{v, v + 1.f, v + 2.f};
-            accels[s] = Eigen::Vector3f{v + 0.5f, v + 1.5f, v + 2.5f};
+            const auto v = static_cast<float>((cycle * kSamplesPerPkt) + s);
+            gyros[s] = Eigen::Vector3f{v, v + 1.0F, v + 2.0F};
+            accels[s] = Eigen::Vector3f{v + 0.5F, v + 1.5F, v + 2.5F};
         }
         fillPacket(in, 0, t_base + (cycle * packetSpan), gyros, accels);
         const OutputAverageAccelAngleVel out_alg = alg.update(in);
@@ -298,16 +295,16 @@ TEST(averageMimuDataTest, SetupTest) {
 
     EXPECT_THROW(alg.setGyroAveragingWindow(-0.1), fsw::invalid_argument);
     EXPECT_NO_THROW(alg.setGyroAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec)));
-    EXPECT_THROW(alg.setGyroAveragingWindow(
-                     static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec) + 0.001),
-                 fsw::invalid_argument);
+    EXPECT_THROW(
+        alg.setGyroAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec) + 0.001),
+        fsw::invalid_argument);
     EXPECT_NO_THROW(alg.setGyroAveragingWindow(0.25));
 
     EXPECT_THROW(alg.setAccelAveragingWindow(-0.1), fsw::invalid_argument);
     EXPECT_NO_THROW(alg.setAccelAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec)));
-    EXPECT_THROW(alg.setAccelAveragingWindow(
-                     static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec) + 0.001),
-                 fsw::invalid_argument);
+    EXPECT_THROW(
+        alg.setAccelAveragingWindow(static_cast<double>(AverageMimuDataAlgorithm::kMaxAveragingWindowSec) + 0.001),
+        fsw::invalid_argument);
     EXPECT_NO_THROW(alg.setAccelAveragingWindow(0.5));
 
     Eigen::Matrix3f badOrtho = Eigen::Matrix3f::Identity();
@@ -326,8 +323,8 @@ TEST(averageMimuDataTest, SetupTest) {
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
-    gyros.fill(Eigen::Vector3f{1.0f, 2.0f, 3.0f});
-    accels.fill(Eigen::Vector3f{4.0f, 5.0f, 6.0f});
+    gyros.fill(Eigen::Vector3f{1.0F, 2.0F, 3.0F});
+    accels.fill(Eigen::Vector3f{4.0F, 5.0F, 6.0F});
     fillPacket(in, 0, kSec2Nano, gyros, accels);
 
     EXPECT_NO_THROW((void)alg.update(in));
@@ -343,8 +340,8 @@ TEST(averageMimuDataTest, StrictMonotonicDropsRepeatedSnapshot) {
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
-    gyros.fill(Eigen::Vector3f{1.f, 2.f, 3.f});
-    accels.fill(Eigen::Vector3f{4.f, 5.f, 6.f});
+    gyros.fill(Eigen::Vector3f{1.0F, 2.0F, 3.0F});
+    accels.fill(Eigen::Vector3f{4.0F, 5.0F, 6.0F});
     fillPacket(in, 0, kSec2Nano, gyros, accels);
 
     const OutputAverageAccelAngleVel out_first = alg.update(in);
@@ -377,10 +374,10 @@ TEST(averageMimuDataTest, OverflowOverwritesOldest) {
         std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
         std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
         for (std::size_t s = 0; s < kSamplesPerPkt; ++s) {
-            const float fi = static_cast<float>(i);
-            const float fs = static_cast<float>(s);
+            const auto fi = static_cast<float>(i);
+            const auto fs = static_cast<float>(s);
             gyros[s] = Eigen::Vector3f{fi, fs, fi + fs};
-            accels[s] = Eigen::Vector3f{fi - fs, fi + 1.f, fs + 1.f};
+            accels[s] = Eigen::Vector3f{fi - fs, fi + 1.0F, fs + 1.0F};
             if (i >= kPacketsToFeed - AverageMimuDataAlgorithm::kRingCapacity) {
                 gyroSumRetained += gyros[s];
                 accelSumRetained += accels[s];
@@ -406,12 +403,12 @@ TEST(averageMimuDataTest, EmptySnapshotReEmitsRingAverage) {
     InputPktsData in{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gyros{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> accels{};
-    gyros.fill(Eigen::Vector3f{1.f, -2.f, 3.f});
-    accels.fill(Eigen::Vector3f{4.f, -5.f, 6.f});
+    gyros.fill(Eigen::Vector3f{1.0F, -2.0F, 3.0F});
+    accels.fill(Eigen::Vector3f{4.0F, -5.0F, 6.0F});
     fillPacket(in, 0, kSec2Nano, gyros, accels);
     const OutputAverageAccelAngleVel out_first = alg.update(in);
 
-    InputPktsData empty{};
+    const InputPktsData empty{};
     const OutputAverageAccelAngleVel out_second = alg.update(empty);
 
     EXPECT_EQ(out_second.gyroOmega_B, out_first.gyroOmega_B);
@@ -430,16 +427,16 @@ TEST(averageMimuDataTest, WindowShrinkMidStream) {
     InputPktsData in1{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gOld{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> aOld{};
-    gOld.fill(Eigen::Vector3f{2.f, 4.f, 6.f});
-    aOld.fill(Eigen::Vector3f{8.f, 10.f, 12.f});
+    gOld.fill(Eigen::Vector3f{2.0F, 4.0F, 6.0F});
+    aOld.fill(Eigen::Vector3f{8.0F, 10.0F, 12.0F});
     fillPacket(in1, 0, kSec2Nano, gOld, aOld);
     (void)alg.update(in1);
 
     InputPktsData in2{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gNew{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> aNew{};
-    gNew.fill(Eigen::Vector3f{1.f, 3.f, 5.f});
-    aNew.fill(Eigen::Vector3f{7.f, 9.f, 11.f});
+    gNew.fill(Eigen::Vector3f{1.0F, 3.0F, 5.0F});
+    aNew.fill(Eigen::Vector3f{7.0F, 9.0F, 11.0F});
     // 500 ms later: still within wide window for now.
     fillPacket(in2, 0, kSec2Nano + (50U * kPeriodNs), gNew, aNew);
     (void)alg.update(in2);
@@ -448,10 +445,10 @@ TEST(averageMimuDataTest, WindowShrinkMidStream) {
     // maxTimeTag) drop out. New packet's 10 samples all qualify.
     alg.setGyroAveragingWindow(0.1);
     alg.setAccelAveragingWindow(0.1);
-    InputPktsData empty{};
-    const OutputAverageAccelAngleVel out = alg.update(empty);
-    EXPECT_EQ(out.gyroOmega_B, gNew[0]);
-    EXPECT_EQ(out.accel_B, aNew[0]);
+    const InputPktsData empty{};
+    const auto [accel_B, gyroOmega_B] = alg.update(empty);
+    EXPECT_EQ(gyroOmega_B, gNew[0]);
+    EXPECT_EQ(accel_B, aNew[0]);
 }
 
 TEST(averageMimuDataTest, WindowGrowMidStream) {
@@ -464,16 +461,16 @@ TEST(averageMimuDataTest, WindowGrowMidStream) {
     InputPktsData in1{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gOld{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> aOld{};
-    gOld.fill(Eigen::Vector3f{1.f, 1.f, 1.f});
-    aOld.fill(Eigen::Vector3f{2.f, 2.f, 2.f});
+    gOld.fill(Eigen::Vector3f{1.0F, 1.0F, 1.0F});
+    aOld.fill(Eigen::Vector3f{2.0F, 2.0F, 2.0F});
     fillPacket(in1, 0, kSec2Nano, gOld, aOld);
     (void)alg.update(in1);
 
     InputPktsData in2{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gNew{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> aNew{};
-    gNew.fill(Eigen::Vector3f{3.f, 3.f, 3.f});
-    aNew.fill(Eigen::Vector3f{4.f, 4.f, 4.f});
+    gNew.fill(Eigen::Vector3f{3.0F, 3.0F, 3.0F});
+    aNew.fill(Eigen::Vector3f{4.0F, 4.0F, 4.0F});
     fillPacket(in2, 0, kSec2Nano + (50U * kPeriodNs), gNew, aNew);
     const OutputAverageAccelAngleVel out_tight = alg.update(in2);
 
@@ -483,11 +480,11 @@ TEST(averageMimuDataTest, WindowGrowMidStream) {
     // Grow window so both packets' samples qualify.
     alg.setGyroAveragingWindow(1.0);
     alg.setAccelAveragingWindow(1.0);
-    InputPktsData empty{};
+    const InputPktsData empty{};
     const OutputAverageAccelAngleVel out_wide = alg.update(empty);
 
-    EXPECT_EQ(out_wide.gyroOmega_B, (gOld[0] + gNew[0]) / 2.f);
-    EXPECT_EQ(out_wide.accel_B, (aOld[0] + aNew[0]) / 2.f);
+    EXPECT_EQ(out_wide.gyroOmega_B, (gOld[0] + gNew[0]) / 2.0F);
+    EXPECT_EQ(out_wide.accel_B, (aOld[0] + aNew[0]) / 2.0F);
 }
 
 TEST(averageMimuDataTest, OutOfOrderPacketDropped) {
@@ -500,16 +497,16 @@ TEST(averageMimuDataTest, OutOfOrderPacketDropped) {
     InputPktsData in1{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gOk{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> aOk{};
-    gOk.fill(Eigen::Vector3f{5.f, 6.f, 7.f});
-    aOk.fill(Eigen::Vector3f{8.f, 9.f, 10.f});
+    gOk.fill(Eigen::Vector3f{5.0F, 6.0F, 7.0F});
+    aOk.fill(Eigen::Vector3f{8.0F, 9.0F, 10.0F});
     fillPacket(in1, 0, kSec2Nano, gOk, aOk);
     (void)alg.update(in1);
 
     InputPktsData in2{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> gLoud{};
     std::array<Eigen::Vector3f, kSamplesPerPkt> aLoud{};
-    gLoud.fill(Eigen::Vector3f{99.f, 99.f, 99.f});
-    aLoud.fill(Eigen::Vector3f{99.f, 99.f, 99.f});
+    gLoud.fill(Eigen::Vector3f{99.0F, 99.0F, 99.0F});
+    aLoud.fill(Eigen::Vector3f{99.0F, 99.0F, 99.0F});
     fillPacket(in2, 0, kSec2Nano - (10U * kPeriodNs), gLoud, aLoud);
     const OutputAverageAccelAngleVel out = alg.update(in2);
 

--- a/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData.cpp
@@ -207,6 +207,74 @@ TEST(averageMimuDataTest, PropertyZeroAveragingWindow) {
     EXPECT_EQ(out_alg.accel_B, accTrue_B);
 }
 
+TEST(averageMimuDataTest, FirstFillZeroMeasTimeRegression) {
+    // Regression: before the staleness rule was introduced, unfilled ring-buffer
+    // slots (isValid=false, measTime=0) polluted the average because the
+    // algorithm iterated over every slot. With a single valid packet in slot 0,
+    // the output must equal dcm_BP * slot0 -- not slot0 divided by the buffer
+    // size.
+    AverageMimuDataAlgorithm alg;
+
+    Eigen::Matrix3f dcm_BP;
+    dcm_BP << 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f;
+    alg.setDcmPltfToBdy(dcm_BP);
+    alg.setAveragingWindow(1.0f);  // wide enough that zero-measTime slots would
+                                   // otherwise slip through the window filter
+
+    InputPktsData in{};  // zero-init: all isValid=false, measTime=0
+
+    const Eigen::Vector3f gyro0{1.f, 2.f, 3.f};
+    const Eigen::Vector3f acc0{4.f, 5.f, 6.f};
+    in.isValid[0] = true;
+    in.measTime[0] = SEC2NANO;
+    in.gyro_P[0] = gyro0;
+    in.accel_P[0] = acc0;
+
+    const OutputAverageAccelAngleVel out = alg.update(in);
+
+    EXPECT_EQ(out.gyroOmega_B, dcm_BP * gyro0);
+    EXPECT_EQ(out.accel_B, dcm_BP * acc0);
+}
+
+TEST(averageMimuDataTest, NoValidPacketsReturnsZero) {
+    // All slots default-initialized (isValid=false, measTime=0) -> zero output.
+    AverageMimuDataAlgorithm alg;
+    alg.setAveragingWindow(0.5f);
+
+    InputPktsData const in{};
+    const auto [accel_B, gyroOmega_B] = alg.update(in);
+
+    EXPECT_EQ(gyroOmega_B, Eigen::Vector3f::Zero());
+    EXPECT_EQ(accel_B, Eigen::Vector3f::Zero());
+}
+
+TEST(averageMimuDataTest, ValidFlagButZeroMeasTimeIsStale) {
+    // A slot with isValid=true but measTime=0 is treated as stale (unfilled).
+    // The only fresh slot is slot 0, so the output must equal dcm_BP * slot0.
+    AverageMimuDataAlgorithm alg;
+    alg.setDcmPltfToBdy(Eigen::Matrix3f::Identity());
+    alg.setAveragingWindow(1.0f);
+
+    InputPktsData in{};
+    const Eigen::Vector3f gyro0{1.f, 0.f, 0.f};
+    const Eigen::Vector3f acc0{0.f, 1.f, 0.f};
+    in.isValid[0] = true;
+    in.measTime[0] = SEC2NANO;
+    in.gyro_P[0] = gyro0;
+    in.accel_P[0] = acc0;
+
+    // Slot 1: isValid=true but measTime=0 -> must be skipped.
+    in.isValid[1] = true;
+    in.measTime[1] = 0U;
+    in.gyro_P[1] = Eigen::Vector3f{9.f, 9.f, 9.f};
+    in.accel_P[1] = Eigen::Vector3f{9.f, 9.f, 9.f};
+
+    const OutputAverageAccelAngleVel out = alg.update(in);
+
+    EXPECT_EQ(out.gyroOmega_B, gyro0);
+    EXPECT_EQ(out.accel_B, acc0);
+}
+
 TEST(averageMimuDataTest, SetupTest) {
     AverageMimuDataAlgorithm alg;
     // 1) Setters should not throw

--- a/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
+++ b/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
@@ -36,6 +36,7 @@ def test_average_mimu_data():
     dcm_pltf_to_body = RigidBodyKinematics.euler3212C([0.01, -0.04, 0.06]).astype(np.float32)
     module.setDcmPltfToBdy(dcm_pltf_to_body)
     module.setGyroAveragingWindow(_MAX_AVG_WINDOW_SEC)  # 2 s window covers the full ring
+    module.setAccelAveragingWindow(_MAX_AVG_WINDOW_SEC)  # accel uses the same full-ring window here
 
     mimu_pkt = messaging.MimuPacketF32Payload()
     mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=0)
@@ -131,6 +132,7 @@ def test_average_mimu_data_buffer_fill():
     dcm_pltf_to_body = np.eye(3, dtype=np.float32)
     module.setDcmPltfToBdy(dcm_pltf_to_body)
     module.setGyroAveragingWindow(_MAX_AVG_WINDOW_SEC)  # 2 s covers the full ring
+    module.setAccelAveragingWindow(_MAX_AVG_WINDOW_SEC)  # accel uses the same full-ring window here
 
     mimu_pkt = messaging.MimuPacketF32Payload()
     mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=0)

--- a/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
+++ b/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
@@ -83,5 +83,109 @@ def test_average_mimu_data():
     np.testing.assert_allclose(module_output_accel[1:, :], expected_accel, rtol=1e-8, atol=1e-6, verbose=True)
 
 
+def test_average_mimu_data_buffer_fill():
+    """Walk a 4-packet ring buffer from empty to full, then wrap.
+
+    Each packet carries MAX_MIMU_SAMPLES_PER_PKT individual samples. The
+    module should skip packets with isValid=False and skip samples with
+    measTime=0 within fresh packets. The averaged output should match the
+    hand-computed mean of the fresh samples at each cycle.
+    """
+    unit_task_name = "unitTask"
+    unit_process_name = "TestProcess"
+
+    unit_test_sim = SimulationBaseClass.SimBaseClass()
+
+    fsw_frequency = 10
+    max_mimu_pkt = 4
+    max_mimu_samples_per_pkt = 10
+    delta_time_sim = 1 / fsw_frequency
+    test_process_rate = macros.sec2nano(delta_time_sim)
+    test_proc = unit_test_sim.CreateNewProcess(unit_process_name)
+    test_proc.addTask(unit_test_sim.CreateNewTask(unit_task_name, test_process_rate))
+
+    module = averageMimuDataF32.AverageMimuData()
+    module.modelTag = "averageMimuData"
+
+    dcm_pltf_to_body = np.eye(3, dtype=np.float32)
+    module.setDcmPltfToBdy(dcm_pltf_to_body)
+    module.setAveragingWindow(1.0e10)  # wide window so only staleness matters
+
+    mimu_pkt = messaging.MimuPacketF32Payload()
+    mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=0)
+
+    unit_test_sim.AddModelToTask(unit_task_name, module)
+    data_log = module.imuOutMsg.recorder()
+    unit_test_sim.AddModelToTask(unit_task_name, data_log)
+    module.mimuPacketInMsg.subscribeTo(mimu_pkt_msg)
+    unit_test_sim.InitializeSimulation()
+
+    # Deterministic per-(packet, sample) gyro/accel grid and timestamps.
+    gyros = np.zeros((max_mimu_pkt, max_mimu_samples_per_pkt, 3), dtype=np.float32)
+    accels = np.zeros((max_mimu_pkt, max_mimu_samples_per_pkt, 3), dtype=np.float32)
+    times_s = np.zeros((max_mimu_pkt, max_mimu_samples_per_pkt), dtype=np.float64)
+    for p in range(max_mimu_pkt):
+        for s in range(max_mimu_samples_per_pkt):
+            gyros[p, s] = np.array([float(p), float(s), float(p + s)], dtype=np.float32)
+            accels[p, s] = np.array([float(p + 1), float(s + 1), float(p - s)], dtype=np.float32)
+            # 1 ms spacing keeps samples ordered and within the wide window.
+            times_s[p, s] = 0.10 + 0.001 * (p * max_mimu_samples_per_pkt + s)
+
+    # Pre-load every packet with its samples once; cycles only flip isValid.
+    for p in range(max_mimu_pkt):
+        for s in range(max_mimu_samples_per_pkt):
+            mimu_pkt.packets[p].samples[s].measTime = macros.sec2nano(float(times_s[p, s]))
+            mimu_pkt.packets[p].samples[s].gyro_B = gyros[p, s].tolist()
+            mimu_pkt.packets[p].samples[s].accel_B = accels[p, s].tolist()
+
+    cycles = 6
+    expected_gyro = np.zeros((cycles, 3), dtype=np.float32)
+    expected_accel = np.zeros((cycles, 3), dtype=np.float32)
+    sim_time = 0.0
+    valid_flags = [False] * max_mimu_pkt
+
+    for cycle in range(cycles):
+        if cycle == 0:
+            # Empty buffer.
+            valid_flags = [False] * max_mimu_pkt
+            expected_gyro[cycle] = 0.0
+            expected_accel[cycle] = 0.0
+        elif cycle <= max_mimu_pkt:
+            # Mark the first `cycle` packets valid.
+            valid_flags = [i < cycle for i in range(max_mimu_pkt)]
+            valid_pkts = cycle
+            sample_count = valid_pkts * max_mimu_samples_per_pkt
+            expected_gyro[cycle] = gyros[:valid_pkts].reshape(-1, 3).sum(axis=0) / sample_count
+            expected_accel[cycle] = accels[:valid_pkts].reshape(-1, 3).sum(axis=0) / sample_count
+        else:
+            # Wrap: overwrite packet 0 sample 0 with a much newer sample. With
+            # the wide window, every fresh sample still qualifies; the mean
+            # simply swaps the old packet[0][0] for the new one.
+            new_gyro = np.array([-1.0, -2.0, -3.0], dtype=np.float32)
+            new_accel = np.array([-4.0, -5.0, -6.0], dtype=np.float32)
+            mimu_pkt.packets[0].samples[0].measTime = macros.sec2nano(1.0)
+            mimu_pkt.packets[0].samples[0].gyro_B = new_gyro.tolist()
+            mimu_pkt.packets[0].samples[0].accel_B = new_accel.tolist()
+            sample_count = max_mimu_pkt * max_mimu_samples_per_pkt
+            gyro_sum = gyros.reshape(-1, 3).sum(axis=0) - gyros[0, 0] + new_gyro
+            accel_sum = accels.reshape(-1, 3).sum(axis=0) - accels[0, 0] + new_accel
+            expected_gyro[cycle] = gyro_sum / sample_count
+            expected_accel[cycle] = accel_sum / sample_count
+
+        mimu_pkt.isValid = list(valid_flags)
+        sim_time += delta_time_sim
+        mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=macros.sec2nano(sim_time))
+        module.mimuPacketInMsg.subscribeTo(mimu_pkt_msg)
+        unit_test_sim.ConfigureStopTime(macros.sec2nano(sim_time))
+        unit_test_sim.ExecuteSimulation()
+
+    module_output_gyro = data_log.AngVelBody[1:, :]
+    module_output_accel = data_log.AccelBody[1:, :]
+
+    np.testing.assert_allclose(module_output_gyro, expected_gyro, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(module_output_accel, expected_accel, rtol=1e-6, atol=1e-6)
+
+
 if __name__ == "__main__":
     test_average_mimu_data()
+    test_average_mimu_data_buffer_fill()

--- a/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
+++ b/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
@@ -7,18 +7,24 @@ from xmera.architecture import messaging
 from xmera.utilities import RigidBodyKinematics
 
 
-def test_average_mimu_data():
-    """Module Unit Test"""
-    unit_task_name = "unitTask"  # arbitrary name (don't change)
-    unit_process_name = "TestProcess"  # arbitrary name (don't change)
+# Algorithm-side compile-time constants. Mirrors averageMimuDataAlgorithm.h.
+_MIMU_SAMPLE_PERIOD_NS = 10_000_000  # 100 Hz device sample rate
+_MAX_AVG_WINDOW_SEC = 2.0
+_RING_CAPACITY_PACKETS = 20  # ceil(100 Hz * 2 s / 10 samples_per_pkt)
+_MAX_MIMU_PKT = 4
+_MAX_MIMU_SAMPLES_PER_PKT = 10
+_PACKET_SPAN_NS = _MIMU_SAMPLE_PERIOD_NS * _MAX_MIMU_SAMPLES_PER_PKT  # 100 ms / packet
 
-    # Create a sim module as an empty container
+
+def test_average_mimu_data():
+    """Module Unit Test: cumulative averaging across cycles with ring eviction."""
+    unit_task_name = "unitTask"
+    unit_process_name = "TestProcess"
+
     unit_test_sim = SimulationBaseClass.SimBaseClass()
 
-    fsw_frequency = 10  # Set fsw frequency to 10 Hz
+    fsw_frequency = 10  # 10 Hz FSW
     num_fsw_steps = 12
-    max_mimu_pkt = 4
-    max_mimu_samples_per_pkt = 10  # matches MAX_MIMU_SAMPLES_PER_PKT in C++
     delta_time_sim = 1 / fsw_frequency
     test_process_rate = macros.sec2nano(delta_time_sim)
     test_proc = unit_test_sim.CreateNewProcess(unit_process_name)
@@ -29,8 +35,7 @@ def test_average_mimu_data():
 
     dcm_pltf_to_body = RigidBodyKinematics.euler3212C([0.01, -0.04, 0.06]).astype(np.float32)
     module.setDcmPltfToBdy(dcm_pltf_to_body)
-    duration_window = 1.0e10  # huge window so the average covers every fresh sample
-    module.setAveragingWindow(duration_window)
+    module.setAveragingWindow(_MAX_AVG_WINDOW_SEC)  # 2 s window covers the full ring
 
     mimu_pkt = messaging.MimuPacketF32Payload()
     mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=0)
@@ -41,55 +46,73 @@ def test_average_mimu_data():
     module.mimuPacketInMsg.subscribeTo(mimu_pkt_msg)
     unit_test_sim.InitializeSimulation()
 
-    total_samples_per_cycle = max_mimu_pkt * max_mimu_samples_per_pkt
-    delta_time = delta_time_sim / total_samples_per_cycle
-    meas_time = 0.0
-    sim_time = 0.0
     expected_gyro = np.zeros([num_fsw_steps, 3], dtype=np.float32)
     expected_accel = np.zeros([num_fsw_steps, 3], dtype=np.float32)
+
+    # Each cycle ingests _MAX_MIMU_PKT new packets (always strictly newer than
+    # the prior cycle's max). Once (k+1)*_MAX_MIMU_PKT exceeds _RING_CAPACITY,
+    # the oldest packets get overwritten on insert. cycles_per_ring is the
+    # number of whole cycles' worth of packets the ring holds.
+    cycles_per_ring = _RING_CAPACITY_PACKETS // _MAX_MIMU_PKT  # 5
+    cycle_gyro_sums = []
+    cycle_accel_sums = []
+
+    # Monotonic packet-time counter. Each packet advances by _PACKET_SPAN_NS.
+    next_packet_time_ns = macros.sec2nano(0.001)
+    sim_time = 0.0
+
     for index in range(num_fsw_steps):
         gyro_sum = np.zeros(3, dtype=np.float32)
         accel_sum = np.zeros(3, dtype=np.float32)
-        for p in range(max_mimu_pkt):
-            for s in range(max_mimu_samples_per_pkt):
-                meas_time += delta_time
-                mimu_pkt.packets[p].samples[s].measTime = macros.sec2nano(meas_time)
+        for p in range(_MAX_MIMU_PKT):
+            mimu_pkt.packets[p].measTime = next_packet_time_ns
+            next_packet_time_ns += _PACKET_SPAN_NS
+            for s in range(_MAX_MIMU_SAMPLES_PER_PKT):
                 gyro_sample = np.random.normal(loc=2, scale=1, size=3).astype(np.float32)
-                gyro_sum += gyro_sample
-                mimu_pkt.packets[p].samples[s].gyro_B = gyro_sample.tolist()
                 accel_sample = np.random.normal(loc=2, scale=1, size=3).astype(np.float32)
-                accel_sum += accel_sample
+                mimu_pkt.packets[p].samples[s].gyro_B = gyro_sample.tolist()
                 mimu_pkt.packets[p].samples[s].accel_B = accel_sample.tolist()
-        mimu_pkt.isValid = [True] * max_mimu_pkt
-        gyro_average = np.dot(dcm_pltf_to_body, gyro_sum / total_samples_per_cycle)
-        accel_average = np.dot(dcm_pltf_to_body, accel_sum / total_samples_per_cycle)
-        expected_gyro[index, :] = gyro_average
-        expected_accel[index, :] = accel_average
-        sim_time += 1 / fsw_frequency
+                gyro_sum += gyro_sample
+                accel_sum += accel_sample
+        mimu_pkt.isValid = [True] * _MAX_MIMU_PKT
+        cycle_gyro_sums.append(gyro_sum)
+        cycle_accel_sums.append(accel_sum)
+
+        cycles_in_ring = min(index + 1, cycles_per_ring)
+        first_retained = (index + 1) - cycles_in_ring
+        cumulative_gyro = np.sum(cycle_gyro_sums[first_retained : index + 1], axis=0)
+        cumulative_accel = np.sum(cycle_accel_sums[first_retained : index + 1], axis=0)
+        sample_count = cycles_in_ring * _MAX_MIMU_PKT * _MAX_MIMU_SAMPLES_PER_PKT
+
+        expected_gyro[index, :] = np.dot(dcm_pltf_to_body, cumulative_gyro / sample_count)
+        expected_accel[index, :] = np.dot(dcm_pltf_to_body, cumulative_accel / sample_count)
+        sim_time += delta_time_sim
         mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=macros.sec2nano(sim_time))
         module.mimuPacketInMsg.subscribeTo(mimu_pkt_msg)
         unit_test_sim.ConfigureStopTime(macros.sec2nano(sim_time))
         unit_test_sim.ExecuteSimulation()
 
-    np.testing.assert_allclose(duration_window, module.getAveragingWindow(), rtol=1e-8, atol=1e-6, verbose=True)
+    np.testing.assert_allclose(_MAX_AVG_WINDOW_SEC, module.getAveragingWindow(), rtol=1e-8, atol=1e-9, verbose=True)
     np.testing.assert_allclose(dcm_pltf_to_body, module.getDcmPltfToBdy(), rtol=1e-8, atol=1e-6, verbose=True)
 
     module_output_accel = data_log.AccelBody
     module_output_angular_velocity = data_log.AngVelBody
 
     np.testing.assert_allclose(
-        module_output_angular_velocity[1:, :], expected_gyro, rtol=1e-8, atol=1e-6, verbose=True
+        module_output_angular_velocity[1:, :], expected_gyro, rtol=1e-6, atol=1e-6, verbose=True
     )
-    np.testing.assert_allclose(module_output_accel[1:, :], expected_accel, rtol=1e-8, atol=1e-6, verbose=True)
+    np.testing.assert_allclose(module_output_accel[1:, :], expected_accel, rtol=1e-6, atol=1e-6, verbose=True)
 
 
 def test_average_mimu_data_buffer_fill():
-    """Walk a 4-packet ring buffer from empty to full, then wrap.
+    """Walk the algorithm-owned ring buffer from empty to wrap.
 
-    Each packet carries MAX_MIMU_SAMPLES_PER_PKT individual samples. The
-    module should skip packets with isValid=False and skip samples with
-    measTime=0 within fresh packets. The averaged output should match the
-    hand-computed mean of the fresh samples at each cycle.
+    Cycle 0: no valid packets -> zero output.
+    Cycles 1..4: progressively mark packets 0..(cycle-1) valid. Each cycle
+                 only the newest packet (one not yet in the ring) is ingested
+                 due to strict-monotonic by packet measTime.
+    Cycle 5:     wrap. Packet 0's measTime jumps far ahead; only that packet
+                 is ingested as a new ring slot. Other packets are dropped.
     """
     unit_task_name = "unitTask"
     unit_process_name = "TestProcess"
@@ -97,8 +120,6 @@ def test_average_mimu_data_buffer_fill():
     unit_test_sim = SimulationBaseClass.SimBaseClass()
 
     fsw_frequency = 10
-    max_mimu_pkt = 4
-    max_mimu_samples_per_pkt = 10
     delta_time_sim = 1 / fsw_frequency
     test_process_rate = macros.sec2nano(delta_time_sim)
     test_proc = unit_test_sim.CreateNewProcess(unit_process_name)
@@ -109,7 +130,7 @@ def test_average_mimu_data_buffer_fill():
 
     dcm_pltf_to_body = np.eye(3, dtype=np.float32)
     module.setDcmPltfToBdy(dcm_pltf_to_body)
-    module.setAveragingWindow(1.0e10)  # wide window so only staleness matters
+    module.setAveragingWindow(_MAX_AVG_WINDOW_SEC)  # 2 s covers the full ring
 
     mimu_pkt = messaging.MimuPacketF32Payload()
     mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=0)
@@ -120,21 +141,20 @@ def test_average_mimu_data_buffer_fill():
     module.mimuPacketInMsg.subscribeTo(mimu_pkt_msg)
     unit_test_sim.InitializeSimulation()
 
-    # Deterministic per-(packet, sample) gyro/accel grid and timestamps.
-    gyros = np.zeros((max_mimu_pkt, max_mimu_samples_per_pkt, 3), dtype=np.float32)
-    accels = np.zeros((max_mimu_pkt, max_mimu_samples_per_pkt, 3), dtype=np.float32)
-    times_s = np.zeros((max_mimu_pkt, max_mimu_samples_per_pkt), dtype=np.float64)
-    for p in range(max_mimu_pkt):
-        for s in range(max_mimu_samples_per_pkt):
+    # Deterministic per-(packet, sample) gyro/accel grid.
+    gyros = np.zeros((_MAX_MIMU_PKT, _MAX_MIMU_SAMPLES_PER_PKT, 3), dtype=np.float32)
+    accels = np.zeros((_MAX_MIMU_PKT, _MAX_MIMU_SAMPLES_PER_PKT, 3), dtype=np.float32)
+    for p in range(_MAX_MIMU_PKT):
+        for s in range(_MAX_MIMU_SAMPLES_PER_PKT):
             gyros[p, s] = np.array([float(p), float(s), float(p + s)], dtype=np.float32)
             accels[p, s] = np.array([float(p + 1), float(s + 1), float(p - s)], dtype=np.float32)
-            # 1 ms spacing keeps samples ordered and within the wide window.
-            times_s[p, s] = 0.10 + 0.001 * (p * max_mimu_samples_per_pkt + s)
 
-    # Pre-load every packet with its samples once; cycles only flip isValid.
-    for p in range(max_mimu_pkt):
-        for s in range(max_mimu_samples_per_pkt):
-            mimu_pkt.packets[p].samples[s].measTime = macros.sec2nano(float(times_s[p, s]))
+    # Pre-load every packet's gyro/accel. measTimes spaced by packet span so
+    # each subsequent packet is strictly newer (one packet's tail = next's head).
+    base_packet_time_ns = macros.sec2nano(0.001)
+    for p in range(_MAX_MIMU_PKT):
+        mimu_pkt.packets[p].measTime = base_packet_time_ns + (p * _PACKET_SPAN_NS)
+        for s in range(_MAX_MIMU_SAMPLES_PER_PKT):
             mimu_pkt.packets[p].samples[s].gyro_B = gyros[p, s].tolist()
             mimu_pkt.packets[p].samples[s].accel_B = accels[p, s].tolist()
 
@@ -142,33 +162,40 @@ def test_average_mimu_data_buffer_fill():
     expected_gyro = np.zeros((cycles, 3), dtype=np.float32)
     expected_accel = np.zeros((cycles, 3), dtype=np.float32)
     sim_time = 0.0
-    valid_flags = [False] * max_mimu_pkt
+    valid_flags = [False] * _MAX_MIMU_PKT
 
     for cycle in range(cycles):
         if cycle == 0:
-            # Empty buffer.
-            valid_flags = [False] * max_mimu_pkt
+            valid_flags = [False] * _MAX_MIMU_PKT
             expected_gyro[cycle] = 0.0
             expected_accel[cycle] = 0.0
-        elif cycle <= max_mimu_pkt:
-            # Mark the first `cycle` packets valid.
-            valid_flags = [i < cycle for i in range(max_mimu_pkt)]
+        elif cycle <= _MAX_MIMU_PKT:
+            # Mark the first `cycle` packets valid. Strict-monotonic ingest
+            # means only the newest (packet `cycle-1`) is added each call;
+            # the earlier packets were already ingested on prior cycles.
+            valid_flags = [i < cycle for i in range(_MAX_MIMU_PKT)]
             valid_pkts = cycle
-            sample_count = valid_pkts * max_mimu_samples_per_pkt
+            sample_count = valid_pkts * _MAX_MIMU_SAMPLES_PER_PKT
             expected_gyro[cycle] = gyros[:valid_pkts].reshape(-1, 3).sum(axis=0) / sample_count
             expected_accel[cycle] = accels[:valid_pkts].reshape(-1, 3).sum(axis=0) / sample_count
         else:
-            # Wrap: overwrite packet 0 sample 0 with a much newer sample. With
-            # the wide window, every fresh sample still qualifies; the mean
-            # simply swaps the old packet[0][0] for the new one.
-            new_gyro = np.array([-1.0, -2.0, -3.0], dtype=np.float32)
-            new_accel = np.array([-4.0, -5.0, -6.0], dtype=np.float32)
-            mimu_pkt.packets[0].samples[0].measTime = macros.sec2nano(1.0)
-            mimu_pkt.packets[0].samples[0].gyro_B = new_gyro.tolist()
-            mimu_pkt.packets[0].samples[0].accel_B = new_accel.tolist()
-            sample_count = max_mimu_pkt * max_mimu_samples_per_pkt
-            gyro_sum = gyros.reshape(-1, 3).sum(axis=0) - gyros[0, 0] + new_gyro
-            accel_sum = accels.reshape(-1, 3).sum(axis=0) - accels[0, 0] + new_accel
+            # Wrap: packet 0's measTime jumps far ahead. Only this packet is
+            # ingested; the others (still at their original measTimes) are
+            # rejected by the strict-monotonic gate. Ring grows from 4 to 5
+            # slots; each of those 10-sample groups uses the derived
+            # schedule for staleness so all 50 samples qualify.
+            wrap_gyros = gyros[0].copy()
+            wrap_accels = accels[0].copy()
+            wrap_gyros[0] = np.array([-1.0, -2.0, -3.0], dtype=np.float32)
+            wrap_accels[0] = np.array([-4.0, -5.0, -6.0], dtype=np.float32)
+            mimu_pkt.packets[0].measTime = macros.sec2nano(1.0)
+            for s in range(_MAX_MIMU_SAMPLES_PER_PKT):
+                mimu_pkt.packets[0].samples[s].gyro_B = wrap_gyros[s].tolist()
+                mimu_pkt.packets[0].samples[s].accel_B = wrap_accels[s].tolist()
+
+            sample_count = 5 * _MAX_MIMU_SAMPLES_PER_PKT
+            gyro_sum = gyros.reshape(-1, 3).sum(axis=0) + wrap_gyros.sum(axis=0)
+            accel_sum = accels.reshape(-1, 3).sum(axis=0) + wrap_accels.sum(axis=0)
             expected_gyro[cycle] = gyro_sum / sample_count
             expected_accel[cycle] = accel_sum / sample_count
 

--- a/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
+++ b/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
@@ -15,94 +15,73 @@ def test_average_mimu_data():
     # Create a sim module as an empty container
     unit_test_sim = SimulationBaseClass.SimBaseClass()
 
-    # Create test thread
     fsw_frequency = 10  # Set fsw frequency to 10 Hz
-    mimu_frequency = 100  # Set mimu sensor frequency to 100 Hz
     num_fsw_steps = 12
-    samples_per_fsw = int(mimu_frequency / fsw_frequency)
-    max_acc_buf_pkt = 120  # matches MAX_ACC_BUF_PKT in C++
-    delta_time_sim = 1 / fsw_frequency  # The averageMimuData module will run at the fsw frequency
-    test_process_rate = macros.sec2nano(delta_time_sim)  # update process rate update time
+    max_mimu_pkt = 4
+    max_mimu_samples_per_pkt = 10  # matches MAX_MIMU_SAMPLES_PER_PKT in C++
+    delta_time_sim = 1 / fsw_frequency
+    test_process_rate = macros.sec2nano(delta_time_sim)
     test_proc = unit_test_sim.CreateNewProcess(unit_process_name)
     test_proc.addTask(unit_test_sim.CreateNewTask(unit_task_name, test_process_rate))
 
-    # Construct algorithm and associated C++ container
     module = averageMimuDataF32.AverageMimuData()
     module.modelTag = "averageMimuData"
 
-    # Define parameters
     dcm_pltf_to_body = RigidBodyKinematics.euler3212C([0.01, -0.04, 0.06]).astype(np.float32)
     module.setDcmPltfToBdy(dcm_pltf_to_body)
-    duration_window = 1.0e10 # make the time window so huge that average is taken over all packets
+    duration_window = 1.0e10  # huge window so the average covers every fresh sample
     module.setAveragingWindow(duration_window)
 
-    # Initialize message for message connection
-    acc_data = messaging.AccDataMsgF32Payload()
-    acc_data_msg = messaging.AccDataMsgF32().write(acc_data, time=0)
+    mimu_pkt = messaging.MimuPacketF32Payload()
+    mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=0)
 
-    # Add test module to runtime call list
     unit_test_sim.AddModelToTask(unit_task_name, module)
-
-    # Setup logging on the test module output message so that we get all the writes to it
     data_log = module.imuOutMsg.recorder()
     unit_test_sim.AddModelToTask(unit_task_name, data_log)
-
-    # Connect messages
-    module.accDataInMsg.subscribeTo(acc_data_msg)
-
-    # Initialize simulation
+    module.mimuPacketInMsg.subscribeTo(mimu_pkt_msg)
     unit_test_sim.InitializeSimulation()
 
-    # Write accData message
-    delta_time = delta_time_sim / 10
-    meas_time = 0
-    sim_time = 0
-    counter = 0
-    gyro_sum = np.zeros(3, dtype=np.float32)
-    accel_sum = np.zeros(3,dtype=np.float32)
-    average_imu_output = np.zeros([num_fsw_steps, 3], dtype=np.float32)
-    average_acc_output = np.zeros([num_fsw_steps, 3], dtype=np.float32)
+    total_samples_per_cycle = max_mimu_pkt * max_mimu_samples_per_pkt
+    delta_time = delta_time_sim / total_samples_per_cycle
+    meas_time = 0.0
+    sim_time = 0.0
+    expected_gyro = np.zeros([num_fsw_steps, 3], dtype=np.float32)
+    expected_accel = np.zeros([num_fsw_steps, 3], dtype=np.float32)
     for index in range(num_fsw_steps):
-        for _ in range(samples_per_fsw):
-            meas_time += delta_time
-            acc_data.accPkts[counter].measTime = macros.sec2nano(meas_time)
-            random_array = np.random.normal(loc=2, scale=1, size=3).astype(np.float32)
-            gyro_sum += random_array
-            acc_data.accPkts[counter].gyro_B = random_array.tolist()
-            random_array = np.random.normal(loc=2, scale=1, size=3).astype(np.float32)
-            accel_sum += random_array
-            acc_data.accPkts[counter].accel_B = random_array.tolist()
-            counter += 1
-        gyro_average = gyro_sum / max_acc_buf_pkt
-        gyro_average = np.dot(dcm_pltf_to_body, gyro_average)
-        accel_average = accel_sum / max_acc_buf_pkt
-        accel_average = np.dot(dcm_pltf_to_body, accel_average)
-        average_imu_output[index, :] = gyro_average
-        average_acc_output[index, :] = accel_average
+        gyro_sum = np.zeros(3, dtype=np.float32)
+        accel_sum = np.zeros(3, dtype=np.float32)
+        for p in range(max_mimu_pkt):
+            for s in range(max_mimu_samples_per_pkt):
+                meas_time += delta_time
+                mimu_pkt.packets[p].samples[s].measTime = macros.sec2nano(meas_time)
+                gyro_sample = np.random.normal(loc=2, scale=1, size=3).astype(np.float32)
+                gyro_sum += gyro_sample
+                mimu_pkt.packets[p].samples[s].gyro_B = gyro_sample.tolist()
+                accel_sample = np.random.normal(loc=2, scale=1, size=3).astype(np.float32)
+                accel_sum += accel_sample
+                mimu_pkt.packets[p].samples[s].accel_B = accel_sample.tolist()
+        mimu_pkt.isValid = [True] * max_mimu_pkt
+        gyro_average = np.dot(dcm_pltf_to_body, gyro_sum / total_samples_per_cycle)
+        accel_average = np.dot(dcm_pltf_to_body, accel_sum / total_samples_per_cycle)
+        expected_gyro[index, :] = gyro_average
+        expected_accel[index, :] = accel_average
         sim_time += 1 / fsw_frequency
-        acc_data_msg = messaging.AccDataMsgF32().write(acc_data, time=macros.sec2nano(sim_time))
-        module.accDataInMsg.subscribeTo(acc_data_msg)
+        mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=macros.sec2nano(sim_time))
+        module.mimuPacketInMsg.subscribeTo(mimu_pkt_msg)
         unit_test_sim.ConfigureStopTime(macros.sec2nano(sim_time))
         unit_test_sim.ExecuteSimulation()
 
-    # Test the getters
     np.testing.assert_allclose(duration_window, module.getAveragingWindow(), rtol=1e-8, atol=1e-6, verbose=True)
     np.testing.assert_allclose(dcm_pltf_to_body, module.getDcmPltfToBdy(), rtol=1e-8, atol=1e-6, verbose=True)
 
-    # Pull logged data
     module_output_accel = data_log.AccelBody
     module_output_angular_velocity = data_log.AngVelBody
 
-    # compare the module results to the truth values
     np.testing.assert_allclose(
-        module_output_angular_velocity[1:, :], average_imu_output, rtol=1e-8, atol=1e-6, verbose=True
+        module_output_angular_velocity[1:, :], expected_gyro, rtol=1e-8, atol=1e-6, verbose=True
     )
-    np.testing.assert_allclose(module_output_accel[1:, :], average_acc_output, rtol=1e-8, atol=1e-6, verbose=True)
+    np.testing.assert_allclose(module_output_accel[1:, :], expected_accel, rtol=1e-8, atol=1e-6, verbose=True)
 
 
-#
-# This statement below ensures that the unitTestScript can be run as a
-# stand-along python script
-#
 if __name__ == "__main__":
     test_average_mimu_data()

--- a/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
+++ b/algorithms/averageMimuData/_tests/test_averageMimuDataF32.py
@@ -35,7 +35,7 @@ def test_average_mimu_data():
 
     dcm_pltf_to_body = RigidBodyKinematics.euler3212C([0.01, -0.04, 0.06]).astype(np.float32)
     module.setDcmPltfToBdy(dcm_pltf_to_body)
-    module.setAveragingWindow(_MAX_AVG_WINDOW_SEC)  # 2 s window covers the full ring
+    module.setGyroAveragingWindow(_MAX_AVG_WINDOW_SEC)  # 2 s window covers the full ring
 
     mimu_pkt = messaging.MimuPacketF32Payload()
     mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=0)
@@ -92,7 +92,7 @@ def test_average_mimu_data():
         unit_test_sim.ConfigureStopTime(macros.sec2nano(sim_time))
         unit_test_sim.ExecuteSimulation()
 
-    np.testing.assert_allclose(_MAX_AVG_WINDOW_SEC, module.getAveragingWindow(), rtol=1e-8, atol=1e-9, verbose=True)
+    np.testing.assert_allclose(_MAX_AVG_WINDOW_SEC, module.getGyroAveragingWindow(), rtol=1e-8, atol=1e-9, verbose=True)
     np.testing.assert_allclose(dcm_pltf_to_body, module.getDcmPltfToBdy(), rtol=1e-8, atol=1e-6, verbose=True)
 
     module_output_accel = data_log.AccelBody
@@ -130,7 +130,7 @@ def test_average_mimu_data_buffer_fill():
 
     dcm_pltf_to_body = np.eye(3, dtype=np.float32)
     module.setDcmPltfToBdy(dcm_pltf_to_body)
-    module.setAveragingWindow(_MAX_AVG_WINDOW_SEC)  # 2 s covers the full ring
+    module.setGyroAveragingWindow(_MAX_AVG_WINDOW_SEC)  # 2 s covers the full ring
 
     mimu_pkt = messaging.MimuPacketF32Payload()
     mimu_pkt_msg = messaging.MimuPacketF32().write(mimu_pkt, time=0)

--- a/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
@@ -1,23 +1,31 @@
 #include "../architecture/testUtilities/eigenFuzzDomains.hpp"
 #include "averageMimuDataTestHelpers.hpp"
+#include "averageMimuDataTypes.h"
 #include <fuzztest/fuzztest.h>
 
 namespace {
 auto sampleDomain() {
-    return fuzztest::StructOf<Sample>(fuzztest::Arbitrary<uint64_t>(),
-                                      xmera::fuzz::Vector3fInRange(-1e6F, 1e6F),
+    return fuzztest::StructOf<Sample>(xmera::fuzz::Vector3fInRange(-1e6F, 1e6F),
                                       xmera::fuzz::Vector3fInRange(-1e6F, 1e6F));
+}
+
+auto inputPacketDomain() {
+    return fuzztest::StructOf<InputPacket>(
+        fuzztest::Arbitrary<bool>(),
+        fuzztest::Arbitrary<uint64_t>(),
+        fuzztest::ArrayOf<MAX_MIMU_SAMPLES_PER_PKT_C>(sampleDomain()));
 }
 
 auto inputPktsDataDomain() {
     return fuzztest::StructOf<InputPktsData>(
-        fuzztest::ArrayOf<MAX_MIMU_PKT>(fuzztest::Arbitrary<bool>()),
-        fuzztest::ArrayOf<MAX_MIMU_PKT>(fuzztest::ArrayOf<MAX_MIMU_SAMPLES_PER_PKT>(sampleDomain())));
+        fuzztest::ArrayOf<MAX_MIMU_PKT_C>(inputPacketDomain()));
 }
 }  // namespace
 
 FUZZ_TEST(averageMimuDataFuzz, regressionTestAverageMimuData)
-    .WithDomains(fuzztest::InRange(0.0F, 1e6F), inputPktsDataDomain());
+    .WithDomains(fuzztest::InRange(0.0F, AverageMimuDataAlgorithm::kMaxAveragingWindowSec),
+                 inputPktsDataDomain());
 
 FUZZ_TEST(averageMimuDataFuzz, sequencedRegressionTestAverageMimuData)
-    .WithDomains(fuzztest::InRange(0.0F, 1e6F), fuzztest::VectorOf(inputPktsDataDomain()).WithSize(8));
+    .WithDomains(fuzztest::InRange(0.0F, AverageMimuDataAlgorithm::kMaxAveragingWindowSec),
+                 fuzztest::VectorOf(inputPktsDataDomain()).WithSize(8));

--- a/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
@@ -1,11 +1,20 @@
+#include "architecture/testUtilities/eigenFuzzDomains.hpp"
 #include "averageMimuDataTestHelpers.hpp"
 #include <fuzztest/fuzztest.h>
 
+namespace {
+auto sampleDomain() {
+    return fuzztest::StructOf<Sample>(fuzztest::Arbitrary<uint64_t>(),
+                                      xmera::fuzz::Vector3fInRange(-1e6F, 1e6F),
+                                      xmera::fuzz::Vector3fInRange(-1e6F, 1e6F));
+}
+
+auto inputPktsDataDomain() {
+    return fuzztest::StructOf<InputPktsData>(
+        fuzztest::ArrayOf<MAX_MIMU_PKT>(fuzztest::Arbitrary<bool>()),
+        fuzztest::ArrayOf<MAX_MIMU_PKT>(fuzztest::ArrayOf<MAX_MIMU_SAMPLES_PER_PKT>(sampleDomain())));
+}
+}  // namespace
+
 FUZZ_TEST(averageMimuDataFuzz, regressionTestAverageMimuData)
-    .WithDomains(fuzztest::InRange<std::size_t>(0U, MAX_ACC_BUF_PKT),
-                 fuzztest::InRange(0.0F, 1e6F),
-                 fuzztest::ArrayOf<MAX_ACC_BUF_PKT>(
-                     fuzztest::StructOf<InputData>(fuzztest::Arbitrary<uint64_t>(),
-                                                   fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6F, 1e6F)),
-                                                   fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6F, 1e6F)),
-                                                   fuzztest::Arbitrary<bool>())));
+    .WithDomains(fuzztest::InRange(0.0F, 1e6F), inputPktsDataDomain());

--- a/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
@@ -1,4 +1,4 @@
-#include "architecture/testUtilities/eigenFuzzDomains.hpp"
+#include "../architecture/testUtilities/eigenFuzzDomains.hpp"
 #include "averageMimuDataTestHelpers.hpp"
 #include <fuzztest/fuzztest.h>
 
@@ -18,3 +18,6 @@ auto inputPktsDataDomain() {
 
 FUZZ_TEST(averageMimuDataFuzz, regressionTestAverageMimuData)
     .WithDomains(fuzztest::InRange(0.0F, 1e6F), inputPktsDataDomain());
+
+FUZZ_TEST(averageMimuDataFuzz, sequencedRegressionTestAverageMimuData)
+    .WithDomains(fuzztest::InRange(0.0F, 1e6F), fuzztest::VectorOf(inputPktsDataDomain()).WithSize(8));

--- a/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
@@ -22,10 +22,12 @@ auto inputPktsDataDomain() {
 }
 }  // namespace
 
-FUZZ_TEST(averageMimuDataFuzz, regressionTestAverageMimuData)
+FUZZ_TEST(averageMimuDataFuzz, regressionTestAverageMimuDataWindows)
     .WithDomains(fuzztest::InRange(0.0F, AverageMimuDataAlgorithm::kMaxAveragingWindowSec),
+                 fuzztest::InRange(0.0F, AverageMimuDataAlgorithm::kMaxAveragingWindowSec),
                  inputPktsDataDomain());
 
-FUZZ_TEST(averageMimuDataFuzz, sequencedRegressionTestAverageMimuData)
+FUZZ_TEST(averageMimuDataFuzz, sequencedRegressionTestAverageMimuDataWindows)
     .WithDomains(fuzztest::InRange(0.0F, AverageMimuDataAlgorithm::kMaxAveragingWindowSec),
+                 fuzztest::InRange(0.0F, AverageMimuDataAlgorithm::kMaxAveragingWindowSec),
                  fuzztest::VectorOf(inputPktsDataDomain()).WithSize(8));

--- a/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
@@ -1,7 +1,7 @@
-#include "../architecture/testUtilities/eigenFuzzDomains.hpp"
 #include "averageMimuDataTestHelpers.hpp"
 #include "averageMimuDataTypes.h"
 #include <fuzztest/fuzztest.h>
+#include <utilities/testUtilities/eigenFuzzDomains.hpp>
 
 namespace {
 auto sampleDomain() {
@@ -10,15 +10,13 @@ auto sampleDomain() {
 }
 
 auto inputPacketDomain() {
-    return fuzztest::StructOf<InputPacket>(
-        fuzztest::Arbitrary<bool>(),
-        fuzztest::Arbitrary<uint64_t>(),
-        fuzztest::ArrayOf<MAX_MIMU_SAMPLES_PER_PKT_C>(sampleDomain()));
+    return fuzztest::StructOf<InputPacket>(fuzztest::Arbitrary<bool>(),
+                                           fuzztest::Arbitrary<uint64_t>(),
+                                           fuzztest::ArrayOf<MAX_MIMU_SAMPLES_PER_PKT_C>(sampleDomain()));
 }
 
 auto inputPktsDataDomain() {
-    return fuzztest::StructOf<InputPktsData>(
-        fuzztest::ArrayOf<MAX_MIMU_PKT_C>(inputPacketDomain()));
+    return fuzztest::StructOf<InputPktsData>(fuzztest::ArrayOf<MAX_MIMU_PKT_C>(inputPacketDomain()));
 }
 }  // namespace
 

--- a/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
+++ b/algorithms/averageMimuData/_tests/test_averageMimuData_fuzz.cpp
@@ -7,4 +7,5 @@ FUZZ_TEST(averageMimuDataFuzz, regressionTestAverageMimuData)
                  fuzztest::ArrayOf<MAX_ACC_BUF_PKT>(
                      fuzztest::StructOf<InputData>(fuzztest::Arbitrary<uint64_t>(),
                                                    fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6F, 1e6F)),
-                                                   fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6F, 1e6F)))));
+                                                   fuzztest::ArrayOf<3>(fuzztest::InRange(-1e6F, 1e6F)),
+                                                   fuzztest::Arbitrary<bool>())));

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -38,9 +38,9 @@ void AverageMimuData::updateState(uint64_t const callTime) {
     this->imuOutMsg.write(&localOutput, this->moduleID, callTime);
 }
 
-void AverageMimuData::setAveragingWindow(float const window) { this->algorithm.setAveragingWindow(window); }
+void AverageMimuData::setAveragingWindow(double const window) { this->algorithm.setAveragingWindow(window); }
 
-float AverageMimuData::getAveragingWindow() const { return this->algorithm.getAveragingWindow(); }
+double AverageMimuData::getAveragingWindow() const { return this->algorithm.getAveragingWindow(); }
 
 void AverageMimuData::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BP) { this->algorithm.setDcmPltfToBdy(dcm_BP); }
 

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -38,9 +38,9 @@ void AverageMimuData::updateState(uint64_t const callTime) {
     this->imuOutMsg.write(&localOutput, this->moduleID, callTime);
 }
 
-void AverageMimuData::setAveragingWindow(double const window) { this->algorithm.setAveragingWindow(window); }
+void AverageMimuData::setGyroAveragingWindow(double const window) { this->algorithm.setGyroAveragingWindow(window); }
 
-double AverageMimuData::getAveragingWindow() const { return this->algorithm.getAveragingWindow(); }
+double AverageMimuData::getGyroAveragingWindow() const { return this->algorithm.getGyroAveragingWindow(); }
 
 void AverageMimuData::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BP) { this->algorithm.setDcmPltfToBdy(dcm_BP); }
 

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -19,12 +19,19 @@ void AverageMimuData::updateState(uint64_t const callTime) {
 
     const AccDataMsgF32Payload localPkts = this->accDataInMsg();
     InputPktsData in{};
-    for (std::size_t i = 0; i < MAX_BUF_PKT; ++i) {
-        const auto& [measTime, gyro_B, accel_B] = localPkts.accPkts[i];
-        in.isValid[i] = true;
-        in.measTime[i] = measTime;
-        in.gyro_P[i] = Eigen::Vector3f(gyro_B[0], gyro_B[1], gyro_B[2]);
-        in.accel_P[i] = Eigen::Vector3f(accel_B[0], accel_B[1], accel_B[2]);
+    // Transition: source message still carries 120 single-measurement slots;
+    // partition the first MAX_MIMU_PKT * MAX_MIMU_SAMPLES_PER_PKT of them
+    // into the 4-packet x 10-sample grid expected by the algorithm. The
+    // module swaps to MimuPacketF32Payload in the following commit.
+    for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
+        in.isValid[p] = true;
+        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
+            const std::size_t idx = (p * MAX_MIMU_SAMPLES_PER_PKT) + s;
+            const auto& [measTime, gyro_B, accel_B] = localPkts.accPkts[idx];
+            in.samples[p][s].measTime = measTime;
+            in.samples[p][s].gyro_P = Eigen::Vector3f(gyro_B[0], gyro_B[1], gyro_B[2]);
+            in.samples[p][s].accel_P = Eigen::Vector3f(accel_B[0], accel_B[1], accel_B[2]);
+        }
     }
     const auto [accel_B, gyroOmega_B] = this->algorithm.update(in);
     IMUSensorBodyMsgF32Payload localOutput{};

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -21,6 +21,7 @@ void AverageMimuData::updateState(uint64_t const callTime) {
     InputPktsData in{};
     for (std::size_t i = 0; i < MAX_BUF_PKT; ++i) {
         const auto& [measTime, gyro_B, accel_B] = localPkts.accPkts[i];
+        in.isValid[i] = true;
         in.measTime[i] = measTime;
         in.gyro_P[i] = Eigen::Vector3f(gyro_B[0], gyro_B[1], gyro_B[2]);
         in.accel_P[i] = Eigen::Vector3f(accel_B[0], accel_B[1], accel_B[2]);

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -1,5 +1,5 @@
 #include "averageMimuData.h"
-#include "utilities/fsw/eigenSupport.h"
+#include <utilities/fsw/eigenSupport.h>
 
 void AverageMimuData::reset(uint64_t const callTime) {
     // check if the required message has not been connected
@@ -24,10 +24,8 @@ void AverageMimuData::updateState(uint64_t const callTime) {
         in.packets[p].measTime = packets[p].measTime;
         for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
             const auto& sample = packets[p].samples[s];
-            in.packets[p].samples[s].gyro_P =
-                Eigen::Vector3f(sample.gyro_B[0], sample.gyro_B[1], sample.gyro_B[2]);
-            in.packets[p].samples[s].accel_P =
-                Eigen::Vector3f(sample.accel_B[0], sample.accel_B[1], sample.accel_B[2]);
+            in.packets[p].samples[s].gyro_P = Eigen::Vector3f(sample.gyro_B[0], sample.gyro_B[1], sample.gyro_B[2]);
+            in.packets[p].samples[s].accel_P = Eigen::Vector3f(sample.accel_B[0], sample.accel_B[1], sample.accel_B[2]);
         }
     }
     const auto [accel_B, gyroOmega_B] = this->algorithm.update(in);

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -3,31 +3,26 @@
 
 void AverageMimuData::reset(uint64_t const callTime) {
     // check if the required message has not been connected
-    if (!this->accDataInMsg.isLinked()) {
-        throw std::invalid_argument("An accData input message name was not linked and is required for execution");
+    if (!this->mimuPacketInMsg.isLinked()) {
+        throw std::invalid_argument("A mimuPacket input message name was not linked and is required for execution");
     }
 }
 
 void AverageMimuData::updateState(uint64_t const callTime) {
     // Tracking the number of times that you do not receive new acceleration data
-    const uint64_t writeTime = this->accDataInMsg.timeWritten();
+    const uint64_t writeTime = this->mimuPacketInMsg.timeWritten();
     if (writeTime == this->prevInMsgTime) {
         this->staleDataCount++;
         return;
     }
     this->prevInMsgTime = writeTime;
 
-    const AccDataMsgF32Payload localPkts = this->accDataInMsg();
+    const auto [packets, isValid] = this->mimuPacketInMsg();
     InputPktsData in{};
-    // Transition: source message still carries 120 single-measurement slots;
-    // partition the first MAX_MIMU_PKT * MAX_MIMU_SAMPLES_PER_PKT of them
-    // into the 4-packet x 10-sample grid expected by the algorithm. The
-    // module swaps to MimuPacketF32Payload in the following commit.
     for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
-        in.isValid[p] = true;
+        in.isValid[p] = isValid[p];
         for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
-            const std::size_t idx = (p * MAX_MIMU_SAMPLES_PER_PKT) + s;
-            const auto& [measTime, gyro_B, accel_B] = localPkts.accPkts[idx];
+            const auto& [measTime, gyro_B, accel_B] = packets[p].samples[s];
             in.samples[p][s].measTime = measTime;
             in.samples[p][s].gyro_P = Eigen::Vector3f(gyro_B[0], gyro_B[1], gyro_B[2]);
             in.samples[p][s].accel_P = Eigen::Vector3f(accel_B[0], accel_B[1], accel_B[2]);

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -42,6 +42,10 @@ void AverageMimuData::setGyroAveragingWindow(double const window) { this->algori
 
 double AverageMimuData::getGyroAveragingWindow() const { return this->algorithm.getGyroAveragingWindow(); }
 
+void AverageMimuData::setAccelAveragingWindow(double const window) { this->algorithm.setAccelAveragingWindow(window); }
+
+double AverageMimuData::getAccelAveragingWindow() const { return this->algorithm.getAccelAveragingWindow(); }
+
 void AverageMimuData::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BP) { this->algorithm.setDcmPltfToBdy(dcm_BP); }
 
 Eigen::Matrix3f AverageMimuData::getDcmPltfToBdy() const { return this->algorithm.getDcmPltfToBdy(); }

--- a/algorithms/averageMimuData/averageMimuData.cpp
+++ b/algorithms/averageMimuData/averageMimuData.cpp
@@ -20,12 +20,14 @@ void AverageMimuData::updateState(uint64_t const callTime) {
     const auto [packets, isValid] = this->mimuPacketInMsg();
     InputPktsData in{};
     for (std::size_t p = 0; p < MAX_MIMU_PKT; ++p) {
-        in.isValid[p] = isValid[p];
+        in.packets[p].isValid = isValid[p];
+        in.packets[p].measTime = packets[p].measTime;
         for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; ++s) {
-            const auto& [measTime, gyro_B, accel_B] = packets[p].samples[s];
-            in.samples[p][s].measTime = measTime;
-            in.samples[p][s].gyro_P = Eigen::Vector3f(gyro_B[0], gyro_B[1], gyro_B[2]);
-            in.samples[p][s].accel_P = Eigen::Vector3f(accel_B[0], accel_B[1], accel_B[2]);
+            const auto& sample = packets[p].samples[s];
+            in.packets[p].samples[s].gyro_P =
+                Eigen::Vector3f(sample.gyro_B[0], sample.gyro_B[1], sample.gyro_B[2]);
+            in.packets[p].samples[s].accel_P =
+                Eigen::Vector3f(sample.accel_B[0], sample.accel_B[1], sample.accel_B[2]);
         }
     }
     const auto [accel_B, gyroOmega_B] = this->algorithm.update(in);

--- a/algorithms/averageMimuData/averageMimuData.h
+++ b/algorithms/averageMimuData/averageMimuData.h
@@ -12,6 +12,8 @@ class AverageMimuData : public SysModel {
     void updateState(uint64_t callTime) override;
     void setGyroAveragingWindow(double window);               //!< [s] Setter method for gyroAveragingWindow
     double getGyroAveragingWindow() const;                    //!< [s] Getter method for gyroAveragingWindow
+    void setAccelAveragingWindow(double window);              //!< [s] Setter method for accelAveragingWindow
+    double getAccelAveragingWindow() const;                   //!< [s] Getter method for accelAveragingWindow
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BP);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;              //!< Getter method for dcm from platform to body
 

--- a/algorithms/averageMimuData/averageMimuData.h
+++ b/algorithms/averageMimuData/averageMimuData.h
@@ -10,8 +10,8 @@ class AverageMimuData : public SysModel {
    public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
-    void setAveragingWindow(double window);               //!< [s] Setter method for averagingWindow
-    double getAveragingWindow() const;                    //!< [s] Getter method for averagingWindow
+    void setGyroAveragingWindow(double window);               //!< [s] Setter method for gyroAveragingWindow
+    double getGyroAveragingWindow() const;                    //!< [s] Getter method for gyroAveragingWindow
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BP);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;              //!< Getter method for dcm from platform to body
 

--- a/algorithms/averageMimuData/averageMimuData.h
+++ b/algorithms/averageMimuData/averageMimuData.h
@@ -10,8 +10,8 @@ class AverageMimuData : public SysModel {
    public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
-    void setAveragingWindow(float window);                //!< [s] Setter method for averagingWindow
-    float getAveragingWindow() const;                     //!< [s] Getter method for averagingWindow
+    void setAveragingWindow(double window);               //!< [s] Setter method for averagingWindow
+    double getAveragingWindow() const;                    //!< [s] Getter method for averagingWindow
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BP);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;              //!< Getter method for dcm from platform to body
 

--- a/algorithms/averageMimuData/averageMimuData.h
+++ b/algorithms/averageMimuData/averageMimuData.h
@@ -4,8 +4,7 @@
 #include "architecture/messaging/messaging.h"
 #include "averageMimuDataAlgorithm.h"
 #include "msgPayloadDef/IMUSensorBodyMsgF32Payload.h"
-
-#include <cstdint>
+#include "msgPayloadDef/MimuPacketF32Payload.h"
 
 class AverageMimuData : public SysModel {
    public:
@@ -17,7 +16,7 @@ class AverageMimuData : public SysModel {
     Eigen::Matrix3f getDcmPltfToBdy() const;              //!< Getter method for dcm from platform to body
 
     Message<IMUSensorBodyMsgF32Payload> imuOutMsg;
-    ReadFunctor<AccDataMsgF32Payload> accDataInMsg;
+    ReadFunctor<MimuPacketF32Payload> mimuPacketInMsg;
 
    private:
     uint64_t prevInMsgTime = 0;  /*!< [ns] Measurement time of the previous message*/

--- a/algorithms/averageMimuData/averageMimuData.h
+++ b/algorithms/averageMimuData/averageMimuData.h
@@ -1,19 +1,19 @@
 #ifndef AVERAGE_MIMU_DATA_H
 #define AVERAGE_MIMU_DATA_H
 
-#include "architecture/messaging/messaging.h"
 #include "averageMimuDataAlgorithm.h"
 #include "msgPayloadDef/IMUSensorBodyMsgF32Payload.h"
 #include "msgPayloadDef/MimuPacketF32Payload.h"
+#include <architecture/messaging/messaging.h>
 
 class AverageMimuData : public SysModel {
    public:
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
-    void setGyroAveragingWindow(double window);               //!< [s] Setter method for gyroAveragingWindow
-    double getGyroAveragingWindow() const;                    //!< [s] Getter method for gyroAveragingWindow
-    void setAccelAveragingWindow(double window);              //!< [s] Setter method for accelAveragingWindow
-    double getAccelAveragingWindow() const;                   //!< [s] Getter method for accelAveragingWindow
+    void setGyroAveragingWindow(double window);           //!< [s] Setter method for gyroAveragingWindow
+    double getGyroAveragingWindow() const;                //!< [s] Getter method for gyroAveragingWindow
+    void setAccelAveragingWindow(double window);          //!< [s] Setter method for accelAveragingWindow
+    double getAccelAveragingWindow() const;               //!< [s] Getter method for accelAveragingWindow
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BP);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;              //!< Getter method for dcm from platform to body
 

--- a/algorithms/averageMimuData/averageMimuData.rst
+++ b/algorithms/averageMimuData/averageMimuData.rst
@@ -4,15 +4,19 @@
 
 Executive Summary
 -----------------
-The ``averageMimuData`` algorithm computes a rolling average of recent gyro and accelerometer samples from a MIMU
-packet buffer. It uses the newest packet time tag as the reference time, selects all packets whose measurement timeTag with respect to the reference time is within a
-user-specified window (``averagingWindow``), averages the selected measurements, and outputs the averaged values expressed in
-the body frame using a user-provided direction cosine matrix (DCM) ``dcm_BP``.
+The ``averageMimuData`` algorithm computes a rolling average of recent gyro and accelerometer measurements drawn from a
+small ring of MIMU packets. Each input slot holds a ``MimuPacketGroupF32Payload`` of up to ``MAX_MIMU_SAMPLES_PER_PKT``
+time-tagged samples; a parallel ``isValid[MAX_MIMU_PKT]`` array marks which packets the caller has filled this cycle.
+The algorithm skips any packet that is not valid and any sample with ``measTime == 0`` (treated as unfilled), uses the
+newest remaining sample's time tag as the reference, averages every fresh sample whose age is within ``averagingWindow``,
+and outputs the result rotated into the body frame using the user-provided DCM ``dcm_BP``. Each contributing sample
+weighs equally. If no fresh sample qualifies, the output is zero.
 
 Message Connection Descriptions
 -------------------------------
-The following table lists the algorithm input and output data structures. The input is a packet buffer containing
-time-tagged measurements, and the output is the averaged body-frame angular velocity and acceleration.
+The following table lists the algorithm input and output data structures. The input is a 4-packet ring-buffer snapshot
+where each packet carries up to ``MAX_MIMU_SAMPLES_PER_PKT`` time-tagged measurements; the output is the averaged
+body-frame angular velocity and acceleration.
 
 .. list-table:: Module I/O Messages
     :widths: 25 25 50
@@ -21,11 +25,11 @@ time-tagged measurements, and the output is the averaged body-frame angular velo
     * - Variable Name
       - Type
       - Description
-    * - localPkts
-      - ``InputPktsData``
-      - Input packet buffer containing arrays of ``(measTime, gyro_P, accel_P)``.
-    * - out
-      - ``OutputAverageAccelAnglevel``
+    * - mimuPacketInMsg
+      - ``MimuPacketF32Payload``
+      - Input snapshot: ``packets[MAX_MIMU_PKT]`` of ``MimuPacketGroupF32Payload`` plus ``isValid[MAX_MIMU_PKT]``.
+    * - imuOutMsg
+      - ``IMUSensorBodyMsgF32Payload``
       - Output averages in body frame: ``AccelBody`` and ``AngVelBody``
 
 Module Parameters
@@ -58,10 +62,16 @@ The following table lists all parameters that can be set. Parameters are optiona
 
 Module Assumptions and Limitations
 ----------------------------------
-- The packet time tags ``measTime`` are assumed to be in nanoseconds.
-- Packets are included if ``(maxTimeTag - measTime) * NANO2SEC <= averagingWindow``, where ``averagingWindow >= 0.0``.
-- If no packets fall within the time window, the output vectors are zero.
-- The algorithm performs an unweighted arithmetic mean (no weighting, outlier rejection, or bias correction).
+- Sample time tags ``measTime`` are assumed to be in nanoseconds.
+- A sample is considered fresh iff ``isValid[p] == true`` **and** ``samples[p][s].measTime != 0``. Stale samples are
+  skipped both when choosing the newest time tag and when accumulating the average. The caller is responsible for
+  clearing ``isValid[p]`` for any packet that has not yet been written this cycle, and for leaving unfilled samples
+  within a fresh packet at ``measTime == 0`` so the algorithm does not include them during ring-buffer warm-up.
+- Among the fresh samples, a measurement is included in the average if
+  ``(maxTimeTag - measTime) * NANO2SEC <= averagingWindow``, where ``averagingWindow >= 0.0``.
+- If no sample is fresh, or if no fresh sample falls within the averaging window, the output vectors are zero.
+- The algorithm performs an unweighted arithmetic mean across measurements (no weighting, outlier rejection, or bias
+  correction). Each contributing sample weighs equally regardless of which packet it came from.
 
 Initialization
 --------------
@@ -69,73 +79,64 @@ Configure the time window and the platform-to-body DCM::
 
     AverageMimuDataAlgorithm alg;
     alg.setAveragingWindow(0.05f);          // seconds
-    alg.setDcmPltfToBdy(dcm_BP);      // Eigen::Matrix3f (platform-to-body)
+    alg.setDcmPltfToBdy(dcm_BP);            // Eigen::Matrix3f (platform-to-body)
 
 Then call the update method each cycle::
 
-    OutData out = alg.update(localPkts);
+    OutputAverageAccelAngleVel out = alg.update(localPkts);
 
 Detailed Module Description
 ---------------------------
 Inputs
 ^^^^^^
-The input payload contains an array of packets. Each packet provides:
+The input payload carries ``packets[MAX_MIMU_PKT]`` (4 ring-buffer slots) along with a parallel ``isValid[MAX_MIMU_PKT]``
+array. Each slot is a ``MimuPacketGroupF32Payload`` containing up to ``MAX_MIMU_SAMPLES_PER_PKT`` (10) individual
+samples, where each sample provides:
 
-- ``measTime``: measurement time tag (assumed nanoseconds)
+- ``measTime``: measurement time tag (assumed nanoseconds; ``0`` denotes an unfilled slot)
 - ``gyro_P``: 3-axis angular rate sample in platform frame (Eigen::Vector3f)
 - ``accel_P``: 3-axis acceleration sample in platform frame (Eigen::Vector3f)
 
 The algorithm expects the inputs ``gyro_P`` and ``accel_P``, where the subscript P denotes the platform frame.
-At the module interface, however, these signals are read from ``AccPktDataMsgF32Payload``, whose field names use the legacy suffix B (``gyro_B`` and ``accel_B``).
-In this context, ``gyro_B`` and ``accel_B`` should therefore be interpreted as platform-frame quantities, despite the field naming.
+At the module interface, however, these signals are read from ``AccPktDataMsgF32Payload``, whose field names use the
+legacy suffix B (``gyro_B`` and ``accel_B``). In this context, ``gyro_B`` and ``accel_B`` should therefore be
+interpreted as platform-frame quantities, despite the field naming.
 
 Configuration
 ^^^^^^^^^^^^^
-1. Set ``averagingWindow`` to define how far back (from the newest measurement) to include samples in the average.
+1. Set ``averagingWindow`` to define how far back (from the newest fresh sample) to include samples in the average.
 2. Set ``dcm_BP`` to map platform-frame vectors into the body frame.
 
 Algorithm
 ^^^^^^^^^^^^^^^^
-Given an input packet buffer ``localPkts``, the algorithm:
+Given an input ring snapshot ``localPkts``, the algorithm:
 
-1. Finds the newest packet time tag ``maxTimeTag`` across the buffer.
-2. Includes i-th packet whose ``ΔT_i=(maxTimeTag-measTime_i)*NANO2SEC<=averagingWindow``
-3. Averages the selected gyro and accelerometer vectors (assumed to be in the platform frame).
+0. Builds the set of fresh samples: those in packets with ``isValid[p] == true`` and with ``samples[p][s].measTime != 0``.
+1. Finds the newest sample time tag ``maxTimeTag`` across the fresh samples. If no fresh sample exists, returns a zero
+   output.
+2. Includes each fresh sample whose ``ΔT_{p,s} = (maxTimeTag - samples[p][s].measTime) * NANO2SEC <= averagingWindow``.
+3. Averages the selected gyro and accelerometer vectors (assumed to be in the platform frame), weighting each sample
+   equally.
 4. Transforms the averaged vectors to the body frame using ``dcm_BP`` and returns them.
-
-We use a simple example to illustrate steps 1 and 2 with three packets:
-
-.. code-block:: text
-
-    time  ------------------------------------------------------------->
-
-             |<-- averagingWindow -->|
-    t1            t2                 t3 = maxTimeTag          t_latest
-    o-------------o------------------o------------------------o
-    |<------------- ΔT1 ------------>|
-                  |<------ ΔT2 ----->|
-
-    1. maxTimeTag is the measurement time tag t3
-    2. packet at t1 is not included since ΔT1 > averagingWindow.
-       packet at t2 is included since ΔT2 <= averagingWindow.
-       packet at t3 is included since ΔT3 = 0 <= averagingWindow.
 
 Recommended Practices
 ^^^^^^^^^^^^^^^^^^^^^
-- Choose ``averagingWindow`` based on the expected packet update rate and desired smoothing. Larger values increase smoothing
+- Choose ``averagingWindow`` based on the expected sample rate and desired smoothing. Larger values increase smoothing
   but introduce more latency.
 - ``dcm_BP`` shall be a proper DCM (orthonormal, right-handed).
+- The caller is responsible for maintaining ``isValid[p]``. Ring-buffer producers should clear ``isValid[p]`` for any
+  packet that has not been written this cycle; the algorithm will treat the whole packet as stale.
 
 Outputs
 ^^^^^^^
 The algorithm returns::
 
-    struct OutData {
-        Eigen::Vector3f AccelBody;   // body-frame averaged acceleration
-        Eigen::Vector3f AngVelBody;  // body-frame averaged angular velocity
+    struct OutputAverageAccelAngleVel {
+        Eigen::Vector3f accel_B = Eigen::Vector3f::Zero();       // body-frame averaged acceleration
+        Eigen::Vector3f gyroOmega_B = Eigen::Vector3f::Zero();   // body-frame averaged angular velocity
     };
 
-If no packets fall within the window, both output vectors are returned as zeros.
+If no fresh sample is in the window, both output vectors are returned as zeros.
 
 API Reference
 -------------
@@ -151,19 +152,25 @@ The algorithm is implemented by::
         void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);
         Eigen::Matrix3f getDcmPltfToBdy() const;
 
-        OutData update(AccDataMsgF32Payload const& localPkts) const;
+        OutputAverageAccelAngleVel update(InputPktsData const& localPkts) const;
     };
 
-Return Type
-^^^^^^^^^^^
-The return type is::
+Input Type
+^^^^^^^^^^
+The algorithm-internal input type is an array-of-structs of ``Sample``::
 
-    struct OutData {
-        Eigen::Vector3f AccelBody = Eigen::Vector3f::Zero();
-        Eigen::Vector3f AngVelBody = Eigen::Vector3f::Zero();
+    struct Sample {
+        std::uint64_t   measTime;
+        Eigen::Vector3f gyro_P;
+        Eigen::Vector3f accel_P;
+    };
+
+    struct InputPktsData {
+        std::array<bool, MAX_MIMU_PKT> isValid;
+        std::array<std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT>, MAX_MIMU_PKT> samples;
     };
 
 Notes
 -----
-- The averaging window is anchored to the newest time tag present in the buffer, not to the current system time.
-- The output is deterministic given the input packet buffer, ``averagingWindow``, and ``dcm_BP``.
+- The averaging window is anchored to the newest time tag among fresh samples, not to the current system time.
+- The output is deterministic given the input ring snapshot, ``averagingWindow``, and ``dcm_BP``.

--- a/algorithms/averageMimuData/averageMimuData.rst
+++ b/algorithms/averageMimuData/averageMimuData.rst
@@ -4,19 +4,23 @@
 
 Executive Summary
 -----------------
-The ``averageMimuData`` algorithm computes a rolling average of recent gyro and accelerometer measurements drawn from a
-small ring of MIMU packets. Each input slot holds a ``MimuPacketGroupF32Payload`` of up to ``MAX_MIMU_SAMPLES_PER_PKT``
-time-tagged samples; a parallel ``isValid[MAX_MIMU_PKT]`` array marks which packets the caller has filled this cycle.
-The algorithm skips any packet that is not valid and any sample with ``measTime == 0`` (treated as unfilled), uses the
-newest remaining sample's time tag as the reference, averages every fresh sample whose age is within ``averagingWindow``,
-and outputs the result rotated into the body frame using the user-provided DCM ``dcm_BP``. Each contributing sample
-weighs equally. If no fresh sample qualifies, the output is zero.
+The ``averageMimuData`` algorithm computes a rolling average of recent gyro and accelerometer measurements held in an
+internal ring that the algorithm itself owns and grows across update cycles. Each call to ``update()`` takes a snapshot
+of up to ``MAX_MIMU_PKT_C`` (4) packets, each carrying a per-packet ``measTime`` (the timestamp of the first sample in
+that group) plus ``MAX_MIMU_SAMPLES_PER_PKT_C`` (10) gyro/accel sample pairs. Phase 1 ingests any newly-arrived packets
+- those whose ``measTime`` is strictly greater than the largest first-sample time ever ingested - into the next slot of
+the ring, overwriting the oldest slot when capacity is reached. Phase 2 averages every sample currently in the ring
+whose derived measurement time (``slot.measTime + s * kMimuSamplePeriodNs``) is within ``averagingWindow`` of the
+newest stored sample's tail time, and rotates the result into the body frame using the user-provided DCM ``dcm_BP``.
+Each contributing sample weighs equally. If the ring is empty or holds no fresh sample within the window, the output
+is zero. The ring is sized at compile time to hold exactly ``kMaxAveragingWindowSec`` (2.0 s) of samples at the MIMU
+device's compile-time sample rate ``kMimuSampleRateHz`` (100 Hz).
 
 Message Connection Descriptions
 -------------------------------
-The following table lists the algorithm input and output data structures. The input is a 4-packet ring-buffer snapshot
-where each packet carries up to ``MAX_MIMU_SAMPLES_PER_PKT`` time-tagged measurements; the output is the averaged
-body-frame angular velocity and acceleration.
+The following table lists the algorithm input and output data structures. The input is a 4-packet snapshot where each
+packet carries a first-sample ``measTime`` plus ``MAX_MIMU_SAMPLES_PER_PKT_C`` gyro/accel samples; the output is the
+averaged body-frame angular velocity and acceleration.
 
 .. list-table:: Module I/O Messages
     :widths: 25 25 50
@@ -28,6 +32,7 @@ body-frame angular velocity and acceleration.
     * - mimuPacketInMsg
       - ``MimuPacketF32Payload``
       - Input snapshot: ``packets[MAX_MIMU_PKT]`` of ``MimuPacketGroupF32Payload`` plus ``isValid[MAX_MIMU_PKT]``.
+        Each ``MimuPacketGroupF32Payload`` has a per-group ``measTime`` for the first sample.
     * - imuOutMsg
       - ``IMUSensorBodyMsgF32Payload``
       - Output averages in body frame: ``AccelBody`` and ``AngVelBody``
@@ -48,57 +53,77 @@ The following table lists all parameters that can be set. Parameters are optiona
       - Setter / Getter
       - Description
     * - averagingWindow
-      - float
+      - double
       - [s]
       - 0.0
       - ``setAveragingWindow()`` / ``getAveragingWindow()``
-      - Rolling time-window.
+      - Rolling time-window. Must be in ``[0.0, kMaxAveragingWindowSec]``; the setter throws otherwise.
     * - dcm_BP
       - Eigen::Matrix3f
       - [-]
       - Identity
       - ``setDcmPltfToBdy()`` / ``getDcmPltfToBdy()``
-      - DCM mapping to body-frame vectors
+      - DCM mapping to body-frame vectors; the setter throws if not orthonormal with det=+1.
 
 Module Assumptions and Limitations
 ----------------------------------
-- Sample time tags ``measTime`` are assumed to be in nanoseconds.
-- A sample is considered fresh iff ``isValid[p] == true`` **and** ``samples[p][s].measTime != 0``. Stale samples are
-  skipped both when choosing the newest time tag and when accumulating the average. The caller is responsible for
-  clearing ``isValid[p]`` for any packet that has not yet been written this cycle, and for leaving unfilled samples
-  within a fresh packet at ``measTime == 0`` so the algorithm does not include them during ring-buffer warm-up.
-- Among the fresh samples, a measurement is included in the average if
-  ``(maxTimeTag - measTime) <= averagingWindowNs``, where ``averagingWindowNs`` is the configured
-  ``averagingWindow`` (seconds, ``>= 0.0``) converted once to nanoseconds. The comparison is done in
-  ``uint64_t`` nanoseconds to avoid the precision loss that would occur casting a multi-second
+- ``measTime`` is in nanoseconds. The packet's ``measTime`` is the first sample's timestamp; subsequent samples are
+  assumed to be at ``measTime + s * kMimuSamplePeriodNs`` for ``s = 1 .. N-1``. Upstream is responsible for ensuring
+  this device-rate-derived schedule matches reality.
+- Packet ``measTime`` values are assumed strictly monotonic across successive ``update()`` calls. A snapshot whose
+  packets have ``measTime`` less than or equal to the prior call's max is dropped at ingest (no out-of-order ingestion).
+- ``isValid`` gates a packet wholesale. When true, every sample in the packet is treated as real. There is no
+  per-sample fill flag.
+- A packet with ``isValid == true`` but ``measTime == 0`` is dropped at ingest. Empty ring slots remain
+  ``isValid == false`` until ingested and therefore cannot pollute the average during warm-up.
+- Among the samples currently in the ring, a measurement at derived time ``slot.measTime + s * kMimuSamplePeriodNs``
+  is included in the average if ``(maxTimeTag - sampleMeasTime) <= averagingWindowNs``, where ``maxTimeTag`` is the
+  newest stored slot's tail (``maxSlotMeasTime + (N - 1) * kMimuSamplePeriodNs``) and ``averagingWindowNs`` is the
+  configured ``averagingWindow`` (seconds, in ``[0.0, kMaxAveragingWindowSec]``) converted once to nanoseconds. The
+  comparison is done in ``uint64_t`` nanoseconds to avoid the precision loss that would occur casting a multi-second
   ``uint64_t`` delta through ``float``.
-- If no sample is fresh, or if no fresh sample falls within the averaging window, the output vectors are zero.
+- ``setAveragingWindow`` throws if the argument is negative or exceeds ``kMaxAveragingWindowSec`` (the compile-time
+  maximum). The ring is sized for exactly this maximum at the MIMU sample rate; larger windows can't be supported
+  by a fixed-size buffer.
+- ``setDcmPltfToBdy`` throws if the supplied matrix is not a proper DCM (orthonormal, right-handed, det=+1). The
+  previously-stored DCM is preserved on rejection.
+- If the ring is empty or holds no fresh sample within the averaging window, the output vectors are zero.
 - The algorithm performs an unweighted arithmetic mean across measurements (no weighting, outlier rejection, or bias
   correction). Each contributing sample weighs equally regardless of which packet it came from.
+- The internal ring is never reset. Setters (``setAveragingWindow``, ``setDcmPltfToBdy``) take effect on the next
+  ``update()`` but do not clear stored data; callers that need a clean state must construct a new instance.
 
 Initialization
 --------------
-Configure the time window and the platform-to-body DCM::
+Production wiring uses the SysModel-style ``AverageMimuData`` wrapper, which owns the algorithm and reads/writes
+its messages::
+
+    AverageMimuData mod;
+    mod.setAveragingWindow(0.05F);           // float at the adapter; <= kMaxAveragingWindowSec
+    mod.setDcmPltfToBdy(dcm_BP);             // Eigen::Matrix3f (platform-to-body)
+    mod.mimuPacketInMsg.subscribeTo(...);    // required - reset() throws if not linked
+
+Each cycle, the scheduler calls ``mod.updateState(callTime)``, which copies the latest ``MimuPacketF32Payload`` into
+the algorithm and writes the body-frame averages to ``mod.imuOutMsg``.
+
+For unit-test or standalone use, the algorithm class can be driven directly::
 
     AverageMimuDataAlgorithm alg;
-    alg.setAveragingWindow(0.05f);          // seconds
-    alg.setDcmPltfToBdy(dcm_BP);            // Eigen::Matrix3f (platform-to-body)
-
-Then call the update method each cycle::
-
+    alg.setAveragingWindow(0.05);            // double at the algorithm layer
+    alg.setDcmPltfToBdy(dcm_BP);
     OutputAverageAccelAngleVel out = alg.update(localPkts);
 
 Detailed Module Description
 ---------------------------
 Inputs
 ^^^^^^
-The input payload carries ``packets[MAX_MIMU_PKT]`` (4 ring-buffer slots) along with a parallel ``isValid[MAX_MIMU_PKT]``
-array. Each slot is a ``MimuPacketGroupF32Payload`` containing up to ``MAX_MIMU_SAMPLES_PER_PKT`` (10) individual
-samples, where each sample provides:
+The input payload carries ``packets[MAX_MIMU_PKT]`` (a 4-slot snapshot from one MIMU source) along with a parallel
+``isValid[MAX_MIMU_PKT]`` array. Each slot is a ``MimuPacketGroupF32Payload`` carrying:
 
-- ``measTime``: measurement time tag (assumed nanoseconds; ``0`` denotes an unfilled slot)
-- ``gyro_P``: 3-axis angular rate sample in platform frame (Eigen::Vector3f)
-- ``accel_P``: 3-axis acceleration sample in platform frame (Eigen::Vector3f)
+- ``measTime``: timestamp of the first sample in the packet (assumed nanoseconds)
+- ``samples[MAX_MIMU_SAMPLES_PER_PKT]``: per-sample gyro/accel pairs. (Each ``AccPktDataMsgF32Payload`` still carries
+  its own ``measTime`` field for legacy consumers, but the algorithm ignores it and uses the group-level ``measTime``
+  + ``kMimuSamplePeriodNs`` schedule.)
 
 The algorithm expects the inputs ``gyro_P`` and ``accel_P``, where the subscript P denotes the platform frame.
 At the module interface, however, these signals are read from ``AccPktDataMsgF32Payload``, whose field names use the
@@ -112,24 +137,42 @@ Configuration
 
 Algorithm
 ^^^^^^^^^^^^^^^^
-Given an input ring snapshot ``localPkts``, the algorithm:
+Given an input snapshot ``localPkts``, the algorithm executes in two phases.
 
-0. Builds the set of fresh samples: those in packets with ``isValid[p] == true`` and with ``samples[p][s].measTime != 0``.
-1. Finds the newest sample time tag ``maxTimeTag`` across the fresh samples. If no fresh sample exists, returns a zero
-   output.
-2. Includes each fresh sample whose ``(maxTimeTag - samples[p][s].measTime) <= averagingWindowNs``,
-   i.e. whose age (in nanoseconds) does not exceed the configured window converted once to nanoseconds.
-3. Averages the selected gyro and accelerometer vectors (assumed to be in the platform frame), weighting each sample
-   equally.
-4. Transforms the averaged vectors to the body frame using ``dcm_BP`` and returns them.
+Phase 1 - ingest:
+
+a. Snapshot the prior-call ``lastIngestedMaxMeasTime`` as ``priorMax`` so that all packets in this snapshot are
+   evaluated against the same boundary (allowing several new packets in one snapshot to be ingested together).
+b. For each input packet ``packet``:
+
+   - skip if ``packet.isValid == false``;
+   - let ``firstSampleTime = packet.measTime``;
+   - skip if ``firstSampleTime`` is ``0`` or not strictly greater than ``priorMax``;
+   - otherwise copy the packet's samples and ``measTime`` into the next ring slot, advance the insert index modulo the
+     ring capacity (overwriting the oldest slot when full), and update ``lastIngestedMaxMeasTime`` to the max of
+     itself and ``firstSampleTime``.
+
+Phase 2 - average over the ring:
+
+0. Find the newest stored slot's ``measTime`` (``maxSlotMeasTime``) across all valid ring slots. If no slot is valid,
+   return a zero output.
+1. Compute ``maxTimeTag = maxSlotMeasTime + (N - 1) * kMimuSamplePeriodNs`` -- the tail sample's time of the newest
+   stored packet.
+2. For each valid ring slot and each ``s`` in ``0 .. N - 1``, compute the derived sample time
+   ``sampleMeasTime = slot.measTime + s * kMimuSamplePeriodNs`` and include the sample iff
+   ``(maxTimeTag - sampleMeasTime) <= averagingWindowNs``.
+3. Average the selected gyro and accelerometer vectors (in the platform frame), weighting each sample equally.
+4. Transform the averaged vectors to the body frame using ``dcm_BP`` and return them.
 
 Recommended Practices
 ^^^^^^^^^^^^^^^^^^^^^
-- Choose ``averagingWindow`` based on the expected sample rate and desired smoothing. Larger values increase smoothing
-  but introduce more latency.
+- Choose ``averagingWindow`` based on the desired smoothing. Larger values increase smoothing but introduce more
+  latency. The setter rejects values outside ``[0.0, kMaxAveragingWindowSec]``.
 - ``dcm_BP`` shall be a proper DCM (orthonormal, right-handed).
-- The caller is responsible for maintaining ``isValid[p]``. Ring-buffer producers should clear ``isValid[p]`` for any
-  packet that has not been written this cycle; the algorithm will treat the whole packet as stale.
+- Set ``packet.measTime`` to the timestamp of the first sample in each packet. Subsequent samples are scheduled at
+  ``measTime + s * kMimuSamplePeriodNs`` regardless of what the per-sample ``AccPktDataMsgF32Payload.measTime`` says.
+- The caller is responsible for maintaining ``isValid[p]``. Producers should clear ``isValid[p]`` for any packet that
+  has not been written this cycle; the algorithm will treat the whole packet as stale.
 
 Outputs
 ^^^^^^^
@@ -140,7 +183,7 @@ The algorithm returns::
         Eigen::Vector3f gyroOmega_B = Eigen::Vector3f::Zero();   // body-frame averaged angular velocity
     };
 
-If no fresh sample is in the window, both output vectors are returned as zeros.
+If no sample qualifies under the window filter, both output vectors are returned as zeros.
 
 API Reference
 -------------
@@ -150,31 +193,64 @@ The algorithm is implemented by::
 
     class AverageMimuDataAlgorithm {
        public:
-        void setAveragingWindow(float averagingWindowIn);
-        float getAveragingWindow() const;
+        // Compile-time MIMU device sample rate + derived period (ns).
+        static constexpr float         kMimuSampleRateHz     = 100.0F;
+        static constexpr std::uint64_t kMimuSamplePeriodNs   = 10'000'000U;
+
+        // Compile-time cap on the configured averaging window. Ring capacity is
+        // sized to hold exactly kMaxAveragingWindowSec of samples at the MIMU rate.
+        static constexpr float kMaxAveragingWindowSec = 2.0F;
+
+        static constexpr std::size_t kRingCapacity =
+            average_mimu_detail::ceilDivSamplesToPackets(
+                kMimuSampleRateHz, kMaxAveragingWindowSec, MAX_MIMU_SAMPLES_PER_PKT_C);
+
+        void setAveragingWindow(double averagingWindowIn);
+        double getAveragingWindow() const;
 
         void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);
         Eigen::Matrix3f getDcmPltfToBdy() const;
 
-        OutputAverageAccelAngleVel update(InputPktsData const& localPkts) const;
+        OutputAverageAccelAngleVel update(InputPktsData const& localPkts);
     };
+
+Component (SysModel) Wrapper
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The SysModel-style wrapper class is ``AverageMimuData`` (declared in ``averageMimuData.h``). It owns a single
+``AverageMimuDataAlgorithm`` instance and is the production entry point. Notable behaviors layered on top of the
+algorithm:
+
+- ``reset(callTime)`` throws ``std::invalid_argument`` if ``mimuPacketInMsg`` is not linked.
+- ``updateState(callTime)`` reads the latest ``MimuPacketF32Payload``, copies it into the algorithm's
+  ``InputPktsData``, calls ``algorithm.update(...)``, and writes ``AccelBody`` / ``AngVelBody`` on
+  ``imuOutMsg``. The ``DVFrameBody`` and ``DRFrameBody`` fields on the output payload are left zero - the
+  algorithm does not compute integrated DVs/DRs.
+- If ``mimuPacketInMsg.timeWritten()`` has not changed since the previous ``updateState``, the call is skipped,
+  ``staleDataCount`` is incremented, and no new output is written. The algorithm's internal ring is unchanged on a
+  skipped cycle.
+- ``setAveragingWindow`` on the adapter takes ``float`` and delegates to the algorithm's ``double`` setter; this
+  is the only public-API type difference between the two layers.
 
 Input Type
 ^^^^^^^^^^
-The algorithm-internal input type is an array-of-structs of ``Sample``::
+The algorithm-internal input types are::
 
     struct Sample {
-        std::uint64_t   measTime;
         Eigen::Vector3f gyro_P;
         Eigen::Vector3f accel_P;
     };
 
+    struct InputPacket {
+        bool          isValid;
+        std::uint64_t measTime;   // First sample's measurement time (firstSampleTime)
+        std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT_C> samples;
+    };
+
     struct InputPktsData {
-        std::array<bool, MAX_MIMU_PKT> isValid;
-        std::array<std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT>, MAX_MIMU_PKT> samples;
+        std::array<InputPacket, MAX_MIMU_PKT_C> packets;
     };
 
 Notes
 -----
-- The averaging window is anchored to the newest time tag among fresh samples, not to the current system time.
-- The output is deterministic given the input ring snapshot, ``averagingWindow``, and ``dcm_BP``.
+- The averaging window is anchored to the newest sample's derived time, not to the current system time.
+- The output is deterministic given the input snapshot history, ``averagingWindow``, and ``dcm_BP``.

--- a/algorithms/averageMimuData/averageMimuData.rst
+++ b/algorithms/averageMimuData/averageMimuData.rst
@@ -68,7 +68,10 @@ Module Assumptions and Limitations
   clearing ``isValid[p]`` for any packet that has not yet been written this cycle, and for leaving unfilled samples
   within a fresh packet at ``measTime == 0`` so the algorithm does not include them during ring-buffer warm-up.
 - Among the fresh samples, a measurement is included in the average if
-  ``(maxTimeTag - measTime) * NANO2SEC <= averagingWindow``, where ``averagingWindow >= 0.0``.
+  ``(maxTimeTag - measTime) <= averagingWindowNs``, where ``averagingWindowNs`` is the configured
+  ``averagingWindow`` (seconds, ``>= 0.0``) converted once to nanoseconds. The comparison is done in
+  ``uint64_t`` nanoseconds to avoid the precision loss that would occur casting a multi-second
+  ``uint64_t`` delta through ``float``.
 - If no sample is fresh, or if no fresh sample falls within the averaging window, the output vectors are zero.
 - The algorithm performs an unweighted arithmetic mean across measurements (no weighting, outlier rejection, or bias
   correction). Each contributing sample weighs equally regardless of which packet it came from.
@@ -114,7 +117,8 @@ Given an input ring snapshot ``localPkts``, the algorithm:
 0. Builds the set of fresh samples: those in packets with ``isValid[p] == true`` and with ``samples[p][s].measTime != 0``.
 1. Finds the newest sample time tag ``maxTimeTag`` across the fresh samples. If no fresh sample exists, returns a zero
    output.
-2. Includes each fresh sample whose ``ΔT_{p,s} = (maxTimeTag - samples[p][s].measTime) * NANO2SEC <= averagingWindow``.
+2. Includes each fresh sample whose ``(maxTimeTag - samples[p][s].measTime) <= averagingWindowNs``,
+   i.e. whose age (in nanoseconds) does not exceed the configured window converted once to nanoseconds.
 3. Averages the selected gyro and accelerometer vectors (assumed to be in the platform frame), weighting each sample
    equally.
 4. Transforms the averaged vectors to the body frame using ``dcm_BP`` and returns them.

--- a/algorithms/averageMimuData/averageMimuData.rst
+++ b/algorithms/averageMimuData/averageMimuData.rst
@@ -9,12 +9,15 @@ internal ring that the algorithm itself owns and grows across update cycles. Eac
 of up to ``MAX_MIMU_PKT_C`` (4) packets, each carrying a per-packet ``measTime`` (the timestamp of the first sample in
 that group) plus ``MAX_MIMU_SAMPLES_PER_PKT_C`` (10) gyro/accel sample pairs. Phase 1 ingests any newly-arrived packets
 - those whose ``measTime`` is strictly greater than the largest first-sample time ever ingested - into the next slot of
-the ring, overwriting the oldest slot when capacity is reached. Phase 2 averages every sample currently in the ring
-whose derived measurement time (``slot.measTime + s * kMimuSamplePeriodNs``) is within ``averagingWindow`` of the
-newest stored sample's tail time, and rotates the result into the body frame using the user-provided DCM ``dcm_BP``.
-Each contributing sample weighs equally. If the ring is empty or holds no fresh sample within the window, the output
-is zero. The ring is sized at compile time to hold exactly ``kMaxAveragingWindowSec`` (2.0 s) of samples at the MIMU
-device's compile-time sample rate ``kMimuSampleRateHz`` (100 Hz).
+the ring, overwriting the oldest slot when capacity is reached. Phase 2 averages the ring, but gyro and accelerometer
+are filtered over **independent** time windows: a sample (derived measurement time
+``slot.measTime + s * kMimuSamplePeriodNs``) contributes to the angular-rate mean when it lies within
+``gyroAveragingWindow`` of the newest stored sample's tail time, and to the acceleration mean when within
+``accelAveragingWindow``. Each mean is rotated into the body frame using the user-provided DCM ``dcm_BP``. Each
+contributing sample weighs equally. A modality with no fresh sample inside its window (or an empty ring) yields a zero
+vector for that modality. The ring is sized at compile time to hold exactly ``kMaxAveragingWindowSec`` (2.0 s) of
+samples at the MIMU device's compile-time sample rate ``kMimuSampleRateHz`` (100 Hz); both windows share this ring and
+are each capped at ``kMaxAveragingWindowSec``.
 
 Message Connection Descriptions
 -------------------------------
@@ -52,12 +55,18 @@ The following table lists all parameters that can be set. Parameters are optiona
       - Default
       - Setter / Getter
       - Description
-    * - averagingWindow
+    * - gyroAveragingWindow
       - double
       - [s]
       - 0.0
-      - ``setAveragingWindow()`` / ``getAveragingWindow()``
-      - Rolling time-window. Must be in ``[0.0, kMaxAveragingWindowSec]``; the setter throws otherwise.
+      - ``setGyroAveragingWindow()`` / ``getGyroAveragingWindow()``
+      - Rolling time-window for angular rate. Must be in ``[0.0, kMaxAveragingWindowSec]``; the setter throws otherwise.
+    * - accelAveragingWindow
+      - double
+      - [s]
+      - 0.0
+      - ``setAccelAveragingWindow()`` / ``getAccelAveragingWindow()``
+      - Rolling time-window for acceleration. Must be in ``[0.0, kMaxAveragingWindowSec]``; the setter throws otherwise.
     * - dcm_BP
       - Eigen::Matrix3f
       - [-]
@@ -67,31 +76,16 @@ The following table lists all parameters that can be set. Parameters are optiona
 
 Module Assumptions and Limitations
 ----------------------------------
+- Packet ``measTime`` values are assumed strictly monotonic across successive ``update()`` calls. A snapshot whose
+  packets have ``measTime`` less than or equal to the prior call's max is dropped at ingest.
 - ``measTime`` is in nanoseconds. The packet's ``measTime`` is the first sample's timestamp; subsequent samples are
   assumed to be at ``measTime + s * kMimuSamplePeriodNs`` for ``s = 1 .. N-1``. Upstream is responsible for ensuring
   this device-rate-derived schedule matches reality.
-- Packet ``measTime`` values are assumed strictly monotonic across successive ``update()`` calls. A snapshot whose
-  packets have ``measTime`` less than or equal to the prior call's max is dropped at ingest (no out-of-order ingestion).
-- ``isValid`` gates a packet wholesale. When true, every sample in the packet is treated as real. There is no
-  per-sample fill flag.
 - A packet with ``isValid == true`` but ``measTime == 0`` is dropped at ingest. Empty ring slots remain
   ``isValid == false`` until ingested and therefore cannot pollute the average during warm-up.
-- Among the samples currently in the ring, a measurement at derived time ``slot.measTime + s * kMimuSamplePeriodNs``
-  is included in the average if ``(maxTimeTag - sampleMeasTime) <= averagingWindowNs``, where ``maxTimeTag`` is the
-  newest stored slot's tail (``maxSlotMeasTime + (N - 1) * kMimuSamplePeriodNs``) and ``averagingWindowNs`` is the
-  configured ``averagingWindow`` (seconds, in ``[0.0, kMaxAveragingWindowSec]``) converted once to nanoseconds. The
-  comparison is done in ``uint64_t`` nanoseconds to avoid the precision loss that would occur casting a multi-second
-  ``uint64_t`` delta through ``float``.
-- ``setAveragingWindow`` throws if the argument is negative or exceeds ``kMaxAveragingWindowSec`` (the compile-time
-  maximum). The ring is sized for exactly this maximum at the MIMU sample rate; larger windows can't be supported
-  by a fixed-size buffer.
-- ``setDcmPltfToBdy`` throws if the supplied matrix is not a proper DCM (orthonormal, right-handed, det=+1). The
-  previously-stored DCM is preserved on rejection.
-- If the ring is empty or holds no fresh sample within the averaging window, the output vectors are zero.
-- The algorithm performs an unweighted arithmetic mean across measurements (no weighting, outlier rejection, or bias
-  correction). Each contributing sample weighs equally regardless of which packet it came from.
-- The internal ring is never reset. Setters (``setAveragingWindow``, ``setDcmPltfToBdy``) take effect on the next
-  ``update()`` but do not clear stored data; callers that need a clean state must construct a new instance.
+- If the ring is empty, or there is no fresh sample within a window, the output vector is zero.
+- The algorithm performs an unweighted arithmetic mean across measurements.
+- The internal ring is only ever reset when reset() is called.
 
 Initialization
 --------------
@@ -99,7 +93,8 @@ Production wiring uses the SysModel-style ``AverageMimuData`` wrapper, which own
 its messages::
 
     AverageMimuData mod;
-    mod.setAveragingWindow(0.05F);           // float at the adapter; <= kMaxAveragingWindowSec
+    mod.setGyroAveragingWindow(0.05);        // <= kMaxAveragingWindowSec
+    mod.setAccelAveragingWindow(0.10);       // independent of the gyro window
     mod.setDcmPltfToBdy(dcm_BP);             // Eigen::Matrix3f (platform-to-body)
     mod.mimuPacketInMsg.subscribeTo(...);    // required - reset() throws if not linked
 
@@ -109,7 +104,8 @@ the algorithm and writes the body-frame averages to ``mod.imuOutMsg``.
 For unit-test or standalone use, the algorithm class can be driven directly::
 
     AverageMimuDataAlgorithm alg;
-    alg.setAveragingWindow(0.05);            // double at the algorithm layer
+    alg.setGyroAveragingWindow(0.05);        // double at the algorithm layer
+    alg.setAccelAveragingWindow(0.10);       // independent of the gyro window
     alg.setDcmPltfToBdy(dcm_BP);
     OutputAverageAccelAngleVel out = alg.update(localPkts);
 
@@ -132,7 +128,8 @@ interpreted as platform-frame quantities, despite the field naming.
 
 Configuration
 ^^^^^^^^^^^^^
-1. Set ``averagingWindow`` to define how far back (from the newest fresh sample) to include samples in the average.
+1. Set ``gyroAveragingWindow`` and ``accelAveragingWindow`` to define, independently per modality, how far back (from
+   the newest fresh sample) to include samples in the average.
 2. Set ``dcm_BP`` to map platform-frame vectors into the body frame.
 
 Algorithm
@@ -159,15 +156,18 @@ Phase 2 - average over the ring:
 1. Compute ``maxTimeTag = maxSlotMeasTime + (N - 1) * kMimuSamplePeriodNs`` -- the tail sample's time of the newest
    stored packet.
 2. For each valid ring slot and each ``s`` in ``0 .. N - 1``, compute the derived sample time
-   ``sampleMeasTime = slot.measTime + s * kMimuSamplePeriodNs`` and include the sample iff
-   ``(maxTimeTag - sampleMeasTime) <= averagingWindowNs``.
-3. Average the selected gyro and accelerometer vectors (in the platform frame), weighting each sample equally.
-4. Transform the averaged vectors to the body frame using ``dcm_BP`` and return them.
+   ``sampleMeasTime = slot.measTime + s * kMimuSamplePeriodNs`` and its age ``maxTimeTag - sampleMeasTime``. Add the
+   gyro vector to the gyro accumulator (and bump the gyro count) iff the age is ``<= gyroAveragingWindowNs``; add the
+   accel vector to the accel accumulator (and bump the accel count) iff the age is ``<= accelAveragingWindowNs``.
+3. Divide each accumulator by its own count to form the platform-frame means, weighting each sample equally. A count of
+   zero leaves that modality's mean at zero.
+4. Transform each averaged vector to the body frame using ``dcm_BP`` and return them.
 
 Recommended Practices
 ^^^^^^^^^^^^^^^^^^^^^
-- Choose ``averagingWindow`` based on the desired smoothing. Larger values increase smoothing but introduce more
-  latency. The setter rejects values outside ``[0.0, kMaxAveragingWindowSec]``.
+- Choose ``gyroAveragingWindow`` and ``accelAveragingWindow`` independently based on the desired smoothing for each
+  modality. Larger values increase smoothing but introduce more latency. Each setter rejects values outside
+  ``[0.0, kMaxAveragingWindowSec]``.
 - ``dcm_BP`` shall be a proper DCM (orthonormal, right-handed).
 - Set ``packet.measTime`` to the timestamp of the first sample in each packet. Subsequent samples are scheduled at
   ``measTime + s * kMimuSamplePeriodNs`` regardless of what the per-sample ``AccPktDataMsgF32Payload.measTime`` says.
@@ -205,8 +205,11 @@ The algorithm is implemented by::
             average_mimu_detail::ceilDivSamplesToPackets(
                 kMimuSampleRateHz, kMaxAveragingWindowSec, MAX_MIMU_SAMPLES_PER_PKT_C);
 
-        void setAveragingWindow(double averagingWindowIn);
-        double getAveragingWindow() const;
+        void setGyroAveragingWindow(double gyroWindowIn);
+        double getGyroAveragingWindow() const;
+
+        void setAccelAveragingWindow(double accelWindowIn);
+        double getAccelAveragingWindow() const;
 
         void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);
         Eigen::Matrix3f getDcmPltfToBdy() const;
@@ -228,8 +231,8 @@ algorithm:
 - If ``mimuPacketInMsg.timeWritten()`` has not changed since the previous ``updateState``, the call is skipped,
   ``staleDataCount`` is incremented, and no new output is written. The algorithm's internal ring is unchanged on a
   skipped cycle.
-- ``setAveragingWindow`` on the adapter takes ``float`` and delegates to the algorithm's ``double`` setter; this
-  is the only public-API type difference between the two layers.
+- ``setGyroAveragingWindow`` / ``setAccelAveragingWindow`` on the adapter delegate directly to the algorithm's
+  setters of the same name; both layers use ``double``.
 
 Input Type
 ^^^^^^^^^^
@@ -252,5 +255,6 @@ The algorithm-internal input types are::
 
 Notes
 -----
-- The averaging window is anchored to the newest sample's derived time, not to the current system time.
-- The output is deterministic given the input snapshot history, ``averagingWindow``, and ``dcm_BP``.
+- Both averaging windows are anchored to the newest sample's derived time, not to the current system time.
+- The output is deterministic given the input snapshot history, ``gyroAveragingWindow``, ``accelAveragingWindow``,
+  and ``dcm_BP``.

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -1,8 +1,8 @@
 #include "averageMimuDataAlgorithm.h"
-#include "utilities/fsw/eigenSupport.h"
-#include "utilities/fsw/freestandingInvalidArgument.h"
-#include "utilities/fsw/timeConstants.h"
-#include "utilities/fsw/validDcmCheck.h"
+#include <utilities/fsw/eigenSupport.h>
+#include <utilities/fsw/freestandingInvalidArgument.h>
+#include <utilities/fsw/timeConstants.h>
+#include <utilities/fsw/validDcmCheck.h>
 
 #include <algorithm>
 
@@ -10,7 +10,7 @@
  *  then return the rolling average of fresh samples currently in the ring.
  *
  *  Phase 1 (ingest): Each input packet carries a `measTime` that is the
- *  first sample's timestamp (`firstSampleTime`). A packet is ingested iff
+ *  first sample's timestamp (`firstSampleTime`). A packet is ingested only if
  *  its `firstSampleTime` is strictly greater than the largest first-sample
  *  time ever ingested before this update() call. The whole packet is
  *  copied into the next ring slot, overwriting the oldest slot when
@@ -20,7 +20,7 @@
  *  Phase 2 (average): Per-sample times are derived from each ring slot's
  *  `measTime` plus `s * kMimuSamplePeriodNs`. The maxTimeTag is the
  *  newest slot's tail sample: `max(slot.measTime) + (N - 1) * period_ns`.
- *  Gyro and acceleration are averaged independently: a sample contributes to
+ *  Gyro and acceleration data are averaged independently: a sample contributes to
  *  the gyro mean when its age relative to maxTimeTag is within
  *  `gyroAveragingWindowNs`, and to the accel mean when within
  *  `accelAveragingWindowNs`. Each mean is rotated to the body frame via
@@ -30,27 +30,26 @@
  *  @return OutputAverageAccelAngleVel: body-frame rolling average.
  */
 OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const& localPkts) {
-    // Phase 1: ingest. Freeze prior max so within one snapshot all packets
-    // are evaluated against the previous-call boundary, not against each
-    // other - this lets multiple new packets in the same snapshot all land.
+    // Phase 1: Ingest packets. Freeze prior maximum time so within one snapshot
+    // all packets are evaluated against the previous-call boundary.
     const uint64_t priorMax = this->lastIngestedMaxMeasTime;
-    for (auto const& packet : localPkts.packets) {
-        if (!packet.isValid) {
+    for (const auto& [isValid, measTime, samples] : localPkts.packets) {
+        if (!isValid) {
             continue;
         }
-        const uint64_t firstSampleTime = packet.measTime;
-        if ((firstSampleTime == 0U) || (firstSampleTime <= priorMax)) {
+        const uint64_t firstSampleTime = measTime;
+        if (firstSampleTime == 0U || firstSampleTime <= priorMax) {
             continue;
         }
 
         this->ring.at(this->insertIdx).isValid = true;
         this->ring.at(this->insertIdx).measTime = firstSampleTime;
-        this->ring.at(this->insertIdx).samples = packet.samples;
+        this->ring.at(this->insertIdx).samples = samples;
         this->insertIdx = (this->insertIdx + 1U) % kRingCapacity;
         this->lastIngestedMaxMeasTime = std::max(this->lastIngestedMaxMeasTime, firstSampleTime);
     }
 
-    // Phase 2: derive maxTimeTag from the newest stored packet's tail sample.
+    // Phase 2: compute the maxTimeTag from the newest stored packet's tail sample.
     // Per-sample measTimes are reconstructed from slot.measTime + s * period_ns.
     uint64_t maxSlotMeasTime = 0U;
     for (auto const& slot : this->ring) {
@@ -64,8 +63,7 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
         return out;
     }
 
-    const uint64_t maxTimeTag =
-        maxSlotMeasTime + ((MAX_MIMU_SAMPLES_PER_PKT_C - 1U) * kMimuSamplePeriodNs);
+    const uint64_t maxTimeTag = maxSlotMeasTime + ((MAX_MIMU_SAMPLES_PER_PKT_C - 1U) * kMimuSamplePeriodNs);
 
     // Gyro and accel each accumulate over their own window, so a sample may
     // contribute to one running mean and not the other.
@@ -74,19 +72,19 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
     uint64_t gyroAvgCount = 0U;
     uint64_t accelAvgCount = 0U;
 
-    for (auto const& slot : this->ring) {
-        if (!slot.isValid) {
+    for (const auto& [isValid, measTime, samples] : this->ring) {
+        if (!isValid) {
             continue;
         }
         for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT_C; ++s) {
-            const uint64_t sampleMeasTime = slot.measTime + (s * kMimuSamplePeriodNs);
+            const uint64_t sampleMeasTime = measTime + (s * kMimuSamplePeriodNs);
             const uint64_t age = maxTimeTag - sampleMeasTime;
             if (age <= this->gyroAveragingWindowNs) {
-                gyroSum_P += slot.samples.at(s).gyro_P;
+                gyroSum_P += samples.at(s).gyro_P;
                 gyroAvgCount++;
             }
             if (age <= this->accelAveragingWindowNs) {
-                accelSum_P += slot.samples.at(s).accel_P;
+                accelSum_P += samples.at(s).accel_P;
                 accelAvgCount++;
             }
         }

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -15,9 +15,19 @@
  * returns zeros.
  */
 OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const& localPkts) const {
+    // A slot is fresh only if the caller marked it valid and supplied a non-zero
+    // measurement time. Zero-initialized ring-buffer slots are skipped so the
+    // first few cycles after power-up do not pollute the average.
     uint64_t maxTimeTag = 0U;
-    for (auto const& time : localPkts.measTime) {
-        maxTimeTag = std::max(time, maxTimeTag);
+    for (uint32_t i = 0; i < MAX_BUF_PKT; ++i) {
+        if (localPkts.isValid.at(i) && localPkts.measTime.at(i) != 0U) {
+            maxTimeTag = std::max(localPkts.measTime.at(i), maxTimeTag);
+        }
+    }
+
+    OutputAverageAccelAngleVel out{};
+    if (maxTimeTag == 0U) {
+        return out;
     }
 
     Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
@@ -25,6 +35,9 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
     uint64_t measAvgCount = 0U;
 
     for (uint32_t i = 0; i < MAX_BUF_PKT; ++i) {
+        if (!localPkts.isValid.at(i) || localPkts.measTime.at(i) == 0U) {
+            continue;
+        }
         // Rolling average with averagingWindow as window width or the maximum buffer size
         if (static_cast<float>(maxTimeTag - localPkts.measTime.at(i)) * kNano2SecF <= this->averagingWindow) {
             gyroSum_P += localPkts.gyro_P.at(i);
@@ -33,7 +46,6 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
         }
     }
 
-    OutputAverageAccelAngleVel out{};
     if (measAvgCount > 0U) {
         gyroSum_P /= static_cast<float>(measAvgCount);
         Eigen::Vector3f const gyroSum_B = this->dcm_BP * gyroSum_P;

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -20,9 +20,11 @@
  *  Phase 2 (average): Per-sample times are derived from each ring slot's
  *  `measTime` plus `s * kMimuSamplePeriodNs`. The maxTimeTag is the
  *  newest slot's tail sample: `max(slot.measTime) + (N - 1) * period_ns`.
- *  Every sample whose derived time is within `gyroAveragingWindowNs` of
- *  maxTimeTag contributes equally to the body-frame average via `dcm_BP`.
- *  Returns zeros if the ring is empty.
+ *  Gyro and acceleration are averaged independently: a sample contributes to
+ *  the gyro mean when its age relative to maxTimeTag is within
+ *  `gyroAveragingWindowNs`, and to the accel mean when within
+ *  `accelAveragingWindowNs`. Each mean is rotated to the body frame via
+ *  `dcm_BP`. Components with no in-window samples (or an empty ring) stay zero.
  *
  *  @param localPkts InputPktsData: 4-packet snapshot from the caller.
  *  @return OutputAverageAccelAngleVel: body-frame rolling average.
@@ -65,9 +67,12 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
     const uint64_t maxTimeTag =
         maxSlotMeasTime + ((MAX_MIMU_SAMPLES_PER_PKT_C - 1U) * kMimuSamplePeriodNs);
 
+    // Gyro and accel each accumulate over their own window, so a sample may
+    // contribute to one running mean and not the other.
     Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
     Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
-    uint64_t measAvgCount = 0U;
+    uint64_t gyroAvgCount = 0U;
+    uint64_t accelAvgCount = 0U;
 
     for (auto const& slot : this->ring) {
         if (!slot.isValid) {
@@ -75,21 +80,25 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
         }
         for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT_C; ++s) {
             const uint64_t sampleMeasTime = slot.measTime + (s * kMimuSamplePeriodNs);
-            if ((maxTimeTag - sampleMeasTime) <= this->gyroAveragingWindowNs) {
+            const uint64_t age = maxTimeTag - sampleMeasTime;
+            if (age <= this->gyroAveragingWindowNs) {
                 gyroSum_P += slot.samples.at(s).gyro_P;
+                gyroAvgCount++;
+            }
+            if (age <= this->accelAveragingWindowNs) {
                 accelSum_P += slot.samples.at(s).accel_P;
-                measAvgCount++;
+                accelAvgCount++;
             }
         }
     }
 
-    if (measAvgCount > 0U) {
-        gyroSum_P /= static_cast<float>(measAvgCount);
-        Eigen::Vector3f const gyroSum_B = this->dcm_BP * gyroSum_P;
-        accelSum_P /= static_cast<float>(measAvgCount);
-        Eigen::Vector3f const accelSum_B = this->dcm_BP * accelSum_P;
-        out.gyroOmega_B = gyroSum_B;
-        out.accel_B = accelSum_B;
+    if (gyroAvgCount > 0U) {
+        gyroSum_P /= static_cast<float>(gyroAvgCount);
+        out.gyroOmega_B = this->dcm_BP * gyroSum_P;
+    }
+    if (accelAvgCount > 0U) {
+        accelSum_P /= static_cast<float>(accelAvgCount);
+        out.accel_B = this->dcm_BP * accelSum_P;
     }
 
     return out;
@@ -97,13 +106,24 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
 
 void AverageMimuDataAlgorithm::setGyroAveragingWindow(double const window) {
     if (window < 0.0 || window > kMaxAveragingWindowSec) {
-        FSW_THROW_INVALID_ARGUMENT("AveragingWindow cannot be smaller than 0.0 or greater than 2.0 seconds");
+        FSW_THROW_INVALID_ARGUMENT("gyroAveragingWindow cannot be smaller than 0.0 or greater than 2.0 seconds");
     }
     this->gyroAveragingWindowNs = static_cast<std::uint64_t>(window * kSec2Nano);
 }
 
 double AverageMimuDataAlgorithm::getGyroAveragingWindow() const {
     return static_cast<double>(this->gyroAveragingWindowNs) * kNano2Sec;
+}
+
+void AverageMimuDataAlgorithm::setAccelAveragingWindow(double const window) {
+    if (window < 0.0 || window > kMaxAveragingWindowSec) {
+        FSW_THROW_INVALID_ARGUMENT("accelAveragingWindow cannot be smaller than 0.0 or greater than 2.0 seconds");
+    }
+    this->accelAveragingWindowNs = static_cast<std::uint64_t>(window * kSec2Nano);
+}
+
+double AverageMimuDataAlgorithm::getAccelAveragingWindow() const {
+    return static_cast<double>(this->accelAveragingWindowNs) * kNano2Sec;
 }
 
 void AverageMimuDataAlgorithm::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn) {

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -49,8 +49,10 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
             if (measTime == 0U) {
                 continue;
             }
-            // Rolling average across all fresh samples within the window
-            if (static_cast<float>(maxTimeTag - measTime) * kNano2SecF <= this->averagingWindow) {
+            // Rolling average across all fresh samples within the window.
+            // Integer compare in ns avoids casting a multi-second uint64_t
+            // delta through float (which has only a 24-bit mantissa).
+            if ((maxTimeTag - measTime) <= this->averagingWindowNs) {
                 gyroSum_P += gyro_P;
                 accelSum_P += accel_P;
                 measAvgCount++;
@@ -74,10 +76,14 @@ void AverageMimuDataAlgorithm::setAveragingWindow(float const window) {
     if (window < 0.0F) {
         FSW_THROW_INVALID_ARGUMENT("AveragingWindow cannot be smaller than 0.0");
     }
-    this->averagingWindow = window;
+    // Convert seconds->nanoseconds in double so plausible window values
+    // (e.g. 2.0 s -> 2_000_000_000 ns) survive without rounding through float.
+    this->averagingWindowNs = static_cast<std::uint64_t>(static_cast<double>(window) * 1.0e9);
 }
 
-float AverageMimuDataAlgorithm::getAveragingWindow() const { return this->averagingWindow; }
+float AverageMimuDataAlgorithm::getAveragingWindow() const {
+    return static_cast<float>(static_cast<double>(this->averagingWindowNs) * 1.0e-9);
+}
 
 void AverageMimuDataAlgorithm::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn) {
     if (!isValidDcm(dcm_BPIn)) {

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -20,7 +20,7 @@
  *  Phase 2 (average): Per-sample times are derived from each ring slot's
  *  `measTime` plus `s * kMimuSamplePeriodNs`. The maxTimeTag is the
  *  newest slot's tail sample: `max(slot.measTime) + (N - 1) * period_ns`.
- *  Every sample whose derived time is within `averagingWindowNs` of
+ *  Every sample whose derived time is within `gyroAveragingWindowNs` of
  *  maxTimeTag contributes equally to the body-frame average via `dcm_BP`.
  *  Returns zeros if the ring is empty.
  *
@@ -75,7 +75,7 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
         }
         for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT_C; ++s) {
             const uint64_t sampleMeasTime = slot.measTime + (s * kMimuSamplePeriodNs);
-            if ((maxTimeTag - sampleMeasTime) <= this->averagingWindowNs) {
+            if ((maxTimeTag - sampleMeasTime) <= this->gyroAveragingWindowNs) {
                 gyroSum_P += slot.samples.at(s).gyro_P;
                 accelSum_P += slot.samples.at(s).accel_P;
                 measAvgCount++;
@@ -95,15 +95,15 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
     return out;
 }
 
-void AverageMimuDataAlgorithm::setAveragingWindow(double const window) {
+void AverageMimuDataAlgorithm::setGyroAveragingWindow(double const window) {
     if (window < 0.0 || window > kMaxAveragingWindowSec) {
         FSW_THROW_INVALID_ARGUMENT("AveragingWindow cannot be smaller than 0.0 or greater than 2.0 seconds");
     }
-    this->averagingWindowNs = static_cast<std::uint64_t>(window * kSec2Nano);
+    this->gyroAveragingWindowNs = static_cast<std::uint64_t>(window * kSec2Nano);
 }
 
-double AverageMimuDataAlgorithm::getAveragingWindow() const {
-    return this->averagingWindowNs * kNano2Sec;
+double AverageMimuDataAlgorithm::getGyroAveragingWindow() const {
+    return static_cast<double>(this->gyroAveragingWindowNs) * kNano2Sec;
 }
 
 void AverageMimuDataAlgorithm::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn) {

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -7,21 +7,28 @@
 #include <algorithm>
 
 /*! @brief Average recent gyro/accel samples and output them in the body frame.
- *  Uses the newest packet time as a reference, then averages all packets whose
- *  age is within `averagingWindow` seconds.
- *  @param localPkts AccDataMsgF32Payload : an array of AccPktDataMsgF32Payload, each AccPktDataMsgF32Payload contains
- * (measTime, gyro_P, accel_P).
- *  @return OutputAverageAccelAngleVel : body-frame average (AngVelBody, AccelBody). If no packets are in the window,
- * returns zeros.
+ *  Iterates the 4 packets; within each fresh packet (isValid=true), iterates
+ *  the MAX_MIMU_SAMPLES_PER_PKT samples and skips any with measTime == 0.
+ *  Uses the newest fresh sample's time as the reference and averages every
+ *  fresh sample whose age is within `averagingWindow` seconds. Each
+ *  contributing sample is weighted equally.
+ *  @param localPkts InputPktsData: 4-packet x 10-sample ring snapshot.
+ *  @return OutputAverageAccelAngleVel: body-frame average. If no sample is
+ * fresh and within the window, returns zeros.
  */
 OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const& localPkts) const {
-    // A slot is fresh only if the caller marked it valid and supplied a non-zero
-    // measurement time. Zero-initialized ring-buffer slots are skipped so the
-    // first few cycles after power-up do not pollute the average.
+    // Find the newest measTime among samples in valid packets, ignoring
+    // unfilled (measTime == 0) samples. Zero-init ring-buffer slots therefore
+    // cannot pollute the output during warm-up.
     uint64_t maxTimeTag = 0U;
-    for (uint32_t i = 0; i < MAX_BUF_PKT; ++i) {
-        if (localPkts.isValid.at(i) && localPkts.measTime.at(i) != 0U) {
-            maxTimeTag = std::max(localPkts.measTime.at(i), maxTimeTag);
+    for (uint32_t p = 0; p < MAX_MIMU_PKT; ++p) {
+        if (!localPkts.isValid.at(p)) {
+            continue;
+        }
+        for (const auto& sample : localPkts.samples.at(p)) {
+            if (sample.measTime != 0U) {
+                maxTimeTag = std::max(sample.measTime, maxTimeTag);
+            }
         }
     }
 
@@ -34,15 +41,20 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
     Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
     uint64_t measAvgCount = 0U;
 
-    for (uint32_t i = 0; i < MAX_BUF_PKT; ++i) {
-        if (!localPkts.isValid.at(i) || localPkts.measTime.at(i) == 0U) {
+    for (uint32_t p = 0; p < MAX_MIMU_PKT; ++p) {
+        if (!localPkts.isValid.at(p)) {
             continue;
         }
-        // Rolling average with averagingWindow as window width or the maximum buffer size
-        if (static_cast<float>(maxTimeTag - localPkts.measTime.at(i)) * kNano2SecF <= this->averagingWindow) {
-            gyroSum_P += localPkts.gyro_P.at(i);
-            accelSum_P += localPkts.accel_P.at(i);
-            measAvgCount++;
+        for (const auto& [measTime, gyro_P, accel_P] : localPkts.samples.at(p)) {
+            if (measTime == 0U) {
+                continue;
+            }
+            // Rolling average across all fresh samples within the window
+            if (static_cast<float>(maxTimeTag - measTime) * kNano2SecF <= this->averagingWindow) {
+                gyroSum_P += gyro_P;
+                accelSum_P += accel_P;
+                measAvgCount++;
+            }
         }
     }
 

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -6,55 +6,78 @@
 
 #include <algorithm>
 
-/*! @brief Average recent gyro/accel samples and output them in the body frame.
- *  Iterates the 4 packets; within each fresh packet (isValid=true), iterates
- *  the MAX_MIMU_SAMPLES_PER_PKT samples and skips any with measTime == 0.
- *  Uses the newest fresh sample's time as the reference and averages every
- *  fresh sample whose age is within `averagingWindow` seconds. Each
- *  contributing sample is weighted equally.
- *  @param localPkts InputPktsData: 4-packet x 10-sample ring snapshot.
- *  @return OutputAverageAccelAngleVel: body-frame average. If no sample is
- * fresh and within the window, returns zeros.
+/*! @brief Ingest new packets from the input snapshot into the internal ring,
+ *  then return the rolling average of fresh samples currently in the ring.
+ *
+ *  Phase 1 (ingest): Each input packet carries a `measTime` that is the
+ *  first sample's timestamp (`firstSampleTime`). A packet is ingested iff
+ *  its `firstSampleTime` is strictly greater than the largest first-sample
+ *  time ever ingested before this update() call. The whole packet is
+ *  copied into the next ring slot, overwriting the oldest slot when
+ *  capacity is reached. Multiple packets within one snapshot can be
+ *  ingested; already-seen or older-than-prior-max packets are dropped.
+ *
+ *  Phase 2 (average): Per-sample times are derived from each ring slot's
+ *  `measTime` plus `s * kMimuSamplePeriodNs`. The maxTimeTag is the
+ *  newest slot's tail sample: `max(slot.measTime) + (N - 1) * period_ns`.
+ *  Every sample whose derived time is within `averagingWindowNs` of
+ *  maxTimeTag contributes equally to the body-frame average via `dcm_BP`.
+ *  Returns zeros if the ring is empty.
+ *
+ *  @param localPkts InputPktsData: 4-packet snapshot from the caller.
+ *  @return OutputAverageAccelAngleVel: body-frame rolling average.
  */
-OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const& localPkts) const {
-    // Find the newest measTime among samples in valid packets, ignoring
-    // unfilled (measTime == 0) samples. Zero-init ring-buffer slots therefore
-    // cannot pollute the output during warm-up.
-    uint64_t maxTimeTag = 0U;
-    for (uint32_t p = 0; p < MAX_MIMU_PKT; ++p) {
-        if (!localPkts.isValid.at(p)) {
+OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const& localPkts) {
+    // Phase 1: ingest. Freeze prior max so within one snapshot all packets
+    // are evaluated against the previous-call boundary, not against each
+    // other - this lets multiple new packets in the same snapshot all land.
+    const uint64_t priorMax = this->lastIngestedMaxMeasTime;
+    for (auto const& packet : localPkts.packets) {
+        if (!packet.isValid) {
             continue;
         }
-        for (const auto& sample : localPkts.samples.at(p)) {
-            if (sample.measTime != 0U) {
-                maxTimeTag = std::max(sample.measTime, maxTimeTag);
-            }
+        const uint64_t firstSampleTime = packet.measTime;
+        if ((firstSampleTime == 0U) || (firstSampleTime <= priorMax)) {
+            continue;
+        }
+
+        this->ring.at(this->insertIdx).isValid = true;
+        this->ring.at(this->insertIdx).measTime = firstSampleTime;
+        this->ring.at(this->insertIdx).samples = packet.samples;
+        this->insertIdx = (this->insertIdx + 1U) % kRingCapacity;
+        this->lastIngestedMaxMeasTime = std::max(this->lastIngestedMaxMeasTime, firstSampleTime);
+    }
+
+    // Phase 2: derive maxTimeTag from the newest stored packet's tail sample.
+    // Per-sample measTimes are reconstructed from slot.measTime + s * period_ns.
+    uint64_t maxSlotMeasTime = 0U;
+    for (auto const& slot : this->ring) {
+        if (slot.isValid && (slot.measTime > maxSlotMeasTime)) {
+            maxSlotMeasTime = slot.measTime;
         }
     }
 
     OutputAverageAccelAngleVel out{};
-    if (maxTimeTag == 0U) {
+    if (maxSlotMeasTime == 0U) {
         return out;
     }
+
+    const uint64_t maxTimeTag =
+        maxSlotMeasTime + ((MAX_MIMU_SAMPLES_PER_PKT_C - 1U) * kMimuSamplePeriodNs);
 
     Eigen::Vector3f gyroSum_P = Eigen::Vector3f::Zero();
     Eigen::Vector3f accelSum_P = Eigen::Vector3f::Zero();
     uint64_t measAvgCount = 0U;
 
-    for (uint32_t p = 0; p < MAX_MIMU_PKT; ++p) {
-        if (!localPkts.isValid.at(p)) {
+    for (auto const& slot : this->ring) {
+        if (!slot.isValid) {
             continue;
         }
-        for (const auto& [measTime, gyro_P, accel_P] : localPkts.samples.at(p)) {
-            if (measTime == 0U) {
-                continue;
-            }
-            // Rolling average across all fresh samples within the window.
-            // Integer compare in ns avoids casting a multi-second uint64_t
-            // delta through float (which has only a 24-bit mantissa).
-            if ((maxTimeTag - measTime) <= this->averagingWindowNs) {
-                gyroSum_P += gyro_P;
-                accelSum_P += accel_P;
+        for (std::size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT_C; ++s) {
+            const uint64_t sampleMeasTime = slot.measTime + (s * kMimuSamplePeriodNs);
+            if ((maxTimeTag - sampleMeasTime) <= this->averagingWindowNs) {
+                gyroSum_P += slot.samples.at(s).gyro_P;
+                accelSum_P += slot.samples.at(s).accel_P;
                 measAvgCount++;
             }
         }
@@ -73,8 +96,8 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
 }
 
 void AverageMimuDataAlgorithm::setAveragingWindow(float const window) {
-    if (window < 0.0F) {
-        FSW_THROW_INVALID_ARGUMENT("AveragingWindow cannot be smaller than 0.0");
+    if (window < 0.0F || window > kMaxAveragingWindowSec) {
+        FSW_THROW_INVALID_ARGUMENT("AveragingWindow cannot be smaller than 0.0 or greater than 2.0 seconds");
     }
     // Convert seconds->nanoseconds in double so plausible window values
     // (e.g. 2.0 s -> 2_000_000_000 ns) survive without rounding through float.

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.cpp
@@ -95,17 +95,15 @@ OutputAverageAccelAngleVel AverageMimuDataAlgorithm::update(InputPktsData const&
     return out;
 }
 
-void AverageMimuDataAlgorithm::setAveragingWindow(float const window) {
-    if (window < 0.0F || window > kMaxAveragingWindowSec) {
+void AverageMimuDataAlgorithm::setAveragingWindow(double const window) {
+    if (window < 0.0 || window > kMaxAveragingWindowSec) {
         FSW_THROW_INVALID_ARGUMENT("AveragingWindow cannot be smaller than 0.0 or greater than 2.0 seconds");
     }
-    // Convert seconds->nanoseconds in double so plausible window values
-    // (e.g. 2.0 s -> 2_000_000_000 ns) survive without rounding through float.
-    this->averagingWindowNs = static_cast<std::uint64_t>(static_cast<double>(window) * 1.0e9);
+    this->averagingWindowNs = static_cast<std::uint64_t>(window * kSec2Nano);
 }
 
-float AverageMimuDataAlgorithm::getAveragingWindow() const {
-    return static_cast<float>(static_cast<double>(this->averagingWindowNs) * 1.0e-9);
+double AverageMimuDataAlgorithm::getAveragingWindow() const {
+    return this->averagingWindowNs * kNano2Sec;
 }
 
 void AverageMimuDataAlgorithm::setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn) {

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -7,6 +7,8 @@
 #include <array>
 #include <cstdint>
 
+#include <cstdint>
+
 class AverageMimuDataAlgorithm {
    public:
     void setAveragingWindow(float window);                  //!< [s] Setter method for windowSec
@@ -16,7 +18,9 @@ class AverageMimuDataAlgorithm {
     OutputAverageAccelAngleVel update(InputPktsData const& localPkts) const;
 
    private:
-    float averagingWindow{0.0F};                           //!< [s] Allowable time difference from "latest"
+    // Stored as nanoseconds so the per-sample comparison in update() is a pure
+    // uint64_t compare. Float is only used at the public seconds-based API.
+    std::uint64_t averagingWindowNs{0U};                   //!< [ns] Allowable time difference from "latest"
     Eigen::Matrix3f dcm_BP = Eigen::Matrix3f::Identity();  //!< [-] Transformation from the platform frame to body
 };
 

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -8,21 +8,6 @@
 #include <array>
 #include <cstdint>
 
-constexpr std::size_t MAX_BUF_PKT = 120;
-
-/*! @brief Structure containing the InputPktsData*/
-struct InputPktsData {
-    std::array<std::uint64_t, MAX_BUF_PKT> measTime{};
-    std::array<Eigen::Vector3f, MAX_BUF_PKT> gyro_P{};
-    std::array<Eigen::Vector3f, MAX_BUF_PKT> accel_P{};
-};
-
-/*! @brief Structure containing the OutputAverageAccelAngleVel*/
-struct OutputAverageAccelAngleVel {
-    Eigen::Vector3f accel_B = Eigen::Vector3f::Zero();
-    Eigen::Vector3f gyroOmega_B = Eigen::Vector3f::Zero();
-};
-
 class AverageMimuDataAlgorithm {
    public:
     void setAveragingWindow(float window);                  //!< [s] Setter method for windowSec

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -63,8 +63,8 @@ class AverageMimuDataAlgorithm {
         average_mimu_detail::ceilDivSamplesToPackets(
             kMimuSampleRateHz, kMaxAveragingWindowSec, MAX_MIMU_SAMPLES_PER_PKT_C);
 
-    void setAveragingWindow(float window);                  //!< [s] Setter method for windowSec
-    float getAveragingWindow() const;                       //!< [s] Getter method for windowSec
+    void setAveragingWindow(double window);                 //!< [s] Setter method for windowSec
+    double getAveragingWindow() const;                      //!< [s] Getter method for windowSec
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;                //!< Getter method for dcm from platform to body
 

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -2,7 +2,6 @@
 #define AVERAGE_MIMU_DATA_ALGORITHM_H
 
 #include "averageMimuDataTypes.h"
-#include "msgPayloadDef/AccDataMsgF32Payload.h"
 
 #include <Eigen/Core>
 #include <array>

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -63,8 +63,8 @@ class AverageMimuDataAlgorithm {
         average_mimu_detail::ceilDivSamplesToPackets(
             kMimuSampleRateHz, kMaxAveragingWindowSec, MAX_MIMU_SAMPLES_PER_PKT_C);
 
-    void setAveragingWindow(double window);                 //!< [s] Setter method for windowSec
-    double getAveragingWindow() const;                      //!< [s] Getter method for windowSec
+    void setGyroAveragingWindow(double window);                 //!< [s] Setter method for windowSec
+    double getGyroAveragingWindow() const;                      //!< [s] Getter method for windowSec
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;                //!< Getter method for dcm from platform to body
 
@@ -85,7 +85,7 @@ class AverageMimuDataAlgorithm {
 
     // Stored as nanoseconds so the per-sample comparison in update() is a
     // pure uint64_t compare. Float is only used at the public seconds-based API.
-    std::uint64_t averagingWindowNs{0U};                   //!< [ns] Allowable time difference from "latest"
+    std::uint64_t gyroAveragingWindowNs{0U};                   //!< [ns] Allowable time difference from "latest"
     Eigen::Matrix3f dcm_BP = Eigen::Matrix3f::Identity();  //!< [-] Transformation from the platform frame to body
     std::array<RingPacket, kRingCapacity> ring{};          //!< Internal ring of recent packets (overwrites oldest on insert)
     std::size_t insertIdx{0U};                             //!< Next ring slot to overwrite

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -32,7 +32,6 @@ struct InputPktsData {
     std::array<InputPacket, MAX_MIMU_PKT_C> packets{};
 };
 
-
 /*! @brief Structure containing the OutputAverageAccelAngleVel*/
 struct OutputAverageAccelAngleVel {
     Eigen::Vector3f accel_B = Eigen::Vector3f::Zero();
@@ -52,21 +51,22 @@ class AverageMimuDataAlgorithm {
    public:
     // MIMU device sample rate (compile-time fixed). Period in nanoseconds
     // is precomputed so the per-sample staleness check stays in integer math.
-    static constexpr float         kMimuSampleRateHz     = 100.0F;
-    static constexpr std::uint64_t kMimuSamplePeriodNs   = 10'000'000U;  // 1e9 / 100
+    static constexpr float kMimuSampleRateHz = 100.0F;
+    static constexpr std::uint64_t kMimuSamplePeriodNs = 10'000'000U;  // 1e9 / 100
 
     // Compile-time cap on the configured averaging window. Ring capacity is
     // sized to hold exactly this many seconds of samples at the MIMU rate.
     static constexpr float kMaxAveragingWindowSec = 2.0F;
 
     static constexpr std::size_t kRingCapacity =
-        average_mimu_detail::ceilDivSamplesToPackets(
-            kMimuSampleRateHz, kMaxAveragingWindowSec, MAX_MIMU_SAMPLES_PER_PKT_C);
+        average_mimu_detail::ceilDivSamplesToPackets(kMimuSampleRateHz,
+                                                     kMaxAveragingWindowSec,
+                                                     MAX_MIMU_SAMPLES_PER_PKT_C);
 
-    void setGyroAveragingWindow(double window);                 //!< [s] Setter method for gyro windowSec
-    double getGyroAveragingWindow() const;                      //!< [s] Getter method for gyro windowSec
-    void setAccelAveragingWindow(double window);                //!< [s] Setter method for accel windowSec
-    double getAccelAveragingWindow() const;                     //!< [s] Getter method for accel windowSec
+    void setGyroAveragingWindow(double window);             //!< [s] Setter method for gyro windowSec
+    double getGyroAveragingWindow() const;                  //!< [s] Getter method for gyro windowSec
+    void setAccelAveragingWindow(double window);            //!< [s] Setter method for accel windowSec
+    double getAccelAveragingWindow() const;                 //!< [s] Getter method for accel windowSec
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;                //!< Getter method for dcm from platform to body
 
@@ -87,12 +87,12 @@ class AverageMimuDataAlgorithm {
 
     // Stored as nanoseconds so the per-sample comparison in update() is a
     // pure uint64_t compare. Float is only used at the public seconds-based API.
-    std::uint64_t gyroAveragingWindowNs{0U};                   //!< [ns] Gyro: allowable time difference from "latest"
-    std::uint64_t accelAveragingWindowNs{0U};                  //!< [ns] Accel: allowable time difference from "latest"
+    std::uint64_t gyroAveragingWindowNs{0U};               //!< [ns] Gyro: allowable time difference from "latest"
+    std::uint64_t accelAveragingWindowNs{0U};              //!< [ns] Accel: allowable time difference from "latest"
     Eigen::Matrix3f dcm_BP = Eigen::Matrix3f::Identity();  //!< [-] Transformation from the platform frame to body
-    std::array<RingPacket, kRingCapacity> ring{};          //!< Internal ring of recent packets (overwrites oldest on insert)
-    std::size_t insertIdx{0U};                             //!< Next ring slot to overwrite
-    std::uint64_t lastIngestedMaxMeasTime{0U};             //!< Newest representative time ever ingested (for new-packet detection)
+    std::array<RingPacket, kRingCapacity> ring{};  //!< Internal ring of recent packets (overwrites oldest on insert)
+    std::size_t insertIdx{0U};                     //!< Next ring slot to overwrite
+    std::uint64_t lastIngestedMaxMeasTime{0U};  //!< Newest representative time ever ingested (for new-packet detection)
 };
 
 #endif

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -63,15 +63,17 @@ class AverageMimuDataAlgorithm {
         average_mimu_detail::ceilDivSamplesToPackets(
             kMimuSampleRateHz, kMaxAveragingWindowSec, MAX_MIMU_SAMPLES_PER_PKT_C);
 
-    void setGyroAveragingWindow(double window);                 //!< [s] Setter method for windowSec
-    double getGyroAveragingWindow() const;                      //!< [s] Getter method for windowSec
+    void setGyroAveragingWindow(double window);                 //!< [s] Setter method for gyro windowSec
+    double getGyroAveragingWindow() const;                      //!< [s] Getter method for gyro windowSec
+    void setAccelAveragingWindow(double window);                //!< [s] Setter method for accel windowSec
+    double getAccelAveragingWindow() const;                     //!< [s] Getter method for accel windowSec
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;                //!< Getter method for dcm from platform to body
 
     // Ingests new packets from the snapshot into the internal ring (strict
     // monotonic by per-packet representative time) and returns the rolling
-    // average over fresh samples in the ring within averagingWindow of the
-    // newest stored sample.
+    // average of fresh samples in the ring, gyro within gyroAveragingWindow and
+    // accel within accelAveragingWindow of the newest stored sample.
     OutputAverageAccelAngleVel update(InputPktsData const& localPkts);
 
    private:
@@ -85,7 +87,8 @@ class AverageMimuDataAlgorithm {
 
     // Stored as nanoseconds so the per-sample comparison in update() is a
     // pure uint64_t compare. Float is only used at the public seconds-based API.
-    std::uint64_t gyroAveragingWindowNs{0U};                   //!< [ns] Allowable time difference from "latest"
+    std::uint64_t gyroAveragingWindowNs{0U};                   //!< [ns] Gyro: allowable time difference from "latest"
+    std::uint64_t accelAveragingWindowNs{0U};                  //!< [ns] Accel: allowable time difference from "latest"
     Eigen::Matrix3f dcm_BP = Eigen::Matrix3f::Identity();  //!< [-] Transformation from the platform frame to body
     std::array<RingPacket, kRingCapacity> ring{};          //!< Internal ring of recent packets (overwrites oldest on insert)
     std::size_t insertIdx{0U};                             //!< Next ring slot to overwrite

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm.h
@@ -7,21 +7,89 @@
 #include <array>
 #include <cstdint>
 
-#include <cstdint>
+/*! @brief One MIMU sample at the algorithm-internal layer: a gyro/accel
+ *         pair in the platform frame. Per-sample timestamps are derived
+ *         from the enclosing packet's `measTime` plus the device sample
+ *         period (kMimuSamplePeriodNs); the sample itself stores no time. */
+struct Sample {
+    Eigen::Vector3f gyro_P{Eigen::Vector3f::Zero()};
+    Eigen::Vector3f accel_P{Eigen::Vector3f::Zero()};
+};
+
+/*! @brief Algorithm-internal view of one MIMU packet. `measTime` is the
+ *         first sample's measurement time; the rest of the samples follow
+ *         at multiples of kMimuSamplePeriodNs. `isValid` gates the whole
+ *         packet; when true, every sample in `samples` is assumed real. */
+struct InputPacket {
+    bool isValid{false};
+    std::uint64_t measTime{0U};
+    std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT_C> samples{};
+};
+
+/*! @brief Algorithm-internal view of a MimuPacketF32Payload: 4 packets,
+ *         each holding MAX_MIMU_SAMPLES_PER_PKT_C samples. */
+struct InputPktsData {
+    std::array<InputPacket, MAX_MIMU_PKT_C> packets{};
+};
+
+
+/*! @brief Structure containing the OutputAverageAccelAngleVel*/
+struct OutputAverageAccelAngleVel {
+    Eigen::Vector3f accel_B = Eigen::Vector3f::Zero();
+    Eigen::Vector3f gyroOmega_B = Eigen::Vector3f::Zero();
+};
+
+namespace average_mimu_detail {
+// Ceiling division so `rateHz * windowSec` samples round up to whole packets.
+constexpr std::size_t ceilDivSamplesToPackets(float rateHz, float windowSec, std::size_t samplesPerPkt) {
+    const float totalSamples = rateHz * windowSec;
+    const std::size_t pkts = static_cast<std::size_t>(totalSamples) / samplesPerPkt;
+    return (static_cast<float>(pkts * samplesPerPkt) < totalSamples) ? pkts + 1U : pkts;
+}
+}  // namespace average_mimu_detail
 
 class AverageMimuDataAlgorithm {
    public:
+    // MIMU device sample rate (compile-time fixed). Period in nanoseconds
+    // is precomputed so the per-sample staleness check stays in integer math.
+    static constexpr float         kMimuSampleRateHz     = 100.0F;
+    static constexpr std::uint64_t kMimuSamplePeriodNs   = 10'000'000U;  // 1e9 / 100
+
+    // Compile-time cap on the configured averaging window. Ring capacity is
+    // sized to hold exactly this many seconds of samples at the MIMU rate.
+    static constexpr float kMaxAveragingWindowSec = 2.0F;
+
+    static constexpr std::size_t kRingCapacity =
+        average_mimu_detail::ceilDivSamplesToPackets(
+            kMimuSampleRateHz, kMaxAveragingWindowSec, MAX_MIMU_SAMPLES_PER_PKT_C);
+
     void setAveragingWindow(float window);                  //!< [s] Setter method for windowSec
     float getAveragingWindow() const;                       //!< [s] Getter method for windowSec
     void setDcmPltfToBdy(Eigen::Matrix3f const& dcm_BPIn);  //!< Setter method for dcm from platform to body
     Eigen::Matrix3f getDcmPltfToBdy() const;                //!< Getter method for dcm from platform to body
-    OutputAverageAccelAngleVel update(InputPktsData const& localPkts) const;
+
+    // Ingests new packets from the snapshot into the internal ring (strict
+    // monotonic by per-packet representative time) and returns the rolling
+    // average over fresh samples in the ring within averagingWindow of the
+    // newest stored sample.
+    OutputAverageAccelAngleVel update(InputPktsData const& localPkts);
 
    private:
-    // Stored as nanoseconds so the per-sample comparison in update() is a pure
-    // uint64_t compare. Float is only used at the public seconds-based API.
+    // Ring slot mirrors the InputPacket shape: a packet's first-sample time
+    // plus its samples. Per-sample times are derived at average compute time.
+    struct RingPacket {
+        bool isValid{false};
+        std::uint64_t measTime{0U};
+        std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT_C> samples{};
+    };
+
+    // Stored as nanoseconds so the per-sample comparison in update() is a
+    // pure uint64_t compare. Float is only used at the public seconds-based API.
     std::uint64_t averagingWindowNs{0U};                   //!< [ns] Allowable time difference from "latest"
     Eigen::Matrix3f dcm_BP = Eigen::Matrix3f::Identity();  //!< [-] Transformation from the platform frame to body
+    std::array<RingPacket, kRingCapacity> ring{};          //!< Internal ring of recent packets (overwrites oldest on insert)
+    std::size_t insertIdx{0U};                             //!< Next ring slot to overwrite
+    std::uint64_t lastIngestedMaxMeasTime{0U};             //!< Newest representative time ever ingested (for new-packet detection)
 };
 
 #endif

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
@@ -17,6 +17,7 @@ OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(const AverageMimuDa
                                                              const InputPktsData_c* input) {
     InputPktsData in{};
     for (size_t i = 0; i < MAX_BUF_PKT; i++) {
+        in.isValid[i] = input->isValid[i];
         in.measTime[i] = input->measTime[i];
         in.gyro_P[i] = Eigen::Vector3f(input->gyro_P[i].data[0], input->gyro_P[i].data[1], input->gyro_P[i].data[2]);
         in.accel_P[i] =

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
@@ -39,11 +39,11 @@ OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgo
     return result;
 }
 
-void AverageMimuDataAlgorithm_setAveragingWindow(AverageMimuDataAlgorithmHandle* self, float window) {
+void AverageMimuDataAlgorithm_setAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window) {
     reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->setAveragingWindow(window);
 }
 
-float AverageMimuDataAlgorithm_getAveragingWindow(const AverageMimuDataAlgorithmHandle* self) {
+double AverageMimuDataAlgorithm_getAveragingWindow(const AverageMimuDataAlgorithmHandle* self) {
     return reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getAveragingWindow();
 }
 

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
@@ -39,12 +39,12 @@ OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgo
     return result;
 }
 
-void AverageMimuDataAlgorithm_setAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window) {
-    reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->setAveragingWindow(window);
+void AverageMimuDataAlgorithm_setGyroAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window) {
+    reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->setGyroAveragingWindow(window);
 }
 
-double AverageMimuDataAlgorithm_getAveragingWindow(const AverageMimuDataAlgorithmHandle* self) {
-    return reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getAveragingWindow();
+double AverageMimuDataAlgorithm_getGyroAveragingWindow(const AverageMimuDataAlgorithmHandle* self) {
+    return reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getGyroAveragingWindow();
 }
 
 void AverageMimuDataAlgorithm_setDcmPltfToBdy(AverageMimuDataAlgorithmHandle* self, Matrix3f_c dcm_BP) {

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
@@ -3,9 +3,9 @@
 
 #include <Eigen/Core>
 
-uint32_t AverageMimuDataAlgorithm_getMaxMimuPkt(void) { return MAX_MIMU_PKT; }
+uint32_t AverageMimuDataAlgorithm_getMaxMimuPkt(void) { return MAX_MIMU_PKT_C; }
 
-uint32_t AverageMimuDataAlgorithm_getMaxMimuSamplesPerPkt(void) { return MAX_MIMU_SAMPLES_PER_PKT; }
+uint32_t AverageMimuDataAlgorithm_getMaxMimuSamplesPerPkt(void) { return MAX_MIMU_SAMPLES_PER_PKT_C; }
 
 AverageMimuDataAlgorithmHandle* AverageMimuDataAlgorithm_create(void) {
     return reinterpret_cast<AverageMimuDataAlgorithmHandle*>(new ::AverageMimuDataAlgorithm());
@@ -15,24 +15,27 @@ void AverageMimuDataAlgorithm_destroy(AverageMimuDataAlgorithmHandle* self) {
     delete reinterpret_cast<::AverageMimuDataAlgorithm*>(self);
 }
 
-OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(const AverageMimuDataAlgorithmHandle* self,
+OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgorithmHandle* self,
                                                              const InputPktsData_c* input) {
     InputPktsData in{};
-    for (size_t p = 0; p < MAX_MIMU_PKT; p++) {
-        in.isValid[p] = input->isValid[p];
-        for (size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; s++) {
-            const Sample_c& src = input->samples[p][s];
-            in.samples[p][s].measTime = src.measTime;
-            in.samples[p][s].gyro_P = Eigen::Vector3f(src.gyro_P.data[0], src.gyro_P.data[1], src.gyro_P.data[2]);
-            in.samples[p][s].accel_P = Eigen::Vector3f(src.accel_P.data[0], src.accel_P.data[1], src.accel_P.data[2]);
+    for (size_t p = 0; p < MAX_MIMU_PKT_C; p++) {
+        const InputPacket_c& src = input->packets[p];
+        in.packets[p].isValid = src.isValid;
+        in.packets[p].measTime = src.measTime;
+        for (size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT_C; s++) {
+            const Sample_c& srcSample = src.samples[s];
+            in.packets[p].samples[s].gyro_P =
+                Eigen::Vector3f(srcSample.gyro_P.data[0], srcSample.gyro_P.data[1], srcSample.gyro_P.data[2]);
+            in.packets[p].samples[s].accel_P =
+                Eigen::Vector3f(srcSample.accel_P.data[0], srcSample.accel_P.data[1], srcSample.accel_P.data[2]);
         }
     }
 
-    const auto [accel_B, gyroOmega_B] = reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->update(in);
+    const auto [accel_B, gyroOmega_B] = reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->update(in);
 
     OutputAverageAccelAngleVel_c result{};
-    result.accel_B = {accel_B[0], accel_B[1], accel_B[2]};
-    result.gyroOmega_B = {gyroOmega_B[0], gyroOmega_B[1], gyroOmega_B[2]};
+    result.accel_B = Vector3f_c{{accel_B[0], accel_B[1], accel_B[2]}};
+    result.gyroOmega_B = Vector3f_c{{gyroOmega_B[0], gyroOmega_B[1], gyroOmega_B[2]}};
     return result;
 }
 

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
@@ -3,7 +3,9 @@
 
 #include <Eigen/Core>
 
-uint32_t AverageMimuDataAlgorithm_getMaxBufPkt(void) { return MAX_BUF_PKT; }
+uint32_t AverageMimuDataAlgorithm_getMaxMimuPkt(void) { return MAX_MIMU_PKT; }
+
+uint32_t AverageMimuDataAlgorithm_getMaxMimuSamplesPerPkt(void) { return MAX_MIMU_SAMPLES_PER_PKT; }
 
 AverageMimuDataAlgorithmHandle* AverageMimuDataAlgorithm_create(void) {
     return reinterpret_cast<AverageMimuDataAlgorithmHandle*>(new ::AverageMimuDataAlgorithm());
@@ -16,12 +18,14 @@ void AverageMimuDataAlgorithm_destroy(AverageMimuDataAlgorithmHandle* self) {
 OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(const AverageMimuDataAlgorithmHandle* self,
                                                              const InputPktsData_c* input) {
     InputPktsData in{};
-    for (size_t i = 0; i < MAX_BUF_PKT; i++) {
-        in.isValid[i] = input->isValid[i];
-        in.measTime[i] = input->measTime[i];
-        in.gyro_P[i] = Eigen::Vector3f(input->gyro_P[i].data[0], input->gyro_P[i].data[1], input->gyro_P[i].data[2]);
-        in.accel_P[i] =
-            Eigen::Vector3f(input->accel_P[i].data[0], input->accel_P[i].data[1], input->accel_P[i].data[2]);
+    for (size_t p = 0; p < MAX_MIMU_PKT; p++) {
+        in.isValid[p] = input->isValid[p];
+        for (size_t s = 0; s < MAX_MIMU_SAMPLES_PER_PKT; s++) {
+            const Sample_c& src = input->samples[p][s];
+            in.samples[p][s].measTime = src.measTime;
+            in.samples[p][s].gyro_P = Eigen::Vector3f(src.gyro_P.data[0], src.gyro_P.data[1], src.gyro_P.data[2]);
+            in.samples[p][s].accel_P = Eigen::Vector3f(src.accel_P.data[0], src.accel_P.data[1], src.accel_P.data[2]);
+        }
     }
 
     const auto [accel_B, gyroOmega_B] = reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->update(in);

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
@@ -47,6 +47,14 @@ double AverageMimuDataAlgorithm_getGyroAveragingWindow(const AverageMimuDataAlgo
     return reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getGyroAveragingWindow();
 }
 
+void AverageMimuDataAlgorithm_setAccelAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window) {
+    reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->setAccelAveragingWindow(window);
+}
+
+double AverageMimuDataAlgorithm_getAccelAveragingWindow(const AverageMimuDataAlgorithmHandle* self) {
+    return reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getAccelAveragingWindow();
+}
+
 void AverageMimuDataAlgorithm_setDcmPltfToBdy(AverageMimuDataAlgorithmHandle* self, Matrix3f_c dcm_BP) {
     Eigen::Matrix3f mat;
     for (int i = 0; i < 3; i++) {

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
@@ -52,14 +52,14 @@ OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgo
  * @param self   Pointer to the instance.
  * @param window Averaging window duration in seconds.
  */
-void AverageMimuDataAlgorithm_setAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window);
+void AverageMimuDataAlgorithm_setGyroAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window);
 
 /**
  * @brief Get the current averaging window duration.
  * @param self Pointer to the instance.
  * @return double  The current averaging window in seconds.
  */
-double AverageMimuDataAlgorithm_getAveragingWindow(const AverageMimuDataAlgorithmHandle* self);
+double AverageMimuDataAlgorithm_getGyroAveragingWindow(const AverageMimuDataAlgorithmHandle* self);
 
 /**
  * @brief Set the DCM from platform frame to body frame.

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
@@ -48,18 +48,32 @@ OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgo
                                                              const InputPktsData_c* input);
 
 /**
- * @brief Set the averaging window duration.
+ * @brief Set the gyro averaging window duration.
  * @param self   Pointer to the instance.
- * @param window Averaging window duration in seconds.
+ * @param window Gyro averaging window duration in seconds.
  */
 void AverageMimuDataAlgorithm_setGyroAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window);
 
 /**
- * @brief Get the current averaging window duration.
+ * @brief Get the current gyro averaging window duration.
  * @param self Pointer to the instance.
- * @return double  The current averaging window in seconds.
+ * @return double  The current gyro averaging window in seconds.
  */
 double AverageMimuDataAlgorithm_getGyroAveragingWindow(const AverageMimuDataAlgorithmHandle* self);
+
+/**
+ * @brief Set the accel averaging window duration.
+ * @param self   Pointer to the instance.
+ * @param window Accel averaging window duration in seconds.
+ */
+void AverageMimuDataAlgorithm_setAccelAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window);
+
+/**
+ * @brief Get the current accel averaging window duration.
+ * @param self Pointer to the instance.
+ * @return double  The current accel averaging window in seconds.
+ */
+double AverageMimuDataAlgorithm_getAccelAveragingWindow(const AverageMimuDataAlgorithmHandle* self);
 
 /**
  * @brief Set the DCM from platform frame to body frame.

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
@@ -52,14 +52,14 @@ OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgo
  * @param self   Pointer to the instance.
  * @param window Averaging window duration in seconds.
  */
-void AverageMimuDataAlgorithm_setAveragingWindow(AverageMimuDataAlgorithmHandle* self, float window);
+void AverageMimuDataAlgorithm_setAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window);
 
 /**
  * @brief Get the current averaging window duration.
  * @param self Pointer to the instance.
- * @return float  The current averaging window in seconds.
+ * @return double  The current averaging window in seconds.
  */
-float AverageMimuDataAlgorithm_getAveragingWindow(const AverageMimuDataAlgorithmHandle* self);
+double AverageMimuDataAlgorithm_getAveragingWindow(const AverageMimuDataAlgorithmHandle* self);
 
 /**
  * @brief Set the DCM from platform frame to body frame.

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
@@ -1,7 +1,7 @@
 #ifndef F32XMERA_AVERAGEMIMUDATAALGORITHM_C_H
 #define F32XMERA_AVERAGEMIMUDATAALGORITHM_C_H
 
-#include "utilities/fsw/plainCAlgorithmDataTypes.h"
+#include <utilities/fsw/plainCAlgorithmDataTypes.h>
 
 #include "averageMimuDataTypes.h"
 

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
@@ -3,9 +3,7 @@
 
 #include "utilities/fsw/plainCAlgorithmDataTypes.h"
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
+#include "averageMimuDataTypes.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,38 +13,6 @@ extern "C" {
  * @brief Opaque handle to the C++ AverageMimuDataAlgorithm instance.
  */
 typedef struct AverageMimuDataAlgorithmHandle AverageMimuDataAlgorithmHandle;
-
-#define MAX_MIMU_PKT_C 4
-#define MAX_MIMU_SAMPLES_PER_PKT_C 10
-
-/**
- * @brief POD equivalent of one MIMU sample (algorithm-internal `Sample`).
- */
-typedef struct {
-    uint64_t measTime;
-    Vector3f_c gyro_P;
-    Vector3f_c accel_P;
-} Sample_c;
-
-/**
- * @brief POD equivalent of InputPktsData.
- *
- * 4 packets x 10 samples per packet. `isValid[p]` gates the whole packet;
- * within a fresh packet, samples with samples[p][s].measTime == 0 are
- * treated as unfilled and skipped.
- */
-typedef struct {
-    bool isValid[MAX_MIMU_PKT_C];
-    Sample_c samples[MAX_MIMU_PKT_C][MAX_MIMU_SAMPLES_PER_PKT_C];
-} InputPktsData_c;
-
-/**
- * @brief POD equivalent of OutputAverageAccelAngleVel.
- */
-typedef struct {
-    Vector3f_c accel_B;
-    Vector3f_c gyroOmega_B;
-} OutputAverageAccelAngleVel_c;
 
 /**
  * @brief Get the MAX_MIMU_PKT constant for Ada validation.
@@ -78,7 +44,7 @@ void AverageMimuDataAlgorithm_destroy(AverageMimuDataAlgorithmHandle* self);
  * @param input     Pointer to input packets data.
  * @return OutputAverageAccelAngleVel_c  The computed body-frame averages.
  */
-OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(const AverageMimuDataAlgorithmHandle* self,
+OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgorithmHandle* self,
                                                              const InputPktsData_c* input);
 
 /**

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
@@ -3,6 +3,8 @@
 
 #include "utilities/fsw/plainCAlgorithmDataTypes.h"
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -20,6 +22,7 @@ typedef struct AverageMimuDataAlgorithmHandle AverageMimuDataAlgorithmHandle;
  * @brief POD equivalent of InputPktsData.
  */
 typedef struct {
+    bool isValid[MAX_BUF_PKT_C];
     uint64_t measTime[MAX_BUF_PKT_C];
     Vector3f_c gyro_P[MAX_BUF_PKT_C];
     Vector3f_c accel_P[MAX_BUF_PKT_C];

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.h
@@ -16,16 +16,28 @@ extern "C" {
  */
 typedef struct AverageMimuDataAlgorithmHandle AverageMimuDataAlgorithmHandle;
 
-#define MAX_BUF_PKT_C 120
+#define MAX_MIMU_PKT_C 4
+#define MAX_MIMU_SAMPLES_PER_PKT_C 10
+
+/**
+ * @brief POD equivalent of one MIMU sample (algorithm-internal `Sample`).
+ */
+typedef struct {
+    uint64_t measTime;
+    Vector3f_c gyro_P;
+    Vector3f_c accel_P;
+} Sample_c;
 
 /**
  * @brief POD equivalent of InputPktsData.
+ *
+ * 4 packets x 10 samples per packet. `isValid[p]` gates the whole packet;
+ * within a fresh packet, samples with samples[p][s].measTime == 0 are
+ * treated as unfilled and skipped.
  */
 typedef struct {
-    bool isValid[MAX_BUF_PKT_C];
-    uint64_t measTime[MAX_BUF_PKT_C];
-    Vector3f_c gyro_P[MAX_BUF_PKT_C];
-    Vector3f_c accel_P[MAX_BUF_PKT_C];
+    bool isValid[MAX_MIMU_PKT_C];
+    Sample_c samples[MAX_MIMU_PKT_C][MAX_MIMU_SAMPLES_PER_PKT_C];
 } InputPktsData_c;
 
 /**
@@ -37,10 +49,16 @@ typedef struct {
 } OutputAverageAccelAngleVel_c;
 
 /**
- * @brief Get the MAX_BUF_PKT constant for Ada validation.
- * @return The maximum buffer packet count (MAX_BUF_PKT_C).
+ * @brief Get the MAX_MIMU_PKT constant for Ada validation.
+ * @return The maximum mimu packet count (MAX_MIMU_PKT_C).
  */
-uint32_t AverageMimuDataAlgorithm_getMaxBufPkt(void);
+uint32_t AverageMimuDataAlgorithm_getMaxMimuPkt(void);
+
+/**
+ * @brief Get the MAX_MIMU_SAMPLES_PER_PKT constant for Ada validation.
+ * @return The maximum number of samples per packet (MAX_MIMU_SAMPLES_PER_PKT_C).
+ */
+uint32_t AverageMimuDataAlgorithm_getMaxMimuSamplesPerPkt(void);
 
 /**
  * @brief Construct a new AverageMimuDataAlgorithm instance.

--- a/algorithms/averageMimuData/averageMimuDataF32.i
+++ b/algorithms/averageMimuData/averageMimuDataF32.i
@@ -11,4 +11,5 @@
 %include <sys_model.i>
 %include "averageMimuData.h"
 
-%include "msgPayloadDef/AccDataMsgF32Payload.h"
+%include "msgPayloadDef/MimuPacketGroupF32Payload.h"
+%include "msgPayloadDef/MimuPacketF32Payload.h"

--- a/algorithms/averageMimuData/averageMimuDataF32.i
+++ b/algorithms/averageMimuData/averageMimuDataF32.i
@@ -11,5 +11,8 @@
 %include <sys_model.i>
 %include "averageMimuData.h"
 
+STRUCTASLIST(AccPktDataMsgF32Payload)
+STRUCTASLIST(MimuPacketGroupF32Payload)
+
 %include "msgPayloadDef/MimuPacketGroupF32Payload.h"
 %include "msgPayloadDef/MimuPacketF32Payload.h"

--- a/algorithms/averageMimuData/averageMimuDataTypes.h
+++ b/algorithms/averageMimuData/averageMimuDataTypes.h
@@ -1,7 +1,7 @@
 #ifndef F32XMERA_AVERAGE_MIMU_DATA_TYPES_H
 #define F32XMERA_AVERAGE_MIMU_DATA_TYPES_H
 
-#include "utilities/fsw/plainCAlgorithmDataTypes.h"
+#include <utilities/fsw/plainCAlgorithmDataTypes.h>
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -53,7 +53,6 @@ typedef struct {
     Vector3f_c accel_B;
     Vector3f_c gyroOmega_B;
 } OutputAverageAccelAngleVel_c;
-
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/algorithms/averageMimuData/averageMimuDataTypes.h
+++ b/algorithms/averageMimuData/averageMimuDataTypes.h
@@ -1,4 +1,30 @@
-#ifndef F32XMERA_AVERAGE_MIMU_DATA_TYPES_H
-#define F32XMERA_AVERAGE_MIMU_DATA_TYPES_H
+#ifndef F32XIMERA_AVERAGE_MIMU_DATA_TYPES_H
+#define F32XIMERA_AVERAGE_MIMU_DATA_TYPES_H
 
-#endif  // F32XMERA_AVERAGE_MIMU_DATA_TYPES_H
+#include <Eigen/Core>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+constexpr std::size_t MAX_BUF_PKT = 120;
+
+/*! @brief Structure containing the InputPktsData*/
+struct InputPktsData {
+    std::array<bool, MAX_BUF_PKT> isValid{};
+    std::array<std::uint64_t, MAX_BUF_PKT> measTime{};
+    std::array<Eigen::Vector3f, MAX_BUF_PKT> gyro_P{};
+    std::array<Eigen::Vector3f, MAX_BUF_PKT> accel_P{};
+};
+
+/*! @brief Structure containing the OutputAverageAccelAngleVel*/
+struct OutputAverageAccelAngleVel {
+    Eigen::Vector3f accel_B = Eigen::Vector3f::Zero();
+    Eigen::Vector3f gyroOmega_B = Eigen::Vector3f::Zero();
+};
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // F32XIMERA_AVERAGE_MIMU_DATA_TYPES_H

--- a/algorithms/averageMimuData/averageMimuDataTypes.h
+++ b/algorithms/averageMimuData/averageMimuDataTypes.h
@@ -1,20 +1,30 @@
 #ifndef F32XIMERA_AVERAGE_MIMU_DATA_TYPES_H
 #define F32XIMERA_AVERAGE_MIMU_DATA_TYPES_H
 
+#include "msgPayloadDef/MimuPacketF32Payload.h"
+
 #include <Eigen/Core>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-constexpr std::size_t MAX_BUF_PKT = 120;
+/*! @brief One MIMU sample at the algorithm-internal layer: a time-tagged
+ *         gyro/accel pair in the platform frame. */
+struct Sample {
+    std::uint64_t measTime{0U};
+    Eigen::Vector3f gyro_P{Eigen::Vector3f::Zero()};
+    Eigen::Vector3f accel_P{Eigen::Vector3f::Zero()};
+};
 
-/*! @brief Structure containing the InputPktsData*/
+/*! @brief Algorithm-internal view of a MimuPacketF32Payload: 4 packets,
+ *         each holding up to MAX_MIMU_SAMPLES_PER_PKT time-tagged samples.
+ *         The per-packet isValid flag gates the whole packet; within a
+ *         fresh packet, a sample with measTime == 0 is treated as
+ *         unfilled. */
 struct InputPktsData {
-    std::array<bool, MAX_BUF_PKT> isValid{};
-    std::array<std::uint64_t, MAX_BUF_PKT> measTime{};
-    std::array<Eigen::Vector3f, MAX_BUF_PKT> gyro_P{};
-    std::array<Eigen::Vector3f, MAX_BUF_PKT> accel_P{};
+    std::array<bool, MAX_MIMU_PKT> isValid{};
+    std::array<std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT>, MAX_MIMU_PKT> samples{};
 };
 
 /*! @brief Structure containing the OutputAverageAccelAngleVel*/

--- a/algorithms/averageMimuData/averageMimuDataTypes.h
+++ b/algorithms/averageMimuData/averageMimuDataTypes.h
@@ -1,40 +1,62 @@
-#ifndef F32XIMERA_AVERAGE_MIMU_DATA_TYPES_H
-#define F32XIMERA_AVERAGE_MIMU_DATA_TYPES_H
+#ifndef F32XMERA_AVERAGE_MIMU_DATA_TYPES_H
+#define F32XMERA_AVERAGE_MIMU_DATA_TYPES_H
 
-#include "msgPayloadDef/MimuPacketF32Payload.h"
+#include "utilities/fsw/plainCAlgorithmDataTypes.h"
 
-#include <Eigen/Core>
+#include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/*! @brief One MIMU sample at the algorithm-internal layer: a time-tagged
- *         gyro/accel pair in the platform frame. */
-struct Sample {
-    std::uint64_t measTime{0U};
-    Eigen::Vector3f gyro_P{Eigen::Vector3f::Zero()};
-    Eigen::Vector3f accel_P{Eigen::Vector3f::Zero()};
-};
+#define MAX_MIMU_PKT_C 4
+#define MAX_MIMU_SAMPLES_PER_PKT_C 10
 
-/*! @brief Algorithm-internal view of a MimuPacketF32Payload: 4 packets,
- *         each holding up to MAX_MIMU_SAMPLES_PER_PKT time-tagged samples.
- *         The per-packet isValid flag gates the whole packet; within a
- *         fresh packet, a sample with measTime == 0 is treated as
- *         unfilled. */
-struct InputPktsData {
-    std::array<bool, MAX_MIMU_PKT> isValid{};
-    std::array<std::array<Sample, MAX_MIMU_SAMPLES_PER_PKT>, MAX_MIMU_PKT> samples{};
-};
+/**
+ * @brief POD equivalent of one MIMU sample (algorithm-internal `Sample`).
+ *
+ * Per-sample timestamps are derived from the enclosing packet's `measTime`
+ * and the MIMU device's compile-time sample period; the sample itself
+ * carries only the gyro/accel measurement.
+ */
+typedef struct {
+    Vector3f_c gyro_P;
+    Vector3f_c accel_P;
+} Sample_c;
 
-/*! @brief Structure containing the OutputAverageAccelAngleVel*/
-struct OutputAverageAccelAngleVel {
-    Eigen::Vector3f accel_B = Eigen::Vector3f::Zero();
-    Eigen::Vector3f gyroOmega_B = Eigen::Vector3f::Zero();
-};
+/**
+ * @brief POD equivalent of one MIMU packet (algorithm-internal `InputPacket`).
+ *
+ * `isValid` gates the whole packet; when true, all samples in the packet are
+ * assumed real. `measTime` is the timestamp of the first sample.
+ */
+typedef struct {
+    bool isValid;
+    uint64_t measTime;
+    Sample_c samples[MAX_MIMU_SAMPLES_PER_PKT_C];
+} InputPacket_c;
+
+/**
+ * @brief POD equivalent of InputPktsData.
+ *
+ * 4 packets x 10 samples per packet.
+ */
+typedef struct {
+    InputPacket_c packets[MAX_MIMU_PKT_C];
+} InputPktsData_c;
+
+/**
+ * @brief POD equivalent of OutputAverageAccelAngleVel.
+ */
+typedef struct {
+    Vector3f_c accel_B;
+    Vector3f_c gyroOmega_B;
+} OutputAverageAccelAngleVel_c;
+
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif
 
-#endif  // F32XIMERA_AVERAGE_MIMU_DATA_TYPES_H
+#endif  // F32XMERA_AVERAGE_MIMU_DATA_TYPES_H

--- a/algorithms/msgPayloadDef/MimuPacketGroupF32Payload.h
+++ b/algorithms/msgPayloadDef/MimuPacketGroupF32Payload.h
@@ -5,13 +5,19 @@
 
 #include "AccPktDataMsgF32Payload.h"
 
-/*! @brief A single MIMU packet: a fixed-size group of time-tagged
- *         gyro/accel samples produced by one MIMU at a contiguous burst
- *         rate. The samples within a packet are independent measurements --
- *         each carries its own measTime -- and downstream consumers may
- *         filter them individually. */
+#include <stdint.h>
+
+/*! @brief A single MIMU packet: a fixed-size group of gyro/accel samples
+ *         produced by one MIMU at a contiguous burst rate. `measTime` is
+ *         the timestamp of the first sample in the group; consumers that
+ *         care about per-sample timing derive it as
+ *         `measTime + s * device_sample_period_ns`. Each
+ *         AccPktDataMsgF32Payload retains its own per-sample `measTime`
+ *         for legacy consumers but the group-level `measTime` is the
+ *         canonical timestamp for this packet. */
 typedef struct {
-    AccPktDataMsgF32Payload samples[MAX_MIMU_SAMPLES_PER_PKT];  //!< [-] Individual time-tagged MIMU samples
+    uint64_t measTime;                                          //!< [ns] First sample's measurement time
+    AccPktDataMsgF32Payload samples[MAX_MIMU_SAMPLES_PER_PKT];  //!< [-] Time-tagged MIMU samples (per-sample measTime is legacy)
 } MimuPacketGroupF32Payload;
 
 #endif

--- a/algorithms/msgPayloadDef/MimuPacketGroupF32Payload.h
+++ b/algorithms/msgPayloadDef/MimuPacketGroupF32Payload.h
@@ -16,8 +16,9 @@
  *         for legacy consumers but the group-level `measTime` is the
  *         canonical timestamp for this packet. */
 typedef struct {
-    uint64_t measTime;                                          //!< [ns] First sample's measurement time
-    AccPktDataMsgF32Payload samples[MAX_MIMU_SAMPLES_PER_PKT];  //!< [-] Time-tagged MIMU samples (per-sample measTime is legacy)
+    uint64_t measTime;  //!< [ns] First sample's measurement time
+    AccPktDataMsgF32Payload
+        samples[MAX_MIMU_SAMPLES_PER_PKT];  //!< [-] Time-tagged MIMU samples (per-sample measTime is legacy)
 } MimuPacketGroupF32Payload;
 
 #endif

--- a/algorithms/utilities/fsw/validDcmCheck.h
+++ b/algorithms/utilities/fsw/validDcmCheck.h
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #include <Eigen/Core>
+#include <Eigen/LU>
 
 inline constexpr float kToleranceF = 1.0e-5F;
 


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2065
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR refactors the averageMimuData algorithm to take as input 4 "packets" of 10 mimu data samples. These time stamped samples are those which are averaged over.

## Verification
The tests are updated to exercise new packets being written into the 4 packet buffer.

## Documentation
The documentation is updated to reflect the 4 packet ring buffer. 

## Future work
None
