### PR TITLE
Refactor mrpFeedback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ set(algorithms
     "inertial3D"
     "inertialUKF"
     "mimuMajorityVote"
+    "mrpFeedback"
     "navAggregate"
     "oeStateEphem"
     "rateControl"

--- a/algorithms/mrpFeedback/_tests/mrpFeedbackTestHelpers.hpp
+++ b/algorithms/mrpFeedback/_tests/mrpFeedbackTestHelpers.hpp
@@ -103,25 +103,21 @@ inline ReferenceOutput referenceUpdate(const MrpFeedbackConfig& cfg,
 inline void testMrpFeedbackSetup() {
     // Valid config builds without throwing.
     EXPECT_NO_THROW({
-        const MrpFeedbackConfig cfg = MrpFeedbackConfig::create(
-            0.0F, 0.0F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+        const MrpFeedbackConfig cfg =
+            MrpFeedbackConfig::create(0.0F, 0.0F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
         const MrpFeedbackAlgorithm alg(cfg);
         (void)alg;
     });
 
     // Negative gains/limit are rejected by the Config factory.
-    EXPECT_ANY_THROW({
-        (void)MrpFeedbackConfig::create(-0.1F, 0.0F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
-    });
-    EXPECT_ANY_THROW({
-        (void)MrpFeedbackConfig::create(0.0F, -0.1F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
-    });
-    EXPECT_ANY_THROW({
-        (void)MrpFeedbackConfig::create(0.0F, 0.0F, -0.1F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
-    });
-    EXPECT_ANY_THROW({
-        (void)MrpFeedbackConfig::create(0.0F, 0.0F, 0.0F, -0.1F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
-    });
+    EXPECT_ANY_THROW(
+        { (void)MrpFeedbackConfig::create(-0.1F, 0.0F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero()); });
+    EXPECT_ANY_THROW(
+        { (void)MrpFeedbackConfig::create(0.0F, -0.1F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero()); });
+    EXPECT_ANY_THROW(
+        { (void)MrpFeedbackConfig::create(0.0F, 0.0F, -0.1F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero()); });
+    EXPECT_ANY_THROW(
+        { (void)MrpFeedbackConfig::create(0.0F, 0.0F, 0.0F, -0.1F, ControlLawType::NORMAL, Eigen::Vector3f::Zero()); });
 }
 
 inline void testMrpFeedback(const Eigen::Vector3f& sigma,

--- a/algorithms/mrpFeedback/_tests/mrpFeedbackTestHelpers.hpp
+++ b/algorithms/mrpFeedback/_tests/mrpFeedbackTestHelpers.hpp
@@ -2,48 +2,44 @@
 #define TEST_MRPFEEDBACK_H
 
 #include "architecture/utilities/eigenSupport.h"
-#include "architecture/utilities/rigidBodyKinematics.hpp"
 #include "mrpFeedbackAlgorithm.h"
+#include "mrpFeedbackTypes.h"
 #include "msgPayloadDef/AttGuidMsgF32Payload.h"
 #include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
 #include "msgPayloadDef/RWArrayConfigMsgF32Payload.h"
+#include "msgPayloadDef/RWAvailabilityMsgPayload.h"
 #include "msgPayloadDef/RWSpeedMsgF32Payload.h"
 #include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
 #include "utilities/freestandingInvalidArgument.h"
 #include "utilities/timeConstants.h"
-#include <architecture/msgPayloadDef/RWAvailabilityMsgPayload.h>
-#include <fswAlgorithms/fswUtilities/fswDefinitions.h>
 #include <gtest/gtest.h>
 #include <Eigen/Core>
 #include <cmath>
-#include <numbers>
 #include <vector>
 
-typedef struct {
+struct ReferenceOutput {
     MrpFeedbackOutput mrpFeedbackOut;
     Eigen::Vector3f int_sigma;
     uint64_t priorTime;
-} ReferenceOutput;
+};
 
-// Reference computation for update
-ReferenceOutput referenceUpdate(const MrpFeedbackAlgorithm& alg,
-                                RWArrayConfigMsgF32Payload rwConfigParams,
-                                const Eigen::Matrix3f& ISCPntB_B,
-                                Eigen::Vector3f int_sigma,
-                                uint64_t priorTime,
-                                const uint64_t callTime,
-                                AttGuidMsgF32Payload guidCmd,
-                                const RWSpeedMsgF32Payload& wheelSpeeds,
-                                const RWAvailabilityMsgPayload& wheelsAvailability) {
-    const float K = alg.getK();
-    const float P = alg.getP();
-    const float Ki = alg.getKi();
-    const float integralLimit = alg.getIntegralLimit();
-    const ControlLawType controlLawType = alg.getControlLawType();
-    const Eigen::Vector3f knownTorquePntB_B = alg.getKnownTorquePntB_B();
+inline ReferenceOutput referenceUpdate(const MrpFeedbackConfig& cfg,
+                                       const RWArrayConfigMsgF32Payload& rwConfigParams,
+                                       const Eigen::Matrix3f& ISCPntB_B,
+                                       Eigen::Vector3f int_sigma,
+                                       uint64_t priorTime,
+                                       const uint64_t callTime,
+                                       AttGuidMsgF32Payload guidCmd,
+                                       const RWSpeedMsgF32Payload& wheelSpeeds,
+                                       const RWAvailabilityMsgPayload& wheelsAvailability) {
+    const float K = cfg.getK();
+    const float P = cfg.getP();
+    const float Ki = cfg.getKi();
+    const float integralLimit = cfg.getIntegralLimit();
+    const ControlLawType controlLawType = cfg.getControlLawType();
+    const Eigen::Vector3f knownTorquePntB_B = cfg.getKnownTorquePntB_B();
 
-    /*! - compute control update time */
-    float dt{}; /* [s] control update period */
+    float dt{};
     if (priorTime == 0U) {
         dt = 0.0F;
     } else {
@@ -56,15 +52,11 @@ ReferenceOutput referenceUpdate(const MrpFeedbackAlgorithm& alg,
     const Eigen::Vector3f omega_RN_B = cArrayToEigenVector(guidCmd.omega_RN_B);
     const Eigen::Vector3f domega_RN_B = cArrayToEigenVector(guidCmd.domega_RN_B);
 
-    /*! - compute body rate */
     const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
 
-    /*! - evaluate integral term */
     Eigen::Vector3f z{Eigen::Vector3f::Zero()};
-    if (Ki > 0.0F) { /* check if integral feedback is turned on  */
+    if (Ki > 0.0F) {
         int_sigma += K * dt * sigma_BR;
-
-        /* keep int_sigma less than integralLimit */
         for (Eigen::Index i = 0; i < 3; ++i) {
             const float intCheck = fabsf(int_sigma[i]);
             if (intCheck > integralLimit) {
@@ -79,7 +71,7 @@ ReferenceOutput referenceUpdate(const MrpFeedbackAlgorithm& alg,
 
     Eigen::Vector3f H_B = ISCPntB_B * omega_BN_B;
     for (Eigen::Index i = 0; i < rwConfigParams.numRW; ++i) {
-        if (wheelsAvailability.wheelAvailability[i] == AVAILABLE) { /* check if wheel is available */
+        if (wheelsAvailability.wheelAvailability[i] == AVAILABLE) {
             const Eigen::Vector3f G_s_B_i = G_s_B.col(i);
             const Eigen::Vector3f h_s_i =
                 rwConfigParams.JsList[i] * (omega_BN_B.dot(G_s_B_i) + wheelSpeeds.wheelSpeeds[i]) * G_s_B_i;
@@ -94,7 +86,6 @@ ReferenceOutput referenceUpdate(const MrpFeedbackAlgorithm& alg,
         momentumContribution = omega_BN_B.cross(H_B);
     }
 
-    /*! - evaluate required attitude control torque Lc */
     const Eigen::Vector3f Lc = K * sigma_BR + P * omega_BR_B + P * Ki * z - momentumContribution +
                                ISCPntB_B * (omega_BN_B.cross(omega_RN_B) - domega_RN_B) + knownTorquePntB_B;
 
@@ -102,25 +93,35 @@ ReferenceOutput referenceUpdate(const MrpFeedbackAlgorithm& alg,
     const Eigen::Vector3f Li = -(P * Ki * z);
 
     ReferenceOutput out{};
-
     eigenVectorToCArray(Lr, out.mrpFeedbackOut.controlOut.torqueRequestBody);
     eigenVectorToCArray(Li, out.mrpFeedbackOut.intFeedbackOut.torqueRequestBody);
     out.int_sigma = int_sigma;
     out.priorTime = priorTime;
-
     return out;
 }
 
 inline void testMrpFeedbackSetup() {
-    MrpFeedbackAlgorithm alg{};
+    // Valid config builds without throwing.
+    EXPECT_NO_THROW({
+        const MrpFeedbackConfig cfg = MrpFeedbackConfig::create(
+            0.0F, 0.0F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+        const MrpFeedbackAlgorithm alg(cfg);
+        (void)alg;
+    });
 
-    // --- Test expected exceptions ---
-
-    // Negative feedback gains or integral limit
-    EXPECT_THROW(alg.setK(-0.1), fsw::invalid_argument);
-    EXPECT_THROW(alg.setP(-0.1), fsw::invalid_argument);
-    EXPECT_THROW(alg.setKi(-0.1), fsw::invalid_argument);
-    EXPECT_THROW(alg.setIntegralLimit(-0.1), fsw::invalid_argument);
+    // Negative gains/limit are rejected by the Config factory.
+    EXPECT_ANY_THROW({
+        (void)MrpFeedbackConfig::create(-0.1F, 0.0F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+    });
+    EXPECT_ANY_THROW({
+        (void)MrpFeedbackConfig::create(0.0F, -0.1F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+    });
+    EXPECT_ANY_THROW({
+        (void)MrpFeedbackConfig::create(0.0F, 0.0F, -0.1F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+    });
+    EXPECT_ANY_THROW({
+        (void)MrpFeedbackConfig::create(0.0F, 0.0F, 0.0F, -0.1F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+    });
 }
 
 inline void testMrpFeedback(const Eigen::Vector3f& sigma,
@@ -142,23 +143,13 @@ inline void testMrpFeedback(const Eigen::Vector3f& sigma,
                             std::vector<float> ISCPntB_B,
                             bool rwIsLinked,
                             float dt) {
-    MrpFeedbackAlgorithm alg{};
+    const ControlLawType controlLawTypeAlg =
+        (controlLawType == 0) ? ControlLawType::NORMAL : ControlLawType::SIMPLE_INTEGRAL;
 
-    ControlLawType controlLawTypeAlg{};
-    if (controlLawType == 0) {
-        controlLawTypeAlg = ControlLawType::NORMAL;
-    } else {
-        controlLawTypeAlg = ControlLawType::SIMPLE_INTEGRAL;
-    }
+    const MrpFeedbackConfig cfg =
+        MrpFeedbackConfig::create(K, P, Ki, integralLimit, controlLawTypeAlg, knownTorquePntB_B);
+    MrpFeedbackAlgorithm alg(cfg);
 
-    alg.setK(K);
-    alg.setP(P);
-    alg.setKi(Ki);
-    alg.setIntegralLimit(integralLimit);
-    alg.setControlLawType(controlLawTypeAlg);
-    alg.setKnownTorquePntB_B(knownTorquePntB_B);
-
-    // Populate messages
     AttGuidMsgF32Payload guidCmdMsg{};
     eigenVectorToCArray(sigma, guidCmdMsg.sigma_BR);
     eigenVectorToCArray(omega_BR_B, guidCmdMsg.omega_BR_B);
@@ -186,26 +177,21 @@ inline void testMrpFeedback(const Eigen::Vector3f& sigma,
     VehicleConfigMsgF32Payload vehConfigMsg{};
     std::copy(ISCPntB_B.begin(), ISCPntB_B.end(), vehConfigMsg.ISCPntB_B);
 
-    // Remaining variables needed by module
-    Eigen::Matrix3f ISC_B = cArrayToEigenMatrix3(ISCPntB_B.data());
+    const Eigen::Matrix3f ISC_B = cArrayToEigenMatrix3(ISCPntB_B.data());
 
-    // Reset module
     EXPECT_NO_THROW(alg.reset(vehConfigMsg, rwConfigMsg, rwIsLinked));
 
     Eigen::Vector3f int_sigma{Eigen::Vector3f::Zero()};
     uint64_t priorTime{};
 
-    // Test over a few time steps
-    int numSteps = 5;
-
+    constexpr int numSteps = 5;
     for (int step = 0; step < numSteps; ++step) {
-        uint64_t callTime = priorTime + static_cast<uint64_t>(dt / kNano2Sec);
+        const uint64_t callTime = priorTime + static_cast<uint64_t>(dt / kNano2Sec);
 
-        // Reference
         MrpFeedbackOutput out{};
         ReferenceOutput refOutput{};
         EXPECT_NO_THROW(out = alg.update(callTime, guidCmdMsg, wheelSpeedsMsg, wheelsAvailabilityMsg));
-        EXPECT_NO_THROW(refOutput = referenceUpdate(alg,
+        EXPECT_NO_THROW(refOutput = referenceUpdate(cfg,
                                                     rwConfigMsg,
                                                     ISC_B,
                                                     int_sigma,
@@ -214,18 +200,14 @@ inline void testMrpFeedback(const Eigen::Vector3f& sigma,
                                                     guidCmdMsg,
                                                     wheelSpeedsMsg,
                                                     wheelsAvailabilityMsg));
-        MrpFeedbackOutput ref = refOutput.mrpFeedbackOut;
+        const MrpFeedbackOutput ref = refOutput.mrpFeedbackOut;
         int_sigma = refOutput.int_sigma;
         priorTime = refOutput.priorTime;
 
         for (int i = 0; i < 3; ++i) {
-            // --- General tests ---
-
-            // Reference correctness
             EXPECT_NEAR(out.controlOut.torqueRequestBody[i], ref.controlOut.torqueRequestBody[i], 1e-6);
             EXPECT_NEAR(out.intFeedbackOut.torqueRequestBody[i], ref.intFeedbackOut.torqueRequestBody[i], 1e-6);
 
-            // Finiteness
             EXPECT_TRUE(std::isfinite(out.controlOut.torqueRequestBody[i]));
             EXPECT_TRUE(std::isfinite(out.intFeedbackOut.torqueRequestBody[i]));
         }

--- a/algorithms/mrpFeedback/_tests/test_mrpFeedback.cpp
+++ b/algorithms/mrpFeedback/_tests/test_mrpFeedback.cpp
@@ -27,8 +27,8 @@ TEST(MrpFeedbackTest, SetupTest) { testMrpFeedbackSetup(); }
 
 TEST(MrpFeedbackTest, IntegralFeedbackDisabledWhenKiIsZero) {
     // With Ki = 0, the integral feedback torque must be zero on every cycle.
-    const MrpFeedbackConfig cfg = MrpFeedbackConfig::create(
-        1.0F, 0.5F, 0.0F, 1.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+    const MrpFeedbackConfig cfg =
+        MrpFeedbackConfig::create(1.0F, 0.5F, 0.0F, 1.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
     MrpFeedbackAlgorithm alg(cfg);
 
     AttGuidMsgF32Payload guidCmd{};
@@ -63,8 +63,8 @@ TEST(MrpFeedbackTest, IntegralLimitClampsLargeError) {
     constexpr float K = 1.0F;
     constexpr float Ki = 1.0F;
     constexpr float intLimit = 0.5F;
-    const MrpFeedbackConfig cfg = MrpFeedbackConfig::create(
-        K, 1.0F, Ki, intLimit, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+    const MrpFeedbackConfig cfg =
+        MrpFeedbackConfig::create(K, 1.0F, Ki, intLimit, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
     MrpFeedbackAlgorithm alg(cfg);
 
     AttGuidMsgF32Payload guidCmd{};

--- a/algorithms/mrpFeedback/_tests/test_mrpFeedback.cpp
+++ b/algorithms/mrpFeedback/_tests/test_mrpFeedback.cpp
@@ -24,3 +24,80 @@ TEST(MrpFeedbackTest, ReferenceTest) {
 }
 
 TEST(MrpFeedbackTest, SetupTest) { testMrpFeedbackSetup(); }
+
+TEST(MrpFeedbackTest, IntegralFeedbackDisabledWhenKiIsZero) {
+    // With Ki = 0, the integral feedback torque must be zero on every cycle.
+    const MrpFeedbackConfig cfg = MrpFeedbackConfig::create(
+        1.0F, 0.5F, 0.0F, 1.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+    MrpFeedbackAlgorithm alg(cfg);
+
+    AttGuidMsgF32Payload guidCmd{};
+    eigenVectorToCArray(Eigen::Vector3f{0.4F, 0.1F, -0.3F}, guidCmd.sigma_BR);
+    eigenVectorToCArray(Eigen::Vector3f{-0.4F, 0.5F, -0.6F}, guidCmd.omega_BR_B);
+    eigenVectorToCArray(Eigen::Vector3f{0.7F, -0.8F, 0.9F}, guidCmd.omega_RN_B);
+    eigenVectorToCArray(Eigen::Vector3f{-1.0F, 1.1F, -1.2F}, guidCmd.domega_RN_B);
+
+    VehicleConfigMsgF32Payload vehConfig{};
+    const std::vector<float> isc{1000.0F, 0.0F, 0.0F, 0.0F, 800.0F, 0.0F, 0.0F, 0.0F, 800.0F};
+    std::copy(isc.begin(), isc.end(), vehConfig.ISCPntB_B);
+
+    const RWArrayConfigMsgF32Payload rwConfig{};
+    const RWSpeedMsgF32Payload wheelSpeeds{};
+    const RWAvailabilityMsgPayload availability{};
+
+    EXPECT_NO_THROW(alg.reset(vehConfig, rwConfig, /*rwIsLinked=*/false));
+    for (int step = 0; step < 5; ++step) {
+        const auto callTime = static_cast<uint64_t>(step + 1) * static_cast<uint64_t>(0.1F / kNano2Sec);
+        MrpFeedbackOutput out{};
+        EXPECT_NO_THROW(out = alg.update(callTime, guidCmd, wheelSpeeds, availability));
+        for (int i = 0; i < 3; ++i) {
+            EXPECT_FLOAT_EQ(out.intFeedbackOut.torqueRequestBody[i], 0.0F);
+            EXPECT_TRUE(std::isfinite(out.controlOut.torqueRequestBody[i]));
+        }
+    }
+}
+
+TEST(MrpFeedbackTest, IntegralLimitClampsLargeError) {
+    // Drive a sustained sigma_BR with Ki > 0 and a tight integralLimit so the integral state
+    // saturates within a few steps. After saturation, |int_sigma_i| should equal integralLimit.
+    constexpr float K = 1.0F;
+    constexpr float Ki = 1.0F;
+    constexpr float intLimit = 0.5F;
+    const MrpFeedbackConfig cfg = MrpFeedbackConfig::create(
+        K, 1.0F, Ki, intLimit, ControlLawType::NORMAL, Eigen::Vector3f::Zero());
+    MrpFeedbackAlgorithm alg(cfg);
+
+    AttGuidMsgF32Payload guidCmd{};
+    eigenVectorToCArray(Eigen::Vector3f{1.0F, 1.0F, 1.0F}, guidCmd.sigma_BR);
+    eigenVectorToCArray(Eigen::Vector3f::Zero(), guidCmd.omega_BR_B);
+    eigenVectorToCArray(Eigen::Vector3f::Zero(), guidCmd.omega_RN_B);
+    eigenVectorToCArray(Eigen::Vector3f::Zero(), guidCmd.domega_RN_B);
+
+    VehicleConfigMsgF32Payload vehConfig{};
+    const std::vector<float> isc{1.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 1.0F};
+    std::copy(isc.begin(), isc.end(), vehConfig.ISCPntB_B);
+
+    const RWArrayConfigMsgF32Payload rwConfig{};
+    const RWSpeedMsgF32Payload wheelSpeeds{};
+    const RWAvailabilityMsgPayload availability{};
+
+    EXPECT_NO_THROW(alg.reset(vehConfig, rwConfig, /*rwIsLinked=*/false));
+
+    // Drive enough integration steps to saturate (each step accumulates K*dt*sigma = 1.0 * 1.0 * 1.0 in each axis).
+    constexpr float dt = 1.0F;
+    constexpr int steps = 10;
+    MrpFeedbackOutput out{};
+    for (int step = 0; step < steps; ++step) {
+        const auto callTime = static_cast<uint64_t>(step + 1) * static_cast<uint64_t>(dt / kNano2Sec);
+        EXPECT_NO_THROW(out = alg.update(callTime, guidCmd, wheelSpeeds, availability));
+        for (int i = 0; i < 3; ++i) {
+            EXPECT_TRUE(std::isfinite(out.controlOut.torqueRequestBody[i]));
+            EXPECT_TRUE(std::isfinite(out.intFeedbackOut.torqueRequestBody[i]));
+        }
+    }
+    // After saturation, the integral feedback torque magnitude per axis is bounded by P*Ki*intLimit.
+    constexpr float bound = 1.0F * Ki * intLimit + 1e-5F;  // P=1 in this test
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_LE(std::abs(out.intFeedbackOut.torqueRequestBody[i]), bound);
+    }
+}

--- a/algorithms/mrpFeedback/_tests/test_mrpFeedback.py
+++ b/algorithms/mrpFeedback/_tests/test_mrpFeedback.py
@@ -5,41 +5,37 @@ from xmera.fp32 import mrpFeedbackF32
 from xmera.utilities import SimulationBaseClass
 from xmera.utilities import macros
 
+
 @pytest.mark.parametrize("int_gain", [0.01, 0])
 @pytest.mark.parametrize("rw_num", [4, 0])
 @pytest.mark.parametrize("integral_limit", [0, 20])
 @pytest.mark.parametrize("ctrl_law", [0, 1])
 @pytest.mark.parametrize("use_rw_availability", ["NO", "ON", "OFF"])
+def test_mrp_feedback(int_gain, rw_num, integral_limit, ctrl_law, use_rw_availability):
+    unit_task_name = "unitTask"
+    unit_process_name = "TestProcess"
 
-def test_mrp_feedback(show_plots, int_gain, rw_num, integral_limit, ctrl_law, use_rw_availability):
-    unit_task_name = "unitTask"               # arbitrary name (don't change)
-    unit_process_name = "TestProcess"         # arbitrary name (don't change)
-
-    #   Create a sim module as an empty container
     unit_test_sim = SimulationBaseClass.SimBaseClass()
 
-    #   Create test thread
-    test_process_rate = macros.sec2nano(0.5)     # update process rate update time
+    test_process_rate = macros.sec2nano(0.5)
     test_proc = unit_test_sim.CreateNewProcess(unit_process_name)
     test_proc.addTask(unit_test_sim.CreateNewTask(unit_task_name, test_process_rate))
 
-    #   Construct algorithm and associated C++ container
     module = mrpFeedbackF32.MrpFeedback()
     module.modelTag = "mrpFeedback"
-
-    #   Add test module to runtime call list
     unit_test_sim.AddModelToTask(unit_task_name, module)
 
-    #   Initialize the test module configuration data
-    module.setK(0.15)
-    module.setKi(int_gain)
-    module.setP(150.0)
-    module.setIntegralLimit(integral_limit)
-    module.setControlLawType(ctrl_law)
-    module.setKnownTorquePntB_B([1., 1., 1.])
+    # Phase 1 config: assign public properties before reset() runs.
+    module.K = 0.15
+    module.Ki = int_gain
+    module.P = 150.0
+    module.integralLimit = integral_limit
+    module.controlLawType = (
+        mrpFeedbackF32.ControlLawType_NORMAL if ctrl_law == 0 else mrpFeedbackF32.ControlLawType_SIMPLE_INTEGRAL
+    )
+    module.knownTorquePntB_B = [1.0, 1.0, 1.0]
 
-    # create input messages
-    #   AttGuidFswMsg Message:
+    # Attitude guidance input
     guid_cmd_data = messaging.AttGuidMsgF32Payload()
     sigma_BR = [0.3, -0.5, 0.7]
     guid_cmd_data.sigma_BR = sigma_BR
@@ -51,31 +47,32 @@ def test_mrp_feedback(show_plots, int_gain, rw_num, integral_limit, ctrl_law, us
     guid_cmd_data.domega_RN_B = domega_RN_B
     guid_in_msg = messaging.AttGuidMsgF32().write(guid_cmd_data)
 
-    # vehicleConfigData Message:
+    # Vehicle inertia
     vehicle_config = messaging.VehicleConfigMsgF32Payload()
-    I = [1000., 0., 0.,
-         0., 800., 0.,
-         0., 0., 800.]
-    vehicle_config.ISCPntB_B = I
+    inertia = [
+        1000.0, 0.0, 0.0,
+        0.0, 800.0, 0.0,
+        0.0, 0.0, 800.0,
+    ]
+    vehicle_config.ISCPntB_B = inertia
     vc_in_msg = messaging.VehicleConfigMsgF32().write(vehicle_config)
 
-    # wheelSpeeds Message
+    # RW speeds
     rw_speed_message = messaging.RWSpeedMsgF32Payload()
-    Omega = [10.0, 25.0, 50.0, 100.0]  # rad/sec
+    Omega = [10.0, 25.0, 50.0, 100.0]
     rw_speed_message.wheelSpeeds = Omega
     rw_speed_in_msg = messaging.RWSpeedMsgF32().write(rw_speed_message)
 
-    # wheelConfigData message
+    # RW config
     js_list = []
     G_s_B = []
     if rw_num > 0:
         rw_config_params = messaging.RWArrayConfigMsgF32Payload()
-
         G_s_B = [
             1.0, 0.0, 0.0,
             0.0, 1.0, 0.0,
             0.0, 0.0, 1.0,
-            0.577350269190, 0.577350269190, 0.577350269190
+            0.577350269190, 0.577350269190, 0.577350269190,
         ]
         js_list = [0.1, 0.1, 0.1, 0.1]
         rw_config_params.GsMatrix_B = G_s_B
@@ -83,31 +80,32 @@ def test_mrp_feedback(show_plots, int_gain, rw_num, integral_limit, ctrl_law, us
         rw_config_params.numRW = rw_num
         rw_param_in_msg = messaging.RWArrayConfigMsgF32().write(rw_config_params)
 
-    # wheelAvailability message
+    # RW availability
     rw_availability_message = messaging.RWAvailabilityMsgPayload()
     if use_rw_availability != "NO":
         if use_rw_availability == "ON":
-            rw_availability_message.wheelAvailability = [messaging.AVAILABLE, messaging.AVAILABLE,
-                                                       messaging.AVAILABLE, messaging.AVAILABLE]
-        elif use_rw_availability == "OFF":
-            rw_availability_message.wheelAvailability = [messaging.UNAVAILABLE, messaging.UNAVAILABLE,
-                                                       messaging.UNAVAILABLE, messaging.UNAVAILABLE]
+            rw_availability_message.wheelAvailability = [
+                messaging.AVAILABLE, messaging.AVAILABLE, messaging.AVAILABLE, messaging.AVAILABLE,
+            ]
         else:
-            print("WARNING: unknown rw availability status")
+            rw_availability_message.wheelAvailability = [
+                messaging.UNAVAILABLE, messaging.UNAVAILABLE, messaging.UNAVAILABLE, messaging.UNAVAILABLE,
+            ]
         rw_avail_in_msg = messaging.RWAvailabilityMsg().write(rw_availability_message)
     else:
-        # set default availability
-        rw_availability_message.wheelAvailability = [messaging.AVAILABLE, messaging.AVAILABLE,
-                                                   messaging.AVAILABLE, messaging.AVAILABLE]
+        # default availability for the truth-builder (algorithm itself ignores when not connected)
+        rw_availability_message.wheelAvailability = [
+            messaging.AVAILABLE, messaging.AVAILABLE, messaging.AVAILABLE, messaging.AVAILABLE,
+        ]
 
-    Lr_true = find_true_torques(module, guid_cmd_data, rw_speed_message, vehicle_config, js_list,
-                                rw_num, G_s_B, rw_availability_message, ctrl_law)
+    Lr_true = find_true_torques(
+        module, guid_cmd_data, rw_speed_message, vehicle_config, js_list, rw_num, G_s_B, rw_availability_message,
+        ctrl_law,
+    )
 
-    #   Setup logging on the test module output message so that we get all the writes to it
     data_log = module.cmdTorqueOutMsg.recorder()
     unit_test_sim.AddModelToTask(unit_task_name, data_log)
 
-    # connect messages
     module.guidInMsg.subscribeTo(guid_in_msg)
     module.vehConfigInMsg.subscribeTo(vc_in_msg)
     if rw_num > 0:
@@ -116,92 +114,78 @@ def test_mrp_feedback(show_plots, int_gain, rw_num, integral_limit, ctrl_law, us
     if use_rw_availability != "NO":
         module.rwAvailInMsg.subscribeTo(rw_avail_in_msg)
 
-    #   Need to call the self-init and cross-init methods
     unit_test_sim.InitializeSimulation()
-
-    #   Step the simulation to 3*process rate so 4 total steps including zero
-    unit_test_sim.ConfigureStopTime(macros.sec2nano(1.0))        # seconds to stop simulation
+    unit_test_sim.ConfigureStopTime(macros.sec2nano(1.0))
     unit_test_sim.ExecuteSimulation()
 
-    module.reset(1)     # this module reset function needs a time input (in NanoSeconds)
+    module.reset(1)
 
-    unit_test_sim.ConfigureStopTime(macros.sec2nano(2.0))        # seconds to stop simulation
+    unit_test_sim.ConfigureStopTime(macros.sec2nano(2.0))
     unit_test_sim.ExecuteSimulation()
 
     Lr = data_log.torqueRequestBody
 
-    # compare the module results to the truth values
     accuracy = 1e-6
     np.testing.assert_allclose(Lr, Lr_true, atol=accuracy, rtol=accuracy, verbose=True)
 
 
-def find_true_torques(module, guid_cmd_data, rw_speed_message, vehicle_config_out, js_list, num_rw, G_s_B, rw_avail_msg, ctrl_law):
+def find_true_torques(module, guid_cmd_data, rw_speed_message, vehicle_config_out, js_list, num_rw, G_s_B, rw_avail_msg,
+                      ctrl_law):
     Lr = []
 
-    #Read in variables
-    L = np.asarray(module.getKnownTorquePntB_B()).flatten()
-    steps = [0, 0, .5, 0, .5]
+    L = np.asarray(module.knownTorquePntB_B).flatten()
+    steps = [0, 0, 0.5, 0, 0.5]
     omega_BR_B = np.asarray(guid_cmd_data.omega_BR_B)
     omega_RN_B = np.asarray(guid_cmd_data.omega_RN_B)
-    omega_BN_B = omega_BR_B + omega_RN_B #find body rate
+    omega_BN_B = omega_BR_B + omega_RN_B
     domega_RN_B = np.asarray(guid_cmd_data.domega_RN_B)
     sigma_BR = np.asarray(guid_cmd_data.sigma_BR)
-    Isc = np.asarray(vehicle_config_out.ISCPntB_B)
-    Isc = np.reshape(Isc, (3, 3))
-    Ki = module.getKi()
-    K = module.getK()
-    P = module.getP()
+    Isc = np.reshape(np.asarray(vehicle_config_out.ISCPntB_B), (3, 3))
+    Ki = module.Ki
+    K = module.K
+    P = module.P
     js_vec = js_list
     G_s_B_array = np.asarray(G_s_B)
     G_s_B_array = np.reshape(G_s_B_array[0:num_rw * 3], (num_rw, 3))
-    sigma_int = np.asarray([0, 0, 0])
+    sigma_int = np.asarray([0.0, 0.0, 0.0])
 
-    #Compute toruqes
     for i in range(len(steps)):
         dt = steps[i]
         if dt == 0:
-            sigma_int = np.asarray([0, 0, 0])
+            sigma_int = np.asarray([0.0, 0.0, 0.0])
 
-        #evaluate integral term
-        if Ki > 0: #if integral feedback is on
+        if Ki > 0:
             sigma_int = K * dt * sigma_BR + sigma_int
             for n in range(3):
-                if abs(sigma_int[n]) > module.getIntegralLimit():
-                    sigma_int[n] *= module.getIntegralLimit()/sigma_int[n] #check elementwise if integral term is greater than limit; preserve direction (+/-)
-
+                if abs(sigma_int[n]) > module.integralLimit:
+                    sigma_int[n] *= module.integralLimit / sigma_int[n]
             z_vec = sigma_int + Isc.dot(omega_BR_B)
-        else: #integral gain turned off/negative setting
-            z_vec = np.asarray([0, 0, 0])
+        else:
+            z_vec = np.asarray([0.0, 0.0, 0.0])
 
-        #compute torque Lr
-        Lr0 = K * sigma_BR  # +K*sigmaBR
-        Lr1 = Lr0 + P * omega_BR_B  # +P*deltaOmega
-        Lr2 = Lr1 + P * Ki * z_vec  # +P*Ki*z
-        GsHs = np.array([0,0,0])
+        Lr0 = K * sigma_BR
+        Lr1 = Lr0 + P * omega_BR_B
+        Lr2 = Lr1 + P * Ki * z_vec
+        GsHs = np.array([0.0, 0.0, 0.0])
 
-        if num_rw>0:
-            for i in range(num_rw):
-                if rw_avail_msg.wheelAvailability[i] == 0:  #Make RW availability check
-                    GsHs = GsHs + np.dot(G_s_B_array[i, :], js_vec[i] * (np.dot(omega_BN_B, G_s_B_array[i, :]) + rw_speed_message.wheelSpeeds[i]))
-                    #J_s*(dot(omegaBN_B,Gs_vec)+Omega_wheel)
+        if num_rw > 0:
+            for j in range(num_rw):
+                if rw_avail_msg.wheelAvailability[j] == 0:
+                    GsHs = GsHs + np.dot(
+                        G_s_B_array[j, :],
+                        js_vec[j] * (np.dot(omega_BN_B, G_s_B_array[j, :]) + rw_speed_message.wheelSpeeds[j]),
+                    )
 
         if ctrl_law == 0:
-            Lr3 = Lr2 - np.cross((omega_RN_B+Ki*z_vec), (Isc.dot(omega_BN_B)+GsHs)) # -[v3Tilde(omega_r+Ki*z)]([I]omega + [Gs]h_s)
+            Lr3 = Lr2 - np.cross((omega_RN_B + Ki * z_vec), (Isc.dot(omega_BN_B) + GsHs))
         else:
-            Lr3 = Lr2 - np.cross(omega_BN_B, (Isc.dot(omega_BN_B)+GsHs)) # -[v3Tilde(omega)]([I]omega + [Gs]h_s)
+            Lr3 = Lr2 - np.cross(omega_BN_B, (Isc.dot(omega_BN_B) + GsHs))
 
-        Lr4 = Lr3 + Isc.dot(-domega_RN_B + np.cross(omega_BN_B, omega_RN_B)) #+[I](-d(omega_r)/dt + omega x omega_r)
-        Lr5 = Lr4 + L
-        Lr5 = -Lr5
+        Lr4 = Lr3 + Isc.dot(-domega_RN_B + np.cross(omega_BN_B, omega_RN_B))
+        Lr5 = -(Lr4 + L)
         Lr.append(np.ndarray.tolist(Lr5))
     return np.array(Lr)
 
 
 if __name__ == "__main__":
-    test_mrp_feedback(False,  # showplots
-                      0.01,  # intGain
-                      0,  # rwNum
-                      0.0,  # integralLimit
-                      1,  # ctrlLaw
-                      "NO"  # useRwAvailability ("NO", "ON", "OFF")
-                      )
+    test_mrp_feedback(0.01, 0, 0.0, 1, "NO")

--- a/algorithms/mrpFeedback/mrpFeedback.cpp
+++ b/algorithms/mrpFeedback/mrpFeedback.cpp
@@ -1,5 +1,6 @@
 #include "mrpFeedback.h"
 
+#include "utilities/xmeraLifecycleException.h"
 #include <stdexcept>
 
 void MrpFeedback::reset(const uint64_t callTime) {
@@ -22,11 +23,17 @@ void MrpFeedback::reset(const uint64_t callTime) {
     }
     this->numRW = static_cast<uint32_t>(rwConfigParams.numRW);
 
-    this->rebuildAlgorithmConfig();
-    this->algorithm.reset(sc, rwConfigParams, rwParamsIsLinked);
+    auto config = MrpFeedbackConfig::create(
+        this->K, this->P, this->Ki, this->integralLimit, this->controlLawType, this->knownTorquePntB_B);
+    this->algorithm = std::make_unique<MrpFeedbackAlgorithm>(config);
+    this->algorithm->reset(sc, rwConfigParams, rwParamsIsLinked);
 }
 
 void MrpFeedback::updateState(const uint64_t callTime) {
+    if (!this->algorithm) {
+        throw XmeraLifecycleException("MrpFeedback reset() has not been called.");
+    }
+
     AttGuidMsgF32Payload guidCmd = this->guidInMsg();
     RWSpeedMsgF32Payload wheelSpeeds{};
     RWAvailabilityMsgPayload wheelsAvailability{};
@@ -38,62 +45,8 @@ void MrpFeedback::updateState(const uint64_t callTime) {
         }
     }
 
-    auto [controlOut, intFeedbackOut] = this->algorithm.update(callTime, guidCmd, wheelSpeeds, wheelsAvailability);
+    auto [controlOut, intFeedbackOut] = this->algorithm->update(callTime, guidCmd, wheelSpeeds, wheelsAvailability);
 
     this->cmdTorqueOutMsg.write(&controlOut, moduleID, callTime);
     this->intFeedbackTorqueOutMsg.write(&intFeedbackOut, this->moduleID, callTime);
-}
-
-void MrpFeedback::setK(const float gain) {
-    if (!MrpFeedbackConfig::isValidK(gain)) {
-        FSW_THROW_INVALID_ARGUMENT("Feedback gain K must not be negative");
-    }
-    this->K = gain;
-    this->rebuildAlgorithmConfig();
-}
-float MrpFeedback::getK() const { return this->K; }
-
-void MrpFeedback::setP(const float gain) {
-    if (!MrpFeedbackConfig::isValidP(gain)) {
-        FSW_THROW_INVALID_ARGUMENT("Feedback gain P must not be negative");
-    }
-    this->P = gain;
-    this->rebuildAlgorithmConfig();
-}
-float MrpFeedback::getP() const { return this->P; }
-
-void MrpFeedback::setKi(const float gain) {
-    if (!MrpFeedbackConfig::isValidKi(gain)) {
-        FSW_THROW_INVALID_ARGUMENT("Integral feedback gain Ki must not be negative");
-    }
-    this->Ki = gain;
-    this->rebuildAlgorithmConfig();
-}
-float MrpFeedback::getKi() const { return this->Ki; }
-
-void MrpFeedback::setIntegralLimit(const float limit) {
-    if (!MrpFeedbackConfig::isValidIntegralLimit(limit)) {
-        FSW_THROW_INVALID_ARGUMENT("Integral limit must not be negative");
-    }
-    this->integralLimit = limit;
-    this->rebuildAlgorithmConfig();
-}
-float MrpFeedback::getIntegralLimit() const { return this->integralLimit; }
-
-void MrpFeedback::setControlLawType(const int type) {
-    this->controlLawType = static_cast<ControlLawType>(type);
-    this->rebuildAlgorithmConfig();
-}
-int MrpFeedback::getControlLawType() const { return static_cast<int>(this->controlLawType); }
-
-void MrpFeedback::setKnownTorquePntB_B(const Eigen::Vector3f& torque) {
-    this->knownTorquePntB_B = torque;
-    this->rebuildAlgorithmConfig();
-}
-Eigen::Vector3f MrpFeedback::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }
-
-void MrpFeedback::rebuildAlgorithmConfig() {
-    const MrpFeedbackConfig cfg = MrpFeedbackConfig::create(
-        this->K, this->P, this->Ki, this->integralLimit, this->controlLawType, this->knownTorquePntB_B);
-    this->algorithm.setConfig(cfg);
 }

--- a/algorithms/mrpFeedback/mrpFeedback.cpp
+++ b/algorithms/mrpFeedback/mrpFeedback.cpp
@@ -2,18 +2,10 @@
 
 #include <stdexcept>
 
-/*! This method performs a complete reset of the module.  Local module variables that retain
- time varying states between function calls are reset to their default values.
- @return void
- @param callTime The clock time at which the function was called (nanoseconds)
-*/
 void MrpFeedback::reset(const uint64_t callTime) {
-    /* check that optional messages are correct connected */
     if (this->rwParamsInMsg.isLinked() && !this->rwSpeedsInMsg.isLinked()) {
         throw std::invalid_argument("MrpFeedback.rwSpeedsInMsg wasn't connected while rwParamsInMsg was connected.");
     }
-
-    // check if the required message has not been connected
     if (!this->guidInMsg.isLinked()) {
         throw std::invalid_argument("MrpFeedback.guidInMsg wasn't connected.");
     }
@@ -24,28 +16,21 @@ void MrpFeedback::reset(const uint64_t callTime) {
     const VehicleConfigMsgF32Payload sc = this->vehConfigInMsg();
     RWArrayConfigMsgF32Payload rwConfigParams{};
     bool rwParamsIsLinked{};
-
-    /*! - check if RW configuration message exists */
     if (this->rwParamsInMsg.isLinked()) {
         rwConfigParams = this->rwParamsInMsg();
         rwParamsIsLinked = true;
     }
     this->numRW = static_cast<uint32_t>(rwConfigParams.numRW);
 
+    this->rebuildAlgorithmConfig();
     this->algorithm.reset(sc, rwConfigParams, rwParamsIsLinked);
 }
 
-/*! This method takes the attitude and rate errors relative to the Reference frame, as well as
-    the reference frame angular rates and acceleration, and computes the required control torque Lr.
- @return void
- @param callTime The clock time at which the function was called (nanoseconds)
-*/
 void MrpFeedback::updateState(const uint64_t callTime) {
-    AttGuidMsgF32Payload guidCmd = this->guidInMsg(); /* attitude tracking error message */
-    RWSpeedMsgF32Payload wheelSpeeds{};               /* Reaction wheel speed message */
-    RWAvailabilityMsgPayload wheelsAvailability{};    /* Reaction wheel availability message */
+    AttGuidMsgF32Payload guidCmd = this->guidInMsg();
+    RWSpeedMsgF32Payload wheelSpeeds{};
+    RWAvailabilityMsgPayload wheelsAvailability{};
 
-    /*! - read in optional RW speed and availability message */
     if (this->numRW > 0U) {
         wheelSpeeds = this->rwSpeedsInMsg();
         if (this->rwAvailInMsg.isLinked()) {
@@ -53,76 +38,62 @@ void MrpFeedback::updateState(const uint64_t callTime) {
         }
     }
 
-    MrpFeedbackOutput mrpFeedbackOutput = algorithm.update(callTime, guidCmd, wheelSpeeds, wheelsAvailability);
+    auto [controlOut, intFeedbackOut] = this->algorithm.update(callTime, guidCmd, wheelSpeeds, wheelsAvailability);
 
-    this->cmdTorqueOutMsg.write(&mrpFeedbackOutput.controlOut, moduleID, callTime);
-    this->intFeedbackTorqueOutMsg.write(&mrpFeedbackOutput.intFeedbackOut, this->moduleID, callTime);
+    this->cmdTorqueOutMsg.write(&controlOut, moduleID, callTime);
+    this->intFeedbackTorqueOutMsg.write(&intFeedbackOut, this->moduleID, callTime);
 }
 
-/*! Setter method for the gain K.
- @return void
- @param gain [N*m] Attitude error feedback gain
-*/
-void MrpFeedback::setK(const float gain) { this->algorithm.setK(gain); }
+void MrpFeedback::setK(const float gain) {
+    if (!MrpFeedbackConfig::isValidK(gain)) {
+        FSW_THROW_INVALID_ARGUMENT("Feedback gain K must not be negative");
+    }
+    this->K = gain;
+    this->rebuildAlgorithmConfig();
+}
+float MrpFeedback::getK() const { return this->K; }
 
-/*! Getter method for the gain K.
- @return const float
-*/
-float MrpFeedback::getK() const { return this->algorithm.getK(); }
+void MrpFeedback::setP(const float gain) {
+    if (!MrpFeedbackConfig::isValidP(gain)) {
+        FSW_THROW_INVALID_ARGUMENT("Feedback gain P must not be negative");
+    }
+    this->P = gain;
+    this->rebuildAlgorithmConfig();
+}
+float MrpFeedback::getP() const { return this->P; }
 
-/*! Setter method for the gain P.
- @return void
- @param gain [N*m*s] Rate error feedback gain
-*/
-void MrpFeedback::setP(const float gain) { this->algorithm.setP(gain); }
+void MrpFeedback::setKi(const float gain) {
+    if (!MrpFeedbackConfig::isValidKi(gain)) {
+        FSW_THROW_INVALID_ARGUMENT("Integral feedback gain Ki must not be negative");
+    }
+    this->Ki = gain;
+    this->rebuildAlgorithmConfig();
+}
+float MrpFeedback::getKi() const { return this->Ki; }
 
-/*! Getter method for the gain P.
- @return const float
-*/
-float MrpFeedback::getP() const { return this->algorithm.getP(); }
+void MrpFeedback::setIntegralLimit(const float limit) {
+    if (!MrpFeedbackConfig::isValidIntegralLimit(limit)) {
+        FSW_THROW_INVALID_ARGUMENT("Integral limit must not be negative");
+    }
+    this->integralLimit = limit;
+    this->rebuildAlgorithmConfig();
+}
+float MrpFeedback::getIntegralLimit() const { return this->integralLimit; }
 
-/*! Setter method for the gain Ki.
- @return void
- @param gain [N*m] Integral feedback gain
-*/
-void MrpFeedback::setKi(const float gain) { this->algorithm.setKi(gain); }
-
-/*! Getter method for the gain Ki.
- @return const float
-*/
-float MrpFeedback::getKi() const { return this->algorithm.getKi(); }
-
-/*! Setter method for the integral limit.
- @return void
- @param limit [N*m*s] Integral limit
-*/
-void MrpFeedback::setIntegralLimit(const float limit) { this->algorithm.setIntegralLimit(limit); }
-
-/*! Getter method for the integral limit.
- @return const float
-*/
-float MrpFeedback::getIntegralLimit() const { return this->algorithm.getIntegralLimit(); }
-
-/*! Setter method for the control law type.
- @return void
- @param type control law type
-*/
 void MrpFeedback::setControlLawType(const int type) {
-    this->algorithm.setControlLawType(static_cast<ControlLawType>(type));
+    this->controlLawType = static_cast<ControlLawType>(type);
+    this->rebuildAlgorithmConfig();
 }
+int MrpFeedback::getControlLawType() const { return static_cast<int>(this->controlLawType); }
 
-/*! Getter method for the control law type.
- @return const int
-*/
-int MrpFeedback::getControlLawType() const { return static_cast<int>(this->algorithm.getControlLawType()); }
+void MrpFeedback::setKnownTorquePntB_B(const Eigen::Vector3f& torque) {
+    this->knownTorquePntB_B = torque;
+    this->rebuildAlgorithmConfig();
+}
+Eigen::Vector3f MrpFeedback::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }
 
-/*! Setter method for the known external torque about point B.
- @return void
- @param torque [N*m] Known external torque expressed in body frame components
-*/
-void MrpFeedback::setKnownTorquePntB_B(const Eigen::Vector3f& torque) { this->algorithm.setKnownTorquePntB_B(torque); }
-
-/*! Getter method for the known torque about point B.
- @return const Eigen::Vector3f
-*/
-Eigen::Vector3f MrpFeedback::getKnownTorquePntB_B() const { return this->algorithm.getKnownTorquePntB_B(); }
+void MrpFeedback::rebuildAlgorithmConfig() {
+    const MrpFeedbackConfig cfg = MrpFeedbackConfig::create(
+        this->K, this->P, this->Ki, this->integralLimit, this->controlLawType, this->knownTorquePntB_B);
+    this->algorithm.setConfig(cfg);
+}

--- a/algorithms/mrpFeedback/mrpFeedback.h
+++ b/algorithms/mrpFeedback/mrpFeedback.h
@@ -7,11 +7,11 @@
 #include "msgPayloadDef/AttGuidMsgF32Payload.h"
 #include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
 #include "msgPayloadDef/RWArrayConfigMsgF32Payload.h"
+#include "msgPayloadDef/RWAvailabilityMsgPayload.h"
 #include "msgPayloadDef/RWSpeedMsgF32Payload.h"
 #include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
-#include "msgPayloadDef/RWAvailabilityMsgPayload.h"
 
 #include <Eigen/Core>
 
@@ -49,7 +49,17 @@ class MrpFeedback final : public SysModel {
     ReadFunctor<VehicleConfigMsgF32Payload> vehConfigInMsg;  //!< vehicle configuration input message
 
    private:
-    MrpFeedbackAlgorithm algorithm{};
+    void rebuildAlgorithmConfig();
+
+    float K = 0.0F;
+    float P = 0.0F;
+    float Ki = 0.0F;
+    float integralLimit = 0.0F;
+    ControlLawType controlLawType = ControlLawType::NORMAL;
+    Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Zero();
+
+    MrpFeedbackAlgorithm algorithm{
+        MrpFeedbackConfig::create(0.0F, 0.0F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero())};
     uint32_t numRW{};  //!< number of reaction wheels
 };
 

--- a/algorithms/mrpFeedback/mrpFeedback.h
+++ b/algorithms/mrpFeedback/mrpFeedback.h
@@ -11,7 +11,7 @@
 #include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
-#include <architecture/msgPayloadDef/RWAvailabilityMsgPayload.h>
+#include "msgPayloadDef/RWAvailabilityMsgPayload.h"
 
 #include <Eigen/Core>
 

--- a/algorithms/mrpFeedback/mrpFeedback.h
+++ b/algorithms/mrpFeedback/mrpFeedback.h
@@ -1,8 +1,8 @@
 #ifndef F32XMERA_MRP_FEEDBACK_H
 #define F32XMERA_MRP_FEEDBACK_H
 
-#include <memory>
 #include <stdint.h>
+#include <memory>
 
 #include "mrpFeedbackAlgorithm.h"
 #include "msgPayloadDef/AttGuidMsgF32Payload.h"
@@ -26,12 +26,12 @@ class MrpFeedback final : public SysModel {
     void updateState(uint64_t callTime) override;
 
     // Phase 1: public config properties -- set before reset().
-    float K = 0.0F;                                                    //!< [N*m]    proportional gain on MRP error
-    float P = 0.0F;                                                    //!< [N*m*s]  rate-error feedback gain
-    float Ki = 0.0F;                                                   //!< [N*m]    integral feedback gain (0 disables)
-    float integralLimit = 0.0F;                                        //!< [N*m*s]  anti-windup clamp on int_sigma
-    ControlLawType controlLawType = ControlLawType::NORMAL;            //!< control-law variant
-    Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Zero();       //!< [N*m]    feedforward known external torque
+    float K = 0.0F;                                               //!< [N*m]    proportional gain on MRP error
+    float P = 0.0F;                                               //!< [N*m*s]  rate-error feedback gain
+    float Ki = 0.0F;                                              //!< [N*m]    integral feedback gain (0 disables)
+    float integralLimit = 0.0F;                                   //!< [N*m*s]  anti-windup clamp on int_sigma
+    ControlLawType controlLawType = ControlLawType::NORMAL;       //!< control-law variant
+    Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Zero();  //!< [N*m]    feedforward known external torque
 
     ReadFunctor<RWSpeedMsgF32Payload> rwSpeedsInMsg;        //!< RW speed input message (Optional)
     ReadFunctor<RWAvailabilityMsgPayload> rwAvailInMsg;     //!< RW availability input message (Optional)

--- a/algorithms/mrpFeedback/mrpFeedback.h
+++ b/algorithms/mrpFeedback/mrpFeedback.h
@@ -1,6 +1,7 @@
 #ifndef F32XMERA_MRP_FEEDBACK_H
 #define F32XMERA_MRP_FEEDBACK_H
 
+#include <memory>
 #include <stdint.h>
 
 #include "mrpFeedbackAlgorithm.h"
@@ -15,7 +16,7 @@
 
 #include <Eigen/Core>
 
-/*! @brief Data configuration structure for the MRP feedback attitude control routine. */
+/*! @brief MRP feedback attitude-control adapter. */
 class MrpFeedback final : public SysModel {
    public:
     MrpFeedback() = default;
@@ -24,20 +25,14 @@ class MrpFeedback final : public SysModel {
     void reset(uint64_t callTime) override;
     void updateState(uint64_t callTime) override;
 
-    void setK(float gain);
-    float getK() const;
-    void setP(float gain);
-    float getP() const;
-    void setKi(float gain);
-    float getKi() const;
-    void setIntegralLimit(float limit);
-    float getIntegralLimit() const;
-    void setControlLawType(int type);
-    int getControlLawType() const;
-    void setKnownTorquePntB_B(const Eigen::Vector3f& torque);
-    Eigen::Vector3f getKnownTorquePntB_B() const;
+    // Phase 1: public config properties -- set before reset().
+    float K = 0.0F;                                                    //!< [N*m]    proportional gain on MRP error
+    float P = 0.0F;                                                    //!< [N*m*s]  rate-error feedback gain
+    float Ki = 0.0F;                                                   //!< [N*m]    integral feedback gain (0 disables)
+    float integralLimit = 0.0F;                                        //!< [N*m*s]  anti-windup clamp on int_sigma
+    ControlLawType controlLawType = ControlLawType::NORMAL;            //!< control-law variant
+    Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Zero();       //!< [N*m]    feedforward known external torque
 
-    /* declare module IO interfaces */
     ReadFunctor<RWSpeedMsgF32Payload> rwSpeedsInMsg;        //!< RW speed input message (Optional)
     ReadFunctor<RWAvailabilityMsgPayload> rwAvailInMsg;     //!< RW availability input message (Optional)
     ReadFunctor<RWArrayConfigMsgF32Payload> rwParamsInMsg;  //!< RW parameter input message.  (Optional)
@@ -49,18 +44,8 @@ class MrpFeedback final : public SysModel {
     ReadFunctor<VehicleConfigMsgF32Payload> vehConfigInMsg;  //!< vehicle configuration input message
 
    private:
-    void rebuildAlgorithmConfig();
-
-    float K = 0.0F;
-    float P = 0.0F;
-    float Ki = 0.0F;
-    float integralLimit = 0.0F;
-    ControlLawType controlLawType = ControlLawType::NORMAL;
-    Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Zero();
-
-    MrpFeedbackAlgorithm algorithm{
-        MrpFeedbackConfig::create(0.0F, 0.0F, 0.0F, 0.0F, ControlLawType::NORMAL, Eigen::Vector3f::Zero())};
-    uint32_t numRW{};  //!< number of reaction wheels
+    std::unique_ptr<MrpFeedbackAlgorithm> algorithm = nullptr;
+    uint32_t numRW{};
 };
 
 #endif

--- a/algorithms/mrpFeedback/mrpFeedback.rst
+++ b/algorithms/mrpFeedback/mrpFeedback.rst
@@ -4,207 +4,216 @@
 
 Executive Summary
 -----------------
-This module provides a general MRP feedback control law.  This 3-axis control can asymptotically track a general
-reference attitude trajectory.  The module is setup to work with or without `N` reaction wheels with
-general orientation.  If the reaction wheel states are fed into this module, then the resulting RW
-gyroscopic terms are compensated for. If the wheel information is not present, then these terms are ignored.
+This module provides a general MRP feedback control law. The 3-axis control can asymptotically track a reference
+attitude trajectory. The module works with or without ``N`` reaction wheels with general orientation. If the reaction
+wheel state messages are connected, the resulting RW gyroscopic terms are compensated for; otherwise those terms are
+ignored.
 
-Message Connection Descriptions
--------------------------------
-The following table lists all the module input and output messages.  The module msg variable name is set by the
-user from python.  The msg type contains a link to the message structure definition, while the description
-provides information on what this message is used for.
+This is the FP32 port of the Xmera ``mrpFeedback`` module.
+
+Module Architecture
+-------------------
+
+The module is split into a thin adapter (``MrpFeedback``) that handles framework integration and an algorithm class
+(``MrpFeedbackAlgorithm``) that contains the pure math. The adapter inherits from ``SysModel`` and validates that the
+required input messages are connected at ``reset()`` time. It builds a ``MrpFeedbackConfig`` from the public properties
+listed below and constructs the algorithm via the two-phase init pattern.
 
 .. list-table:: Module I/O Messages
-    :widths: 25 25 50
+    :widths: 25 30 45
     :header-rows: 1
 
     * - Msg Variable Name
       - Msg Type
       - Description
     * - cmdTorqueOutMsg
-      - :ref:`CmdTorqueBodyMsgPayload`
-      - Control torque output message
+      - :ref:`CmdTorqueBodyMsgF32Payload`
+      - Control torque output
     * - intFeedbackTorqueOutMsg
-      - :ref:`CmdTorqueBodyMsgPayload`
-      - Integral feedback control torque output message
+      - :ref:`CmdTorqueBodyMsgF32Payload`
+      - Integral feedback control torque output
     * - guidInMsg
-      - :ref:`AttGuidMsgPayload`
-      - Attitude guidance input message
+      - :ref:`AttGuidMsgF32Payload`
+      - Attitude guidance input (required)
     * - vehConfigInMsg
-      - :ref:`VehicleConfigMsgPayload`
-      - Vehicle configuration input message
+      - :ref:`VehicleConfigMsgF32Payload`
+      - Vehicle configuration input (required)
     * - rwParamsInMsg
-      - :ref:`RWArrayConfigMsgPayload`
-      - Reaction wheel array configuration input message
+      - :ref:`RWArrayConfigMsgF32Payload`
+      - Reaction-wheel array configuration input (optional)
     * - rwSpeedsInMsg
-      - :ref:`RWSpeedMsgPayload`
-      - Reaction wheel speeds message
+      - :ref:`RWSpeedMsgF32Payload`
+      - Reaction-wheel speeds (required when ``rwParamsInMsg`` is connected)
     * - rwAvailInMsg
       - :ref:`RWAvailabilityMsgPayload`
-      - Reaction wheel availability message.
+      - Reaction-wheel availability (optional)
 
-Module Parameters
--------------------------------
-The following table lists all the module parameters than can be set. The parameters are optional unless indicated
-(if not specified default is used).
+Configuration
+~~~~~~~~~~~~~
 
-.. list-table:: Module Parameters
-    :widths: 60 30 30 30
+All configurable parameters are validated at ``reset()`` time via ``MrpFeedbackConfig::create``. A negative gain or
+limit causes the factory to throw before the algorithm is constructed.
+
+.. list-table:: Configuration parameters
+    :widths: 22 14 14 14 36
     :header-rows: 1
 
-    * - Parameter Name
+    * - Parameter
       - Type
       - Units
       - Default
-      - Description
-      - Bounds
-    * - K
+      - Description / valid range
+    * - ``K``
       - float
-      - [rad/s]
+      - [N*m]
       - 0
-      - Proportional gain applied to MRP errors
-      - Must not be negative (checked in setter)
-    * - P
+      - Proportional gain on the MRP error. Must be ``>= 0``.
+    * - ``P``
       - float
-      - [N m s]
+      - [N*m*s]
       - 0
-      - Rate error feedback gain
-      - Must not be negative (checked in setter)
-    * - Ki
+      - Rate-error feedback gain. Must be ``>= 0``.
+    * - ``Ki``
       - float
-      - [N m]
+      - [N*m]
       - 0
-      - Integral feedback gain
-      - Must not be negative (checked in setter). If 0, no integral feedback is applied and the corresponding computation is skipped
-    * - integralLimit
+      - Integral feedback gain. Must be ``>= 0``. ``Ki = 0`` disables the integral term entirely.
+    * - ``integralLimit``
       - float
-      - [N m]
+      - [N*m*s]
       - 0
-      - Limit for integral feedback term (term will be capped by integralLimit)
-      - Must not be negative (checked in setter)
-    * - controlLawType
-      - enum ControlLawType
-      - [-]
-      - 0
-      - Considers integral feedback term for momentum contribution if 0, ignores otherwise
-      - N/A
-    * - knownTorquePntB_B
-      - Eigen::Vector3f
-      - [N m]]
-      - [0, 0, 0]
-      - Known external torque in body frame components
-      - None
+      - Anti-windup clamp applied element-wise to the integrated MRP error. Must be ``>= 0``.
+    * - ``controlLawType``
+      - ``ControlLawType``
+      - --
+      - ``NORMAL``
+      - ``NORMAL`` includes the integral term in the gyroscopic-compensation cross product;
+        ``SIMPLE_INTEGRAL`` uses :math:`\boldsymbol{\omega}_{B/N}` directly.
+    * - ``knownTorquePntB_B``
+      - ``Eigen::Vector3f``
+      - [N*m]
+      - ``[0,0,0]``
+      - Feedforward known external torque in body-frame components.
 
-Module Assumptions and Limitations
-----------------------------------
-This module assumes the main spacecraft is a rigid body.  If RW devices are installed, their wheel speeds are assumed to
-be fed into this control solution.
+Two-Phase Initialization
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Initialization
---------------
-The module is configured by::
+Subscribe inputs and set the public configuration properties before ``reset()`` is invoked. ::
 
-    module = mrpFeedback.MrpFeedback()
-    module.modelTag = "mrpFeedback"
-    module.K = K
-    module.P = P
-    module.Ki = Ki
-    module.integralLimit = integral_limit
-    module.controlLawType = control_law_type
-    module.knownTorquePntB_B = known_torque
+    module = mrpFeedbackF32.MrpFeedback()
+    module.K = 0.15
+    module.P = 150.0
+    module.Ki = 0.01
+    module.integralLimit = 20.0
+    module.controlLawType = mrpFeedbackF32.ControlLawType_NORMAL
+    module.knownTorquePntB_B = [0.0, 0.0, 0.0]
 
-Detailed Module Description
+    module.guidInMsg.subscribeTo(guid_msg)
+    module.vehConfigInMsg.subscribeTo(veh_config_msg)
+    module.rwParamsInMsg.subscribeTo(rw_params_msg)   # optional
+    module.rwSpeedsInMsg.subscribeTo(rw_speeds_msg)   # required when rwParamsInMsg is connected
+    module.rwAvailInMsg.subscribeTo(rw_avail_msg)     # optional
+
+    sim.AddModelToTask(task_name, module)
+    sim.InitializeSimulation()
+    sim.ExecuteSimulation()
+
+If a required input message has not been connected when ``reset()`` runs, an ``std::invalid_argument`` is thrown.
+If any of the gain or limit parameters fail validation (negative value), ``MrpFeedbackConfig::create`` throws an
+``fsw::invalid_argument``. If ``updateState()`` is called before ``reset()``, an ``XmeraLifecycleException`` is thrown.
+
+Mathematical Formulation
+------------------------
+
+The ``mrpFeedback`` module implements the MRP attitude feedback control torque :math:`\mathbf{L}_{r}` developed in
+chapter 8 of `Analytical Mechanics of Space Systems <http://doi.org/10.2514/4.105210>`__ (Example 8.14). It is a
+nonlinear attitude tracking law that includes an integral measure of the attitude error and avoids quadratic
+:math:`\mathbf{\omega}` terms to reduce the likelihood of control saturation during a detumbling phase. The output
+message is a body-frame control torque vector.
+
+Required guidance inputs (read every cycle via ``guidInMsg``):
+
+- :math:`\boldsymbol{\sigma}_{B/R}` (``sigma_BR``)
+- :math:`{}^{B}\boldsymbol{\omega}_{B/R}` (``omega_BR_B``)
+- :math:`{}^{B}\boldsymbol{\omega}_{R/N}` (``omega_RN_B``)
+- :math:`{}^{B}\dot{\boldsymbol{\omega}}_{R/N}` (``domega_RN_B``)
+
+The spacecraft inertia tensor :math:`[I]` is read once at ``reset()`` from ``vehConfigInMsg``. If ``rwParamsInMsg`` is
+connected, the RW spin-axis matrix :math:`[G_s]` and per-wheel spin-axis inertia :math:`I_{W_{s,i}}` are also captured
+at ``reset()`` time; the per-cycle wheel speeds :math:`\Omega_i` come from ``rwSpeedsInMsg``.
+
+Control Law (``controlLawType = NORMAL``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. math::
+
+    \boldsymbol{L}_{r} = -K \boldsymbol{\sigma}_{B/R}
+        - P \, {}^{B}\boldsymbol{\omega}_{B/R}
+        - P K_{I} \boldsymbol{z}
+        - [I_{\text{RW}}]\!\left(
+            -\dot{\boldsymbol{\omega}}_{R/N}
+            + [\tilde{\boldsymbol{\omega}}]\boldsymbol{\omega}_{R/N}
+          \right)
+        - \boldsymbol{L}
+        + \left([\tilde{\boldsymbol{\omega}}_{R/N}] + [\widetilde{K_{I} \boldsymbol{z}}]\right)
+          \!\left([I_{\text{RW}}]\boldsymbol{\omega}_{B/N} + [G_{s}]\boldsymbol{h}_{s}\right),
+
+where the per-wheel angular momentum is
+
+.. math::
+
+    h_{s_{i}} = I_{W_{s_{i}}}\!\left( \hat{\boldsymbol{g}}_{s_{i}}^{T} \boldsymbol{\omega}_{B/N} + \Omega_{i} \right),
+
+and :math:`I_{W_{s_{i}}}` is the RW spin-axis inertia.
+
+The integral attitude-error measure :math:`\boldsymbol{z}` is
+
+.. math::
+
+    \boldsymbol{z} = K \int_{t_{0}}^{t} \boldsymbol{\sigma}_{B/R}\, \mathrm{d}t
+                   + [I_{\text{RW}}] \boldsymbol{\omega}_{B/R}.
+
+The element-wise magnitude of :math:`\int \boldsymbol{\sigma}_{B/R}\, \mathrm{d}t` is clamped against
+``integralLimit``, preserving sign per element. The integral term is computed and applied only when ``Ki > 0``;
+setting ``Ki = 0`` skips the integral path entirely.
+
+Control Law (``controlLawType = SIMPLE_INTEGRAL``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. math::
+
+    \boldsymbol{L}_{r} = -K \boldsymbol{\sigma}_{B/R}
+        - P \, {}^{B}\boldsymbol{\omega}_{B/R}
+        - P K_{I} \boldsymbol{z}
+        - [I_{\text{RW}}]\!\left(
+            -\dot{\boldsymbol{\omega}}_{R/N}
+            + [\tilde{\boldsymbol{\omega}}]\boldsymbol{\omega}_{R/N}
+          \right)
+        - \boldsymbol{L}
+        + [\tilde{\boldsymbol{\omega}}_{B/N}]
+          \!\left([I_{\text{RW}}]\boldsymbol{\omega}_{B/N} + [G_{s}]\boldsymbol{h}_{s}\right).
+
+This variant is also asymptotically stable. Compared to ``NORMAL``, the integral feedback (which may contain
+integration errors) appears only once; in exchange the law depends quadratically on the body angular rate, which can
+generate a large control torque during a high-rate tumble.
+
+Reset
+~~~~~
+
+At ``reset()`` the algorithm:
+
+1. Captures :math:`[I]` from ``vehConfigInMsg``.
+2. Captures the RW configuration from ``rwParamsInMsg`` if it is connected; otherwise marks the RW count as zero.
+3. Zeros the integral state :math:`\int \boldsymbol{\sigma}_{B/R}\, \mathrm{d}t`.
+4. Resets the prior-call timestamp; the first ``update`` after a reset uses :math:`\Delta t = 0`.
+
+Assumptions and Limitations
 ---------------------------
-General Function
-^^^^^^^^^^^^^^^^
-The ``mrpFeedback`` module creates the MRP attitude feedback control torque :math:`{\mathbf L}_{r}` developed in chapter 8
-of `Analytical Mechanics of Space Systems <http://doi.org/10.2514/4.105210>`__. The output message is a body-frame
-control torque vector. The required attitude guidance message contains both attitude tracking error states as well as
-reference frame states. This message is read in with every update cycle. The vehicle configuration message is only read
-in on reset and contains the spacecraft inertia tensor about the vehicle's center of mass location.
 
-The MRP feedback control can compensate for Reaction Wheel (RW) gyroscopic effects as well.
-This is an optional input message where the RW configuration array message contains the RW spin axis
-:math:`\hat{\mathbf g}_{s,i}` information and the RW polar inertia about the spin axis :math:`I_{W_{s,i}}`.
-This is only read in on reset. The RW speed message contains the RW speed :math:`\Omega_{i}` and is read in every time
-step. The optional RW availability message can be used to include or not include RWs in the MRP feedback.
-This allows the module to selectively turn off some RWs. The default is that all RWs are operational and are included.
-
-Initialization
-^^^^^^^^^^^^^^
-Simply call the module reset function prior to using this control module.  This will reset the prior function call time
-variable, and reset the attitude error integral measure. The control update period :math:`\Delta t` is evaluated
-automatically.
-
-Algorithm
-^^^^^^^^^
-This module employs the MRP feedback algorithm of Example (8.14) of
-`Analytical Mechanics of Space Systems <http://doi.org/10.2514/4.105210>`__. This nonlinear attitude tracking control
-includes an integral measure of the attitude error. Further, we seek to avoid quadratic :math:`\mathbf\omega` terms to
-reduce the likelihood of control saturation during a detumbling phase. Let the new nonlinear feedback control be
-expressed as
-
-.. math::
-    [G_{s}]{\mathbf u}_{s} = -{\mathbf L}_{r}
-
-where
-
-.. math::
-    {\mathbf L}_{r} =  -K \mathbf\sigma - [P] \delta\mathbf\omega - [P][K_{I}] {\mathbf z}  - [I_{\text{RW}}](-\dot{\mathbf\omega}_{r} + [\tilde{\mathbf\omega}]\mathbf\omega_{r}) - {\mathbf L}
-    \\
-    + ([\tilde{\mathbf \omega}_{r}] + [\widetilde{K_{I}{\mathbf z}}])
-    \left([I_{\text{RW}}]\mathbf\omega + [G_{s}]{\mathbf h}_{s} \right)
-
-and
-
-.. math::
-    h_{s_{i}} = I_{W_{s_{i}}} (\hat{\mathbf g}_{s_{i}}^{T} \mathbf\omega_{B/N} + \Omega_{i})
-
-with :math:`I_{W_{s}}` being the RW spin axis inertia.
-
-The integral attitude error measure :math:`\mathbf z` is defined through
-
-.. math::  {\mathbf z} = K \int_{t_{0}}^{t} \mathbf\sigma \text{d}t + [I_{\text{RW}}] \delta\mathbf\omega
-
-A limit to the magnitude of the :math:`\int_{t_{0}}^{t} \mathbf\sigma \text{d}t` can be specified, which is a scalar
-compared to each element of the integral term.
-
-The integral measure :math:`\mathbf z` must be computed to determine :math:`[P][K_{I}] {\mathbf z}`, and the expression
-:math:`[\widetilde{K_{I}{\mathbf z}}]` is added to :math:`[\widetilde{\mathbf\omega_{r}}]` term.
-
-User Guide
-----------
-This module requires the following variables from the required input messages:
-
-- :math:`{\mathbf\sigma}_{B/N}` as ``guidCmdData.sigma_BR``
-- :math:`^B{\mathbf\omega}_{B/R}`  as ``guidCmdData.omega_BR_B``
-- :math:`^B{\mathbf\omega}_{R/N}` as ``guidCmdData.omega_RN_B``
-- :math:`^B\dot{\mathbf\omega}_{R/N}` as ``guidCmdData.domega_RN_B``
-- :math:`[I]`, the inertia matrix of the body as ``vehicleConfigOut.ISCPntB_B``
-
-The gains :math:`K` and :math:`P` must be set to positive values.  The integral gain :math:`K_i` is optional, it is 0
-by default, in which case the error integration for the controller is disabled, leaving just PD terms. The integrator
-is required to maintain asymptotic tracking in the presence of an external disturbing torque.  The ``integralLimit``
-is a scalar value applied in an element-wise check to ensure that the value of each element of the
-:math:`\int_{t_{0}}^{t} \mathbf\sigma \text{d}t` vector is within the desired limit. If not, the sign of that element
-is persevered, but the magnitude is replaced by ``integralLimit``.
-
-If the ``rwParamsInMsg`` is specified, then the associated ``rwSpeedsInMsg`` is required as well.
-
-The ``rwAvailInMsg`` is optional and is used to selectively include RW devices in the control solution.
-
-The ``controlLawType`` is an input that enables the user to choose between two different control laws.
-When ``controlLawType = NORMAL``, the control law is that specified above. Otherwise, the control law takes the form:
-
-.. math::
-
-    {\mathbf L}_{r} =  -K \mathbf\sigma - [P] \delta\mathbf\omega - [P][K_{I}] {\mathbf z}  - [I_{\text{RW}}](-\dot{\mathbf\omega}_{r} + [\tilde{\mathbf\omega}]\mathbf\omega_{r}) - {\mathbf L}
-    \\
-    + [\tilde{\mathbf \omega}]
-    \left([I_{\text{RW}}]\mathbf\omega + [G_{s}]{\mathbf h}_{s} \right).
-
-This control law is also asymptotically stable. The advantage when compared to ``controlLawType = NORMAL`` is that in
-this one, the integral control feedback, which may contain integration errors, only appears once. On the downside, this
-control law depends quadratically on the angular rates of the spacecraft, and could cause a large control torque when
-the spacecraft is tumbling at a high rate. When unspecified, this parameter defaults to ``controlLawType = NORMAL``.
+- The spacecraft is treated as a rigid body.
+- If RW devices are installed, their wheel speeds must be fed in via ``rwSpeedsInMsg``; otherwise the gyroscopic terms
+  are not included in the control torque.
+- The reference acceleration ``domega_RN_B`` is included verbatim in the control torque -- discontinuities in the
+  reference trajectory will appear directly in the output.
+- The output is single-precision FP32. With FP32 inputs and bounded magnitudes, expect relative accuracy on the
+  attitude-feedback term on the order of :math:`10^{-7}`.

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm.cpp
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm.cpp
@@ -2,53 +2,36 @@
 #include "architecture/utilities/eigenSupport.h"
 #include "utilities/timeConstants.h"
 
-#include "utilities/freestandingInvalidArgument.h"
 #include <math.h>
 
-/*! This method performs a complete reset of the module.  Local module variables that retain
- time varying states between function calls are reset to their default values.
- @return void
- @param vehConfigMsg vehicle config message
- @param rwConfigMsg reaction wheel config message
- @param rwIsLinked boolean indicating whether reaction wheel config message is linked
-*/
+MrpFeedbackAlgorithm::MrpFeedbackAlgorithm(const MrpFeedbackConfig& config) : cfg(config) {}
+
+void MrpFeedbackAlgorithm::setConfig(const MrpFeedbackConfig& config) { this->cfg = config; }
+
+/*! Reset the algorithm: snapshot the spacecraft inertia and (optional) RW configuration, and
+    clear the integral state. */
 void MrpFeedbackAlgorithm::reset(VehicleConfigMsgF32Payload vehConfigMsg,
                                  const RWArrayConfigMsgF32Payload& rwConfigMsg,
                                  const bool rwIsLinked) {
-    /*! - copy over spacecraft inertia tensor */
     this->ISCPntB_B = cArrayToEigenMatrix3(vehConfigMsg.ISCPntB_B);
 
-    /*! - zero the number of RW by default */
     this->rwConfigParams.numRW = 0;
-
-    /*! - check if RW configuration message exists */
     if (rwIsLinked) {
-        /*! - Read static RW config data message and store it in module variables*/
         this->rwConfigParams = rwConfigMsg;
     }
 
-    /*! - Reset the integral measure of the rate tracking error */
     this->int_sigma = Eigen::Vector3f::Zero();
-
-    /*! - Reset the prior time flag state.
-     If zero, control time step not evaluated on the first function call */
+    // priorTime == 0 signals first-call: no time delta is taken on the first update.
     this->priorTime = 0U;
 }
 
-/*! This method takes the attitude and rate errors relative to the Reference frame, as well as
-    the reference frame angular rates and acceleration, and computes the required control torque Lr.
- @return MrpFeedbackOutput
- @param callTime The clock time at which the function was called (nanoseconds)
- @param guidCmd Attitude tracking error message
- @param wheelSpeeds Reaction wheel speed message
- @param wheelsAvailability Reaction wheel availability message
-*/
+/*! Compute the required control torque Lr from the attitude/rate tracking error and (optional)
+    RW state. */
 MrpFeedbackOutput MrpFeedbackAlgorithm::update(uint64_t callTime,
                                                AttGuidMsgF32Payload& guidCmd,
                                                const RWSpeedMsgF32Payload& wheelSpeeds,
                                                const RWAvailabilityMsgPayload& wheelsAvailability) {
-    /*! - compute control update time */
-    float dt{}; /* [s] control update period */
+    float dt{};
     if (this->priorTime == 0U) {
         dt = 0.0F;
     } else {
@@ -61,19 +44,18 @@ MrpFeedbackOutput MrpFeedbackAlgorithm::update(uint64_t callTime,
     const Eigen::Vector3f omega_RN_B = cArrayToEigenVector(guidCmd.omega_RN_B);
     const Eigen::Vector3f domega_RN_B = cArrayToEigenVector(guidCmd.domega_RN_B);
 
-    /*! - compute body rate */
     const Eigen::Vector3f omega_BN_B = omega_BR_B + omega_RN_B;
 
-    /*! - evaluate integral term */
     Eigen::Vector3f z{Eigen::Vector3f::Zero()};
-    if (this->Ki > 0.0F) { /* check if integral feedback is turned on  */
-        this->int_sigma += this->K * dt * sigma_BR;
+    if (this->cfg.getKi() > 0.0F) {
+        this->int_sigma += this->cfg.getK() * dt * sigma_BR;
 
-        /* keep int_sigma less than integralLimit */
+        // Anti-windup clamp on the integral state.
+        const float integralLimit = this->cfg.getIntegralLimit();
         for (Eigen::Index i = 0; i < 3; ++i) {
             const float intCheck = fabsf(this->int_sigma[i]);
-            if (intCheck > this->integralLimit) {
-                this->int_sigma[i] *= this->integralLimit / intCheck;
+            if (intCheck > integralLimit) {
+                this->int_sigma[i] *= integralLimit / intCheck;
             }
         }
         z = this->int_sigma + this->ISCPntB_B * omega_BR_B;
@@ -84,7 +66,7 @@ MrpFeedbackOutput MrpFeedbackAlgorithm::update(uint64_t callTime,
 
     Eigen::Vector3f H_B = this->ISCPntB_B * omega_BN_B;
     for (Eigen::Index i = 0; i < this->rwConfigParams.numRW; ++i) {
-        if (wheelsAvailability.wheelAvailability[i] == AVAILABLE) { /* check if wheel is available */
+        if (wheelsAvailability.wheelAvailability[i] == AVAILABLE) {
             const Eigen::Vector3f G_s_B_i = G_s_B.col(i);
             const Eigen::Vector3f h_s_i =
                 this->rwConfigParams.JsList[i] * (omega_BN_B.dot(G_s_B_i) + wheelSpeeds.wheelSpeeds[i]) * G_s_B_i;
@@ -93,115 +75,22 @@ MrpFeedbackOutput MrpFeedbackAlgorithm::update(uint64_t callTime,
     }
 
     Eigen::Vector3f momentumContribution{};
-    if (this->controlLawType == ControlLawType::NORMAL) {
-        momentumContribution = (omega_RN_B + this->Ki * z).cross(H_B);
+    if (this->cfg.getControlLawType() == ControlLawType::NORMAL) {
+        momentumContribution = (omega_RN_B + this->cfg.getKi() * z).cross(H_B);
     } else {
         momentumContribution = omega_BN_B.cross(H_B);
     }
 
-    /*! - evaluate required attitude control torque Lc */
-    const Eigen::Vector3f Lc = this->K * sigma_BR + this->P * omega_BR_B + this->P * this->Ki * z -
-                               momentumContribution + this->ISCPntB_B * (omega_BN_B.cross(omega_RN_B) - domega_RN_B) +
-                               this->knownTorquePntB_B;
+    const Eigen::Vector3f Lc = this->cfg.getK() * sigma_BR + this->cfg.getP() * omega_BR_B +
+                               this->cfg.getP() * this->cfg.getKi() * z - momentumContribution +
+                               this->ISCPntB_B * (omega_BN_B.cross(omega_RN_B) - domega_RN_B) +
+                               this->cfg.getKnownTorquePntB_B();
 
     const Eigen::Vector3f Lr = -Lc;
-    const Eigen::Vector3f Li = -(this->P * this->Ki * z);
+    const Eigen::Vector3f Li = -(this->cfg.getP() * this->cfg.getKi() * z);
 
-    CmdTorqueBodyMsgF32Payload controlOut{};
-    CmdTorqueBodyMsgF32Payload intFeedbackOut{};
-
-    eigenVectorToCArray(Lr, controlOut.torqueRequestBody);
-    eigenVectorToCArray(Li, intFeedbackOut.torqueRequestBody);
-
-    MrpFeedbackOutput mrpFeedbackOutput{};
-    mrpFeedbackOutput.controlOut = controlOut;
-    mrpFeedbackOutput.intFeedbackOut = intFeedbackOut;
-
-    return mrpFeedbackOutput;
+    MrpFeedbackOutput out{};
+    eigenVectorToCArray(Lr, out.controlOut.torqueRequestBody);
+    eigenVectorToCArray(Li, out.intFeedbackOut.torqueRequestBody);
+    return out;
 }
-
-/*! Setter method for the gain K.
- @return void
- @param gain [N*m] Attitude error feedback gain
-*/
-void MrpFeedbackAlgorithm::setK(const float gain) {
-    if (gain < 0.0) {
-        FSW_THROW_INVALID_ARGUMENT("Feedback gain K must not be negative");
-    }
-    this->K = gain;
-}
-
-/*! Getter method for the gain K.
- @return const float
-*/
-float MrpFeedbackAlgorithm::getK() const { return this->K; }
-
-/*! Setter method for the gain P.
- @return void
- @param gain [N*m*s] Rate error feedback gain
-*/
-void MrpFeedbackAlgorithm::setP(const float gain) {
-    if (gain < 0.0) {
-        FSW_THROW_INVALID_ARGUMENT("Feedback gain P must not be negative");
-    }
-    this->P = gain;
-}
-
-/*! Getter method for the gain P.
- @return const float
-*/
-float MrpFeedbackAlgorithm::getP() const { return this->P; }
-
-/*! Setter method for the gain Ki.
- @return void
- @param gain [N*m] Integral feedback gain
-*/
-void MrpFeedbackAlgorithm::setKi(const float gain) {
-    if (gain < 0.0) {
-        FSW_THROW_INVALID_ARGUMENT("Integral feedback gain Ki must not be negative");
-    }
-    this->Ki = gain;
-}
-
-/*! Getter method for the gain Ki.
- @return const float
-*/
-float MrpFeedbackAlgorithm::getKi() const { return this->Ki; }
-
-/*! Setter method for the integral limit.
- @return void
- @param limit [N*m*s] Integral limit
-*/
-void MrpFeedbackAlgorithm::setIntegralLimit(const float limit) {
-    if (limit < 0.0) {
-        FSW_THROW_INVALID_ARGUMENT("Integral limit must not be negative");
-    }
-    this->integralLimit = limit;
-}
-
-/*! Getter method for the integral limit.
- @return const float
-*/
-float MrpFeedbackAlgorithm::getIntegralLimit() const { return this->integralLimit; }
-
-/*! Setter method for the control law type.
- @return void
- @param type control law type
-*/
-void MrpFeedbackAlgorithm::setControlLawType(const ControlLawType type) { this->controlLawType = type; }
-
-/*! Getter method for the control law type.
- @return const ControlLawType
-*/
-ControlLawType MrpFeedbackAlgorithm::getControlLawType() const { return this->controlLawType; }
-
-/*! Setter method for the known external torque about point B.
- @return void
- @param torque [N*m] Known external torque expressed in body frame components
-*/
-void MrpFeedbackAlgorithm::setKnownTorquePntB_B(const Eigen::Vector3f& torque) { this->knownTorquePntB_B = torque; }
-
-/*! Getter method for the known torque about point B.
- @return const Eigen::Vector3f
-*/
-Eigen::Vector3f MrpFeedbackAlgorithm::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm.cpp
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm.cpp
@@ -3,8 +3,9 @@
 #include "utilities/timeConstants.h"
 
 #include <math.h>
+#include <utility>
 
-MrpFeedbackAlgorithm::MrpFeedbackAlgorithm(const MrpFeedbackConfig& config) : cfg(config) {}
+MrpFeedbackAlgorithm::MrpFeedbackAlgorithm(MrpFeedbackConfig config) : cfg(std::move(config)) {}
 
 void MrpFeedbackAlgorithm::setConfig(const MrpFeedbackConfig& config) { this->cfg = config; }
 
@@ -28,7 +29,7 @@ void MrpFeedbackAlgorithm::reset(VehicleConfigMsgF32Payload vehConfigMsg,
 /*! Compute the required control torque Lr from the attitude/rate tracking error and (optional)
     RW state. */
 MrpFeedbackOutput MrpFeedbackAlgorithm::update(uint64_t callTime,
-                                               AttGuidMsgF32Payload& guidCmd,
+                                               const AttGuidMsgF32Payload& guidCmd,
                                                const RWSpeedMsgF32Payload& wheelSpeeds,
                                                const RWAvailabilityMsgPayload& wheelsAvailability) {
     float dt{};

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm.h
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm.h
@@ -8,7 +8,7 @@
 #include "msgPayloadDef/RWArrayConfigMsgF32Payload.h"
 #include "msgPayloadDef/RWSpeedMsgF32Payload.h"
 #include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
-#include <architecture/msgPayloadDef/RWAvailabilityMsgPayload.h>
+#include "msgPayloadDef/RWAvailabilityMsgPayload.h"
 
 #include <Eigen/Core>
 

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm.h
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm.h
@@ -15,38 +15,22 @@
 /*! @brief Data configuration structure for the MRP feedback attitude control routine. */
 class MrpFeedbackAlgorithm final {
    public:
+    explicit MrpFeedbackAlgorithm(const MrpFeedbackConfig& config);
+
+    void setConfig(const MrpFeedbackConfig& config);
+
     void reset(VehicleConfigMsgF32Payload vehConfigMsg, const RWArrayConfigMsgF32Payload& rwConfigMsg, bool rwIsLinked);
     MrpFeedbackOutput update(uint64_t callTime,
                              AttGuidMsgF32Payload& guidCmd,
                              const RWSpeedMsgF32Payload& wheelSpeeds,
                              const RWAvailabilityMsgPayload& wheelsAvailability);
 
-    void setK(float gain);
-    float getK() const;
-    void setP(float gain);
-    float getP() const;
-    void setKi(float gain);
-    float getKi() const;
-    void setIntegralLimit(float limit);
-    float getIntegralLimit() const;
-    void setControlLawType(ControlLawType type);
-    ControlLawType getControlLawType() const;
-    void setKnownTorquePntB_B(const Eigen::Vector3f& torque);
-    Eigen::Vector3f getKnownTorquePntB_B() const;
-
    private:
-    float K{};                        //!< [rad/sec] Proportional gain applied to MRP errors
-    float P{};                        //!< [N*m*s]   Rate error feedback gain applied
-    float Ki{};                       //!< [N*m]     Integration feedback error on rate error
-    float integralLimit{};            //!< [N*m]     Integration limit to avoid wind-up issue
-    ControlLawType controlLawType{};  //!<           Flag to choose between the two control laws available
-    Eigen::Vector3f knownTorquePntB_B{
-        Eigen::Vector3f::Zero()};  //!< [N*m]     known external torque in body frame vector components
-    uint64_t priorTime{};          //!< [ns]      Last time the attitude control is called
-    Eigen::Vector3f int_sigma{};   //!< [s] integral of the MPR attitude error
-    Eigen::Matrix3f ISCPntB_B{};   //!< [kg m^2] Spacecraft Inertia
-    RWArrayConfigMsgF32Payload
-        rwConfigParams{};  //!< [-] struct to store message containing RW config parameters in body B frame
+    MrpFeedbackConfig cfg;
+    uint64_t priorTime{};                       //!< [ns]      Last time the attitude control is called
+    Eigen::Vector3f int_sigma{};                //!< [s] integral of the MPR attitude error
+    Eigen::Matrix3f ISCPntB_B{};                //!< [kg m^2] Spacecraft Inertia
+    RWArrayConfigMsgF32Payload rwConfigParams{};  //!< RW config snapshot taken at reset() time
 };
 
 #endif

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm.h
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm.h
@@ -3,22 +3,14 @@
 
 #include <cstdint>
 
+#include "mrpFeedbackTypes.h"
 #include "msgPayloadDef/AttGuidMsgF32Payload.h"
-#include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
 #include "msgPayloadDef/RWArrayConfigMsgF32Payload.h"
+#include "msgPayloadDef/RWAvailabilityMsgPayload.h"
 #include "msgPayloadDef/RWSpeedMsgF32Payload.h"
 #include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
-#include "msgPayloadDef/RWAvailabilityMsgPayload.h"
 
 #include <Eigen/Core>
-
-/*! structure containing the MRP feedback algorithm output */
-typedef struct {
-    CmdTorqueBodyMsgF32Payload controlOut;     /*!< control torque output */
-    CmdTorqueBodyMsgF32Payload intFeedbackOut; /*!< integral feedback torque output */
-} MrpFeedbackOutput;
-
-enum class ControlLawType { NORMAL = 0, SIMPLE_INTEGRAL = 1 };
 
 /*! @brief Data configuration structure for the MRP feedback attitude control routine. */
 class MrpFeedbackAlgorithm final {

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm.h
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm.h
@@ -15,21 +15,21 @@
 /*! @brief Data configuration structure for the MRP feedback attitude control routine. */
 class MrpFeedbackAlgorithm final {
    public:
-    explicit MrpFeedbackAlgorithm(const MrpFeedbackConfig& config);
+    explicit MrpFeedbackAlgorithm(MrpFeedbackConfig config);
 
     void setConfig(const MrpFeedbackConfig& config);
 
     void reset(VehicleConfigMsgF32Payload vehConfigMsg, const RWArrayConfigMsgF32Payload& rwConfigMsg, bool rwIsLinked);
     MrpFeedbackOutput update(uint64_t callTime,
-                             AttGuidMsgF32Payload& guidCmd,
+                             const AttGuidMsgF32Payload& guidCmd,
                              const RWSpeedMsgF32Payload& wheelSpeeds,
                              const RWAvailabilityMsgPayload& wheelsAvailability);
 
    private:
     MrpFeedbackConfig cfg;
-    uint64_t priorTime{};                       //!< [ns]      Last time the attitude control is called
-    Eigen::Vector3f int_sigma{};                //!< [s] integral of the MPR attitude error
-    Eigen::Matrix3f ISCPntB_B{};                //!< [kg m^2] Spacecraft Inertia
+    uint64_t priorTime{};                         //!< [ns]      Last time the attitude control is called
+    Eigen::Vector3f int_sigma{};                  //!< [s] integral of the MPR attitude error
+    Eigen::Matrix3f ISCPntB_B{};                  //!< [kg m^2] Spacecraft Inertia
     RWArrayConfigMsgF32Payload rwConfigParams{};  //!< RW config snapshot taken at reset() time
 };
 

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.cpp
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.cpp
@@ -52,12 +52,8 @@ MrpFeedbackOutput_c MrpFeedbackAlgorithm_update(MrpFeedbackAlgorithm* self,
                                                 const AttGuidMsgF32Payload* guidCmd,
                                                 const RWSpeedMsgF32Payload* wheelSpeeds,
                                                 const RWAvailabilityMsgPayload* wheelsAvailability) {
-    // The C++ algorithm currently takes guidCmd by non-const reference; cast away the const
-    // here so callers see a const-correct shim API. The algorithm only reads guidCmd.
-    AttGuidMsgF32Payload& guidCmdRef = const_cast<AttGuidMsgF32Payload&>(*guidCmd);
-
     // clang-format off
-    const MrpFeedbackOutput out = reinterpret_cast<::MrpFeedbackAlgorithm*>(self)->update(callTime, guidCmdRef, *wheelSpeeds, *wheelsAvailability);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    const MrpFeedbackOutput out = reinterpret_cast<::MrpFeedbackAlgorithm*>(self)->update(callTime, *guidCmd, *wheelSpeeds, *wheelsAvailability);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     // clang-format on
 
     MrpFeedbackOutput_c result{};

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.cpp
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.cpp
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2026 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ */
+
+#include "mrpFeedbackAlgorithm_c.h"
+#include "architecture/utilities/eigenSupport.h"
+#include "mrpFeedbackAlgorithm.h"
+#include "mrpFeedbackTypes.h"
+
+#include <Eigen/Core>
+
+namespace {
+MrpFeedbackConfig configFromC(const MrpFeedbackConfig_c& c) {
+    return MrpFeedbackConfig::create(c.K,
+                                     c.P,
+                                     c.Ki,
+                                     c.integralLimit,
+                                     static_cast<ControlLawType>(c.controlLawType),
+                                     cArrayToEigenVector3<float>(c.knownTorquePntB_B.data));
+}
+}  // namespace
+
+MrpFeedbackAlgorithm* MrpFeedbackAlgorithm_create(const MrpFeedbackConfig_c* config) {
+    // clang-format off
+    return reinterpret_cast<MrpFeedbackAlgorithm*>(new ::MrpFeedbackAlgorithm(configFromC(*config)));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
+    // clang-format on
+}
+
+void MrpFeedbackAlgorithm_destroy(MrpFeedbackAlgorithm* self) {
+    // clang-format off
+    delete reinterpret_cast<::MrpFeedbackAlgorithm*>(self);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
+    // clang-format on
+}
+
+void MrpFeedbackAlgorithm_setConfig(MrpFeedbackAlgorithm* self, const MrpFeedbackConfig_c* config) {
+    // clang-format off
+    reinterpret_cast<::MrpFeedbackAlgorithm*>(self)->setConfig(configFromC(*config));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    // clang-format on
+}
+
+void MrpFeedbackAlgorithm_reset(MrpFeedbackAlgorithm* self,
+                                const VehicleConfigMsgF32Payload* vehConfigMsg,
+                                const RWArrayConfigMsgF32Payload* rwConfigMsg,
+                                int rwIsLinked) {
+    // clang-format off
+    reinterpret_cast<::MrpFeedbackAlgorithm*>(self)->reset(*vehConfigMsg, *rwConfigMsg, rwIsLinked != 0);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    // clang-format on
+}
+
+MrpFeedbackOutput_c MrpFeedbackAlgorithm_update(MrpFeedbackAlgorithm* self,
+                                                uint64_t callTime,
+                                                const AttGuidMsgF32Payload* guidCmd,
+                                                const RWSpeedMsgF32Payload* wheelSpeeds,
+                                                const RWAvailabilityMsgPayload* wheelsAvailability) {
+    // The C++ algorithm currently takes guidCmd by non-const reference; cast away the const
+    // here so callers see a const-correct shim API. The algorithm only reads guidCmd.
+    AttGuidMsgF32Payload& guidCmdRef = const_cast<AttGuidMsgF32Payload&>(*guidCmd);
+
+    // clang-format off
+    const MrpFeedbackOutput out = reinterpret_cast<::MrpFeedbackAlgorithm*>(self)->update(callTime, guidCmdRef, *wheelSpeeds, *wheelsAvailability);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    // clang-format on
+
+    MrpFeedbackOutput_c result{};
+    result.controlOut = out.controlOut;
+    result.intFeedbackOut = out.intFeedbackOut;
+    return result;
+}

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.h
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.h
@@ -34,10 +34,7 @@ typedef struct {
  *
  * Numeric values must stay in lockstep with the C++ enum class in mrpFeedbackTypes.h.
  */
-typedef enum {
-    CONTROL_LAW_TYPE_NORMAL_C = 0,
-    CONTROL_LAW_TYPE_SIMPLE_INTEGRAL_C = 1
-} ControlLawType_c;
+typedef enum { CONTROL_LAW_TYPE_NORMAL_C = 0, CONTROL_LAW_TYPE_SIMPLE_INTEGRAL_C = 1 } ControlLawType_c;
 
 /**
  * @brief Plain-old-data mirror of the C++ MrpFeedbackConfig fields.

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.h
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.h
@@ -1,0 +1,120 @@
+/* SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2026 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ */
+
+#ifndef F32XMERA_MRPFEEDBACKALGORITHM_C_H
+#define F32XMERA_MRPFEEDBACKALGORITHM_C_H
+
+#include "msgPayloadDef/AttGuidMsgF32Payload.h"
+#include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
+#include "msgPayloadDef/RWArrayConfigMsgF32Payload.h"
+#include "msgPayloadDef/RWAvailabilityMsgPayload.h"
+#include "msgPayloadDef/RWSpeedMsgF32Payload.h"
+#include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Opaque handle to the C++ MrpFeedbackAlgorithm instance.
+ */
+typedef struct MrpFeedbackAlgorithm MrpFeedbackAlgorithm;
+
+/**
+ * @brief POD representation of a 3-vector (Eigen::Vector3f).
+ */
+typedef struct {
+    float data[3];
+} Vector3f_c;
+
+/**
+ * @brief C-compatible mirror of the C++ ControlLawType enum class.
+ *
+ * Numeric values must stay in lockstep with the C++ enum class in mrpFeedbackTypes.h.
+ */
+typedef enum {
+    CONTROL_LAW_TYPE_NORMAL_C = 0,
+    CONTROL_LAW_TYPE_SIMPLE_INTEGRAL_C = 1
+} ControlLawType_c;
+
+/**
+ * @brief Plain-old-data mirror of the C++ MrpFeedbackConfig fields.
+ *
+ * Caller fills this struct and passes it to MrpFeedbackAlgorithm_create or _setConfig. The C++
+ * side validates each field via MrpFeedbackConfig::create and throws on invalid input.
+ *  - K, P, Ki, integralLimit must be >= 0
+ *  - controlLawType is unconstrained
+ *  - knownTorquePntB_B is unconstrained
+ */
+typedef struct {
+    float K;
+    float P;
+    float Ki;
+    float integralLimit;
+    ControlLawType_c controlLawType;
+    Vector3f_c knownTorquePntB_B;
+} MrpFeedbackConfig_c;
+
+/**
+ * @brief C-compatible mirror of the C++ MrpFeedbackOutput.
+ */
+typedef struct {
+    CmdTorqueBodyMsgF32Payload controlOut;     /*!< control torque output */
+    CmdTorqueBodyMsgF32Payload intFeedbackOut; /*!< integral feedback torque output */
+} MrpFeedbackOutput_c;
+
+/**
+ * @brief Construct a new MrpFeedbackAlgorithm instance from the supplied configuration.
+ * @param config Pointer to the configuration to apply (validated; throws on invalid input).
+ * @return Pointer to a new MrpFeedbackAlgorithm (must be destroyed).
+ */
+MrpFeedbackAlgorithm* MrpFeedbackAlgorithm_create(const MrpFeedbackConfig_c* config);
+
+/**
+ * @brief Destroy a previously created MrpFeedbackAlgorithm.
+ * @param self Pointer to the instance to destroy.
+ */
+void MrpFeedbackAlgorithm_destroy(MrpFeedbackAlgorithm* self);
+
+/**
+ * @brief Replace the algorithm's configuration at runtime.
+ * @param self   Pointer to the instance.
+ * @param config Pointer to the configuration to apply (validated; throws on invalid input).
+ */
+void MrpFeedbackAlgorithm_setConfig(MrpFeedbackAlgorithm* self, const MrpFeedbackConfig_c* config);
+
+/**
+ * @brief Reset the algorithm: snapshot the spacecraft inertia and (optional) RW configuration,
+ *        and clear the integral state.
+ * @param self          Pointer to the instance.
+ * @param vehConfigMsg  Spacecraft inertia configuration.
+ * @param rwConfigMsg   Reaction-wheel configuration (consumed only when rwIsLinked is non-zero).
+ * @param rwIsLinked    Non-zero when rwConfigMsg holds a valid configuration; zero to ignore it.
+ */
+void MrpFeedbackAlgorithm_reset(MrpFeedbackAlgorithm* self,
+                                const VehicleConfigMsgF32Payload* vehConfigMsg,
+                                const RWArrayConfigMsgF32Payload* rwConfigMsg,
+                                int rwIsLinked);
+
+/**
+ * @brief Compute the required control torque Lr and integral feedback torque Li.
+ * @param self                Pointer to the instance.
+ * @param callTime            Time stamp for update [ns].
+ * @param guidCmd             Attitude tracking error.
+ * @param wheelSpeeds         Reaction-wheel speeds (read only when reset configured numRW > 0).
+ * @param wheelsAvailability  Reaction-wheel availability flags.
+ * @return MrpFeedbackOutput_c  Control torque and integral feedback torque payloads.
+ */
+MrpFeedbackOutput_c MrpFeedbackAlgorithm_update(MrpFeedbackAlgorithm* self,
+                                                uint64_t callTime,
+                                                const AttGuidMsgF32Payload* guidCmd,
+                                                const RWSpeedMsgF32Payload* wheelSpeeds,
+                                                const RWAvailabilityMsgPayload* wheelsAvailability);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // F32XMERA_MRPFEEDBACKALGORITHM_C_H

--- a/algorithms/mrpFeedback/mrpFeedbackF32.i
+++ b/algorithms/mrpFeedback/mrpFeedbackF32.i
@@ -8,12 +8,13 @@
 %include <architecture/_GeneralModuleFiles/swig_conly_data.i>
 %include <architecture/_GeneralModuleFiles/swig_eigen.i>
 
-%include "mrpFeedback.h"
+%include "mrpFeedbackTypes.h"
 %include "mrpFeedbackAlgorithm.h"
+%include "mrpFeedback.h"
 
 %include "msgPayloadDef/AttGuidMsgF32Payload.h"
 %include "msgPayloadDef/VehicleConfigMsgF32Payload.h"
 %include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
 %include "msgPayloadDef/RWArrayConfigMsgF32Payload.h"
 %include "msgPayloadDef/RWSpeedMsgF32Payload.h"
-%include <architecture/msgPayloadDef/RWAvailabilityMsgPayload.h>
+%include "msgPayloadDef/RWAvailabilityMsgPayload.h"

--- a/algorithms/mrpFeedback/mrpFeedbackTypes.h
+++ b/algorithms/mrpFeedback/mrpFeedbackTypes.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+#ifndef F32XMERA_MRP_FEEDBACK_TYPES_H
+#define F32XMERA_MRP_FEEDBACK_TYPES_H
+
+#include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
+#include "utilities/freestandingInvalidArgument.h"
+#include <Eigen/Core>
+
+enum class ControlLawType { NORMAL = 0, SIMPLE_INTEGRAL = 1 };
+
+struct MrpFeedbackOutput {
+    CmdTorqueBodyMsgF32Payload controlOut{};      //!< control torque output
+    CmdTorqueBodyMsgF32Payload intFeedbackOut{};  //!< integral feedback torque output
+};
+
+class MrpFeedbackConfig final {
+   public:
+    static MrpFeedbackConfig create(float K,
+                                    float P,
+                                    float Ki,
+                                    float integralLimit,
+                                    ControlLawType controlLawType,
+                                    const Eigen::Vector3f& knownTorquePntB_B) {
+        if (!isValidK(K)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpFeedback: K must be >= 0");
+        }
+        if (!isValidP(P)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpFeedback: P must be >= 0");
+        }
+        if (!isValidKi(Ki)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpFeedback: Ki must be >= 0");
+        }
+        if (!isValidIntegralLimit(integralLimit)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpFeedback: integralLimit must be >= 0");
+        }
+        if (!isValidControlLawType(controlLawType)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpFeedback: controlLawType must be NORMAL or SIMPLE_INTEGRAL");
+        }
+        if (!isValidKnownTorquePntB_B(knownTorquePntB_B)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpFeedback: knownTorquePntB_B must be finite");
+        }
+        return {K, P, Ki, integralLimit, controlLawType, knownTorquePntB_B};
+    }
+
+    static bool isValidK(float K) { return K >= 0.0F; }
+    static bool isValidP(float P) { return P >= 0.0F; }
+    static bool isValidKi(float Ki) { return Ki >= 0.0F; }
+    static bool isValidIntegralLimit(float limit) { return limit >= 0.0F; }
+    static bool isValidControlLawType(ControlLawType t) {
+        return t == ControlLawType::NORMAL || t == ControlLawType::SIMPLE_INTEGRAL;
+    }
+    static bool isValidKnownTorquePntB_B(const Eigen::Vector3f& torque) { return torque.allFinite(); }
+
+    float getK() const { return K; }
+    float getP() const { return P; }
+    float getKi() const { return Ki; }
+    float getIntegralLimit() const { return integralLimit; }
+    ControlLawType getControlLawType() const { return controlLawType; }
+    Eigen::Vector3f getKnownTorquePntB_B() const { return knownTorquePntB_B; }
+
+   private:
+    MrpFeedbackConfig(float K,
+                      float P,
+                      float Ki,
+                      float integralLimit,
+                      ControlLawType controlLawType,
+                      const Eigen::Vector3f& knownTorquePntB_B)
+        : K(K),
+          P(P),
+          Ki(Ki),
+          integralLimit(integralLimit),
+          controlLawType(controlLawType),
+          knownTorquePntB_B(knownTorquePntB_B) {}
+
+    float K;
+    float P;
+    float Ki;
+    float integralLimit;
+    ControlLawType controlLawType;
+    Eigen::Vector3f knownTorquePntB_B;
+};
+
+#endif

--- a/algorithms/utilities/xmeraLifecycleException.h
+++ b/algorithms/utilities/xmeraLifecycleException.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+#ifndef F32XMERA_XMERA_LIFECYCLE_EXCEPTION_H
+#define F32XMERA_XMERA_LIFECYCLE_EXCEPTION_H
+
+#include <stdexcept>
+
+// Thrown by Xmera adapters when they detect a lifecycle violation -- typically updateState() being
+// called before reset(), so the algorithm has never been constructed.
+//
+// This header is for adapter use (hosted environment) only. Algorithm production code targeting
+// freestanding C++ must not throw, so should not include this header.
+class XmeraLifecycleException : public std::runtime_error {
+   public:
+    using std::runtime_error::runtime_error;
+};
+
+#endif  // F32XMERA_XMERA_LIFECYCLE_EXCEPTION_H


### PR DESCRIPTION
* **Tickets addressed:** maxgnc-2227
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
- Adds shared `XmeraLifecycleException` header for adapter use.                                                             
- Add mrpFeedback to freestanding build.
- Adds `MrpFeedbackConfig` validated configuration class. New `mrpFeedbackTypes.h` with validating Config.
- Convert algorithm to accept config object.              
- Add two-phase init lifecycle to adapter. Adapter switches to public properties and `unique_ptr<MrpFeedbackAlgorithm>` constructed in `reset(); updateState()` throws `XmeraLifecycleException` if called first.                                                                                                                                                    
- Add C shim for mrpFeedback.
- Refactor pytest. Test uses public properties and the SWIG-exposed enum; .i file fixed to include `mrpFeedbackTypes.h` and the relative `RWAvailabilityMsgPayload.h`.               
- Update cpp regression tests for Config API.
- Add property and edge case tests. New tests: integral feedback is exactly zero when Ki = 0, and integral feedback saturates at P*Ki*integralLimit.                             
- Update documentation.
- Formatting changes.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't
add or update any tests justify this choice. -->

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and
completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
