### PR TITLE
Add configuration validation object to mrpPd

### DIFF
--- a/.github/clang-tidy-exclude.txt
+++ b/.github/clang-tidy-exclude.txt
@@ -23,6 +23,8 @@ algorithms/mrpFeedback/mrpFeedback.h
 algorithms/mrpFeedback/mrpFeedback.cpp
 algorithms/mrpPD/mrpPD.h
 algorithms/mrpPD/mrpPD.cpp
+algorithms/mrpPD/mrpPDAlgorithm_c.h
+algorithms/mrpPD/mrpPDAlgorithm_c.cpp
 algorithms/mrpSteering/mrpSteering.h
 algorithms/mrpSteering/mrpSteering.cpp
 algorithms/navAggregate/navAggregate.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ set(algorithms
     "inertialUKF"
     "mimuMajorityVote"
     "mrpFeedback"
+    "mrpPD"
     "navAggregate"
     "oeStateEphem"
     "rateControl"

--- a/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
+++ b/algorithms/mrpPD/_tests/mrpPDTestHelpers.hpp
@@ -1,23 +1,24 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
 #ifndef TEST_MRPPD_H
 #define TEST_MRPPD_H
 
 #include "architecture/utilities/eigenSupport.h"
 #include "mrpPDAlgorithm.h"
+#include "mrpPDTypes.h"
 #include "utilities/freestandingInvalidArgument.h"
 #include <gtest/gtest.h>
 #include <math.h>
 #include <Eigen/Core>
 #include <numbers>
 
-// Reference computation for update
-inline Eigen::Vector3f referenceUpdate(const MrpPDAlgorithm& alg,
+inline Eigen::Vector3f referenceUpdate(const MrpPDConfig& cfg,
                                        const Eigen::Vector3f& sigma_BR,
                                        const Eigen::Vector3f& omega_BR_B,
                                        const Eigen::Vector3f& domega_RN_B) {
-    const Eigen::Vector3f Lr = -alg.getProportionalGainK() * sigma_BR - alg.getDerivativeGainP() * omega_BR_B +
-                               alg.getSpacecraftInertia() * domega_RN_B - alg.getKnownTorquePntB_B();
-
-    return Lr;
+    return -cfg.getProportionalGainK() * sigma_BR - cfg.getDerivativeGainP() * omega_BR_B +
+           cfg.getSpacecraftInertia() * domega_RN_B - cfg.getKnownTorquePntB_B();
 }
 
 inline void regressionTestMrpPD(float K,
@@ -26,25 +27,17 @@ inline void regressionTestMrpPD(float K,
                                 const Eigen::Vector3f& sigma_BR,
                                 const Eigen::Vector3f& omega_BR_B,
                                 const Eigen::Vector3f& domega_RN_B) {
-    // --- Regression test using expected update algorithm ---
+    const Eigen::Matrix3f inertia = Eigen::Matrix3f::Identity();
+    const MrpPDConfig cfg = MrpPDConfig::create(K, P, torque, inertia);
+    const MrpPDAlgorithm alg{cfg};
 
-    MrpPDAlgorithm alg{};
-
-    alg.setProportionalGainK(K);
-    alg.setDerivativeGainP(P);
-    alg.setKnownTorquePntB_B(torque);
-
-    // Reference
     Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
     Eigen::Vector3f referenceTorque = Eigen::Vector3f::Zero();
     EXPECT_NO_THROW(outputTorque = alg.update(sigma_BR, omega_BR_B, domega_RN_B));
-    EXPECT_NO_THROW(referenceTorque = referenceUpdate(alg, sigma_BR, omega_BR_B, domega_RN_B));
+    EXPECT_NO_THROW(referenceTorque = referenceUpdate(cfg, sigma_BR, omega_BR_B, domega_RN_B));
 
     for (int i = 0; i < 3; ++i) {
-        // Reference correctness
         EXPECT_NEAR(outputTorque[i], referenceTorque[i], 1e-6);
-
-        // Finiteness
         EXPECT_TRUE(std::isfinite(outputTorque[i]));
     }
 }

--- a/algorithms/mrpPD/_tests/test_mrpPD.cpp
+++ b/algorithms/mrpPD/_tests/test_mrpPD.cpp
@@ -3,6 +3,8 @@
 
 #include "mrpPDTestHelpers.hpp"
 #include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
 
 TEST(MrpPDTest, RegressionTest) {
     regressionTestMrpPD(10,
@@ -72,7 +74,13 @@ TEST(MrpPDTest, SetupTest) {
     EXPECT_THROW(MrpPDConfig::create(-0.1F, 10.0F, zeroTorque, inertia), fsw::invalid_argument);
     EXPECT_THROW(MrpPDConfig::create(10.0F, -0.1F, zeroTorque, inertia), fsw::invalid_argument);
 
-    // Invalid inertias
+    // Non-finite known torque
+    const Eigen::Vector3f nanTorque{std::nanf(""), 0.0F, 0.0F};
+    EXPECT_THROW(MrpPDConfig::create(10.0F, 10.0F, nanTorque, inertia), fsw::invalid_argument);
+    const Eigen::Vector3f infTorque{std::numeric_limits<float>::infinity(), 0.0F, 0.0F};
+    EXPECT_THROW(MrpPDConfig::create(10.0F, 10.0F, infTorque, inertia), fsw::invalid_argument);
+
+    // Invalid inertias: zero diagonal, asymmetric, triangle-inequality violating
     Eigen::Matrix3f badInertia{};
     badInertia << 1, 0, 0, 0, 1, 0, 0, 0, 0;
     EXPECT_THROW(MrpPDConfig::create(10.0F, 10.0F, zeroTorque, badInertia), fsw::invalid_argument);
@@ -81,14 +89,94 @@ TEST(MrpPDTest, SetupTest) {
     badInertia << 3, 0, 0, 0, 1, 0, 0, 0, 1;
     EXPECT_THROW(MrpPDConfig::create(10.0F, 10.0F, zeroTorque, badInertia), fsw::invalid_argument);
 
-    // Round-trip
+    // Zero gains are allowed (boundary of valid range)
+    EXPECT_NO_THROW(MrpPDConfig::create(0.0F, 0.0F, zeroTorque, inertia));
+
+    // Round-trip via getters
     const float K = 100.0F;
     const float P = 10.0F;
     const Eigen::Vector3f torque(1.0F, 2.0F, 3.0F);
-    const auto cfg = MrpPDConfig::create(K, P, torque, inertia);
-    EXPECT_NEAR(cfg.getProportionalGainK(), K, 1e-6);
-    EXPECT_NEAR(cfg.getDerivativeGainP(), P, 1e-6);
+    Eigen::Matrix3f principalInertia{};
+    principalInertia << 1000.0F, 0.0F, 0.0F, 0.0F, 800.0F, 0.0F, 0.0F, 0.0F, 800.0F;
+    const auto cfg = MrpPDConfig::create(K, P, torque, principalInertia);
+    EXPECT_FLOAT_EQ(cfg.getProportionalGainK(), K);
+    EXPECT_FLOAT_EQ(cfg.getDerivativeGainP(), P);
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(cfg.getKnownTorquePntB_B()[i], torque[i], 1e-6);
+        EXPECT_FLOAT_EQ(cfg.getKnownTorquePntB_B()[i], torque[i]);
     }
+    EXPECT_TRUE(cfg.getSpacecraftInertia().isApprox(principalInertia));
+}
+
+TEST(MrpPDTest, FinitenessUnderRandomInputs) {
+    // For any bounded valid configuration and bounded inputs, the output torque must be finite.
+    Eigen::Matrix3f inertia{};
+    inertia << 1000.0F, 0.0F, 0.0F, 0.0F, 800.0F, 0.0F, 0.0F, 0.0F, 800.0F;
+    const MrpPDAlgorithm alg{MrpPDConfig::create(0.15F, 150.0F, Eigen::Vector3f{0.1F, 0.2F, 0.3F}, inertia)};
+
+    const Eigen::Vector3f sigmaSamples[] = {
+        {0.0F, 0.0F, 0.0F}, {0.999F, 0.0F, 0.0F}, {-0.5F, 0.5F, -0.5F}, {0.3F, -0.3F, 0.3F}};
+    const Eigen::Vector3f omegaSamples[] = {
+        {0.0F, 0.0F, 0.0F}, {1.0F, -1.0F, 1.0F}, {-10.0F, 10.0F, -10.0F}, {0.001F, -0.001F, 0.001F}};
+    const Eigen::Vector3f domegaSamples[] = {{0.0F, 0.0F, 0.0F}, {0.1F, 0.0F, -0.1F}, {-1.0F, 1.0F, -1.0F}};
+    for (const auto& sigma : sigmaSamples) {
+        for (const auto& omega : omegaSamples) {
+            for (const auto& domega : domegaSamples) {
+                const Eigen::Vector3f Lr = alg.update(sigma, omega, domega);
+                for (int i = 0; i < 3; ++i) {
+                    EXPECT_TRUE(std::isfinite(Lr[i]));
+                }
+            }
+        }
+    }
+}
+
+TEST(MrpPDTest, ZeroGainsProduceOnlyFeedforwardTerms) {
+    // With K = 0 and P = 0, the output collapses to [I] * domega_RN_B - knownTorque, regardless of
+    // sigma and omega errors.
+    const Eigen::Matrix3f inertia = Eigen::Matrix3f::Identity();
+    const Eigen::Vector3f knownTorque{1.0F, -2.0F, 3.0F};
+    const MrpPDAlgorithm alg{MrpPDConfig::create(0.0F, 0.0F, knownTorque, inertia)};
+
+    const Eigen::Vector3f sigma{0.7F, -0.5F, 0.2F};
+    const Eigen::Vector3f omega{1.0F, 2.0F, 3.0F};
+    const Eigen::Vector3f domega{0.4F, 0.5F, 0.6F};
+    const Eigen::Vector3f Lr = alg.update(sigma, omega, domega);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FLOAT_EQ(Lr[i], domega[i] - knownTorque[i]);
+    }
+}
+
+TEST(MrpPDTest, SetConfigUpdatesGainsAtRuntime) {
+    // setConfig must replace the active configuration; a subsequent update reflects the new gains.
+    const Eigen::Matrix3f inertia = Eigen::Matrix3f::Identity();
+    MrpPDAlgorithm alg{MrpPDConfig::create(1.0F, 2.0F, Eigen::Vector3f::Zero(), inertia)};
+
+    const Eigen::Vector3f sigma{0.1F, 0.2F, 0.3F};
+    const Eigen::Vector3f Lr1 = alg.update(sigma, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero());
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FLOAT_EQ(Lr1[i], -1.0F * sigma[i]);
+    }
+
+    alg.setConfig(MrpPDConfig::create(5.0F, 2.0F, Eigen::Vector3f::Zero(), inertia));
+    const Eigen::Vector3f Lr2 = alg.update(sigma, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero());
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FLOAT_EQ(Lr2[i], -5.0F * sigma[i]);
+    }
+}
+
+TEST(MrpPDTest, IsValidPredicates) {
+    // Each predicate must accept the boundary value and reject the just-below/above case.
+    EXPECT_TRUE(MrpPDConfig::isValidProportionalGainK(0.0F));
+    EXPECT_FALSE(MrpPDConfig::isValidProportionalGainK(-1e-7F));
+
+    EXPECT_TRUE(MrpPDConfig::isValidDerivativeGainP(0.0F));
+    EXPECT_FALSE(MrpPDConfig::isValidDerivativeGainP(-1e-7F));
+
+    EXPECT_TRUE(MrpPDConfig::isValidKnownTorquePntB_B(Eigen::Vector3f::Zero()));
+    EXPECT_FALSE(MrpPDConfig::isValidKnownTorquePntB_B(Eigen::Vector3f{std::nanf(""), 0.0F, 0.0F}));
+
+    EXPECT_TRUE(MrpPDConfig::isValidSpacecraftInertia(Eigen::Matrix3f::Identity()));
+    Eigen::Matrix3f singular{};
+    singular << 1, 0, 0, 0, 1, 0, 0, 0, 0;
+    EXPECT_FALSE(MrpPDConfig::isValidSpacecraftInertia(singular));
 }

--- a/algorithms/mrpPD/_tests/test_mrpPD.cpp
+++ b/algorithms/mrpPD/_tests/test_mrpPD.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
 #include "mrpPDTestHelpers.hpp"
 #include <gtest/gtest.h>
 
@@ -11,75 +14,81 @@ TEST(MrpPDTest, RegressionTest) {
 }
 
 TEST(MrpPDTest, PropertyTest) {
-    // --- Test module with targeted inputs to ensure individual terms are properly implemented ---
-    MrpPDAlgorithm alg{};
-    alg.setProportionalGainK(10);
-    alg.setDerivativeGainP(200);
+    const float K = 10.0F;
+    const float P = 200.0F;
+    const Eigen::Matrix3f inertia = Eigen::Matrix3f::Identity();
 
-    Eigen::Vector3f torque = Eigen::Vector3f::Zero();
-
-    // All inputs are zeros except external torque should return external torque
-    torque << 1, 2, 3;
-    alg.setKnownTorquePntB_B(torque);
-    Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
-    EXPECT_NO_THROW(outputTorque =
-                        alg.update(Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero()));
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], -torque[i], 1e-6);
+    // All inputs are zeros except external torque should return -external torque
+    {
+        const Eigen::Vector3f torque{1.0F, 2.0F, 3.0F};
+        const MrpPDAlgorithm alg{MrpPDConfig::create(K, P, torque, inertia)};
+        Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
+        EXPECT_NO_THROW(outputTorque =
+                            alg.update(Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero()));
+        for (int i = 0; i < 3; ++i) {
+            EXPECT_NEAR(outputTorque[i], -torque[i], 1e-6);
+        }
     }
 
-    // If input rates and accelerations are null, the torque is the input mrp scaled by proportional gain
-    torque << 0, 0, 0;
-    alg.setKnownTorquePntB_B(torque);
-    Eigen::Vector3f const sigma_BR(0.5, 0.2, 0.1);
-    EXPECT_NO_THROW(outputTorque = alg.update(sigma_BR, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero()));
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], -alg.getProportionalGainK() * sigma_BR[i], 1e-6);
+    // If input rates and accelerations are null, the torque is the input MRP scaled by -K
+    {
+        const MrpPDAlgorithm alg{MrpPDConfig::create(K, P, Eigen::Vector3f::Zero(), inertia)};
+        const Eigen::Vector3f sigma_BR(0.5F, 0.2F, 0.1F);
+        Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
+        EXPECT_NO_THROW(outputTorque = alg.update(sigma_BR, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero()));
+        for (int i = 0; i < 3; ++i) {
+            EXPECT_NEAR(outputTorque[i], -K * sigma_BR[i], 1e-6);
+        }
     }
 
-    // If input rates and accelerations are null, with Identity inertia matrix, the torque is the domega term
-    Eigen::Vector3f const domega_RN_B(0.5, 0.2, 0.1);
-    EXPECT_NO_THROW(outputTorque = alg.update(Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), domega_RN_B));
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], domega_RN_B[i], 1e-6);
+    // With identity inertia, only the domega term contributes
+    {
+        const MrpPDAlgorithm alg{MrpPDConfig::create(K, P, Eigen::Vector3f::Zero(), inertia)};
+        const Eigen::Vector3f domega_RN_B(0.5F, 0.2F, 0.1F);
+        Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
+        EXPECT_NO_THROW(outputTorque = alg.update(Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), domega_RN_B));
+        for (int i = 0; i < 3; ++i) {
+            EXPECT_NEAR(outputTorque[i], domega_RN_B[i], 1e-6);
+        }
     }
 
-    // If all but omega_BR_B null, the torque is omega_BR_B scaled by derivative gain
-    Eigen::Vector3f const omega_BR_B(-0.3, 0.1, -0.8);
-    EXPECT_NO_THROW(outputTorque = alg.update(Eigen::Vector3f::Zero(), omega_BR_B, Eigen::Vector3f::Zero()));
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(outputTorque[i], -alg.getDerivativeGainP() * omega_BR_B[i], 1e-6);
+    // If only omega_BR_B is non-zero, the torque is omega_BR_B scaled by -P
+    {
+        const MrpPDAlgorithm alg{MrpPDConfig::create(K, P, Eigen::Vector3f::Zero(), inertia)};
+        const Eigen::Vector3f omega_BR_B(-0.3F, 0.1F, -0.8F);
+        Eigen::Vector3f outputTorque = Eigen::Vector3f::Zero();
+        EXPECT_NO_THROW(outputTorque = alg.update(Eigen::Vector3f::Zero(), omega_BR_B, Eigen::Vector3f::Zero()));
+        for (int i = 0; i < 3; ++i) {
+            EXPECT_NEAR(outputTorque[i], -P * omega_BR_B[i], 1e-6);
+        }
     }
 }
 
 TEST(MrpPDTest, SetupTest) {
-    MrpPDAlgorithm alg{};
+    const Eigen::Matrix3f inertia = Eigen::Matrix3f::Identity();
+    const Eigen::Vector3f zeroTorque = Eigen::Vector3f::Zero();
 
-    // --- Test expected exceptions ---
+    // Negative gains
+    EXPECT_THROW(MrpPDConfig::create(-0.1F, 10.0F, zeroTorque, inertia), fsw::invalid_argument);
+    EXPECT_THROW(MrpPDConfig::create(10.0F, -0.1F, zeroTorque, inertia), fsw::invalid_argument);
 
-    // Negative feedback gains
-    EXPECT_THROW(alg.setProportionalGainK(-0.1), fsw::invalid_argument);
-    EXPECT_THROW(alg.setDerivativeGainP(-0.1), fsw::invalid_argument);
-
+    // Invalid inertias
     Eigen::Matrix3f badInertia{};
     badInertia << 1, 0, 0, 0, 1, 0, 0, 0, 0;
-    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fsw::invalid_argument);
+    EXPECT_THROW(MrpPDConfig::create(10.0F, 10.0F, zeroTorque, badInertia), fsw::invalid_argument);
     badInertia << 1, 0, 0, 0, 1, 0, 0, 1, 1;
-    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fsw::invalid_argument);
+    EXPECT_THROW(MrpPDConfig::create(10.0F, 10.0F, zeroTorque, badInertia), fsw::invalid_argument);
     badInertia << 3, 0, 0, 0, 1, 0, 0, 0, 1;
-    EXPECT_THROW(alg.setSpacecraftInertia(badInertia), fsw::invalid_argument);
+    EXPECT_THROW(MrpPDConfig::create(10.0F, 10.0F, zeroTorque, badInertia), fsw::invalid_argument);
 
-    float K = 100;
-    float P = 10;
-    Eigen::Vector3f torque = Eigen::Vector3f(1., 2, 3);
-    alg.setProportionalGainK(K);
-    alg.setDerivativeGainP(P);
-    alg.setKnownTorquePntB_B(torque);
-
-    // Check setters and getters
-    EXPECT_NEAR(alg.getProportionalGainK(), K, 1e-6);
-    EXPECT_NEAR(alg.getDerivativeGainP(), P, 1e-6);
+    // Round-trip
+    const float K = 100.0F;
+    const float P = 10.0F;
+    const Eigen::Vector3f torque(1.0F, 2.0F, 3.0F);
+    const auto cfg = MrpPDConfig::create(K, P, torque, inertia);
+    EXPECT_NEAR(cfg.getProportionalGainK(), K, 1e-6);
+    EXPECT_NEAR(cfg.getDerivativeGainP(), P, 1e-6);
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(alg.getKnownTorquePntB_B()[i], torque[i], 1e-6);
+        EXPECT_NEAR(cfg.getKnownTorquePntB_B()[i], torque[i], 1e-6);
     }
 }

--- a/algorithms/mrpPD/mrpPD.cpp
+++ b/algorithms/mrpPD/mrpPD.cpp
@@ -2,10 +2,12 @@
 // SPDX-FileCopyrightText: 2025 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
 #include "mrpPD.h"
-#include "utilities/freestandingInvalidArgument.h"
-#include <architecture/utilities/eigenSupport.h>
 
-void MrpPD::reset(uint64_t callTime) {
+#include "utilities/xmeraLifecycleException.h"
+#include <architecture/utilities/eigenSupport.h>
+#include <stdexcept>
+
+void MrpPD::reset(const uint64_t callTime) {
     if (!this->guidInMsg.isLinked()) {
         throw std::invalid_argument("mrpPD.guidInMsg wasn't connected.");
     }
@@ -13,59 +15,26 @@ void MrpPD::reset(uint64_t callTime) {
         throw std::invalid_argument("mrpPD.vehConfigInMsg wasn't connected.");
     }
 
-    if (this->vehConfigInMsg.isWritten()) {
-        const auto vehicleConfigInMsg = this->vehConfigInMsg();
-        this->spacecraftInertia = cArrayToEigenMatrix3(vehicleConfigInMsg.ISCPntB_B);
-    }
-    this->rebuildAlgorithmConfig();
+    const VehicleConfigMsgF32Payload sc = this->vehConfigInMsg();
+    const Eigen::Matrix3f spacecraftInertia = cArrayToEigenMatrix3(sc.ISCPntB_B);
+
+    auto config = MrpPDConfig::create(this->K, this->P, this->knownTorquePntB_B, spacecraftInertia);
+    this->algorithm = std::make_unique<MrpPDAlgorithm>(config);
 }
 
-void MrpPD::updateState(uint64_t callTime) {
-    auto torqueCmdMsgF32Payload = CmdTorqueBodyMsgF32Payload();
-    if (this->guidInMsg.isWritten()) {
-        const auto localGuidInMsg = this->guidInMsg();
-        const Eigen::Vector3f sigma_BR = cArrayToEigenVector(localGuidInMsg.sigma_BR);
-        const Eigen::Vector3f omega_BR_B = cArrayToEigenVector(localGuidInMsg.omega_BR_B);
-        const Eigen::Vector3f domega_RN_B = cArrayToEigenVector(localGuidInMsg.domega_RN_B);
-
-        const auto torque = this->algorithm.update(sigma_BR, omega_BR_B, domega_RN_B);
-        eigenVectorToCArray(torque, torqueCmdMsgF32Payload.torqueRequestBody);
+void MrpPD::updateState(const uint64_t callTime) {
+    if (!this->algorithm) {
+        throw XmeraLifecycleException("MrpPD reset() has not been called.");
     }
 
-    this->cmdTorqueOutMsg.write(&torqueCmdMsgF32Payload, moduleID, callTime);
-}
+    const auto [sigma_BR_arr, omega_BR_B_arr, omega_RN_B_arr, domega_RN_B_arr] = this->guidInMsg();
+    const Eigen::Vector3f sigma_BR = cArrayToEigenVector(sigma_BR_arr);
+    const Eigen::Vector3f omega_BR_B = cArrayToEigenVector(omega_BR_B_arr);
+    const Eigen::Vector3f domega_RN_B = cArrayToEigenVector(domega_RN_B_arr);
 
-void MrpPD::setK(float K) {
-    if (!MrpPDConfig::isValidProportionalGainK(K)) {
-        FSW_THROW_INVALID_ARGUMENT("mrpPD: K must be non-negative");
-    }
-    this->K = K;
-    this->rebuildAlgorithmConfig();
-}
+    const Eigen::Vector3f torque = this->algorithm->update(sigma_BR, omega_BR_B, domega_RN_B);
 
-float MrpPD::getK() const { return this->K; }
-
-void MrpPD::setP(float P) {
-    if (!MrpPDConfig::isValidDerivativeGainP(P)) {
-        FSW_THROW_INVALID_ARGUMENT("mrpPD: P must be non-negative");
-    }
-    this->P = P;
-    this->rebuildAlgorithmConfig();
-}
-
-float MrpPD::getP() const { return this->P; }
-
-void MrpPD::setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B) {
-    if (!MrpPDConfig::isValidKnownTorquePntB_B(knownTorquePntB_B)) {
-        FSW_THROW_INVALID_ARGUMENT("mrpPD: knownTorquePntB_B must be finite");
-    }
-    this->knownTorquePntB_B = knownTorquePntB_B;
-    this->rebuildAlgorithmConfig();
-}
-
-const Eigen::Vector3f& MrpPD::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }
-
-void MrpPD::rebuildAlgorithmConfig() {
-    const MrpPDConfig cfg = MrpPDConfig::create(this->K, this->P, this->knownTorquePntB_B, this->spacecraftInertia);
-    this->algorithm.setConfig(cfg);
+    CmdTorqueBodyMsgF32Payload out{};
+    eigenVectorToCArray(torque, out.torqueRequestBody);
+    this->cmdTorqueOutMsg.write(&out, this->moduleID, callTime);
 }

--- a/algorithms/mrpPD/mrpPD.cpp
+++ b/algorithms/mrpPD/mrpPD.cpp
@@ -1,10 +1,10 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
 #include "mrpPD.h"
+#include "utilities/freestandingInvalidArgument.h"
 #include <architecture/utilities/eigenSupport.h>
 
-/*! Reset method for the BSK module adapter interface. This method also calls the algorithm reset method.
- @return void
- @param callTime [ns] Time the method is called
-*/
 void MrpPD::reset(uint64_t callTime) {
     if (!this->guidInMsg.isLinked()) {
         throw std::invalid_argument("mrpPD.guidInMsg wasn't connected.");
@@ -14,25 +14,20 @@ void MrpPD::reset(uint64_t callTime) {
     }
 
     if (this->vehConfigInMsg.isWritten()) {
-        auto vehicleConfigInMsg = this->vehConfigInMsg();
-        auto inertia = cArrayToEigenMatrix3(vehicleConfigInMsg.ISCPntB_B);
-        this->algorithm.setSpacecraftInertia(inertia);
+        const auto vehicleConfigInMsg = this->vehConfigInMsg();
+        this->spacecraftInertia = cArrayToEigenMatrix3(vehicleConfigInMsg.ISCPntB_B);
     }
+    this->rebuildAlgorithmConfig();
 }
 
-/*! Update method for the BSK module adapter interface. This method also calls the algorithm update method.
- @return void
- @param callTime [ns] Time the method is called
-*/
 void MrpPD::updateState(uint64_t callTime) {
     auto torqueCmdMsgF32Payload = CmdTorqueBodyMsgF32Payload();
     if (this->guidInMsg.isWritten()) {
-        auto localGuidInMsg = this->guidInMsg();
-        Eigen::Vector3f const sigma_BR = cArrayToEigenVector(localGuidInMsg.sigma_BR);
-        Eigen::Vector3f const omega_BR_B = cArrayToEigenVector(localGuidInMsg.omega_BR_B);
-        Eigen::Vector3f const domega_RN_B = cArrayToEigenVector(localGuidInMsg.domega_RN_B);
+        const auto localGuidInMsg = this->guidInMsg();
+        const Eigen::Vector3f sigma_BR = cArrayToEigenVector(localGuidInMsg.sigma_BR);
+        const Eigen::Vector3f omega_BR_B = cArrayToEigenVector(localGuidInMsg.omega_BR_B);
+        const Eigen::Vector3f domega_RN_B = cArrayToEigenVector(localGuidInMsg.domega_RN_B);
 
-        // Call the algorithm update method
         const auto torque = this->algorithm.update(sigma_BR, omega_BR_B, domega_RN_B);
         eigenVectorToCArray(torque, torqueCmdMsgF32Payload.torqueRequestBody);
     }
@@ -40,37 +35,37 @@ void MrpPD::updateState(uint64_t callTime) {
     this->cmdTorqueOutMsg.write(&torqueCmdMsgF32Payload, moduleID, callTime);
 }
 
-/*! Setter method for the derivative gain P.
- @return void
- @param P [N*m*s] Rate error feedback gain applied
-*/
-void MrpPD::setDerivativeGainP(float P) { this->algorithm.setDerivativeGainP(P); }
-
-/*! Getter method for the derivative gain P.
- @return float
-*/
-float MrpPD::getDerivativeGainP() const { return this->algorithm.getDerivativeGainP(); }
-
-/*! Setter method for the known external torque about point B.
- @return void
- @param knownTorquePntB_B [N*m] Known external torque expressed in body frame components
-*/
-void MrpPD::setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B) {
-    this->algorithm.setKnownTorquePntB_B(knownTorquePntB_B);
+void MrpPD::setK(float K) {
+    if (!MrpPDConfig::isValidProportionalGainK(K)) {
+        FSW_THROW_INVALID_ARGUMENT("mrpPD: K must be non-negative");
+    }
+    this->K = K;
+    this->rebuildAlgorithmConfig();
 }
 
-/*! Getter method for the known torque about point B.
- @return const Eigen::Vector3f&
-*/
-const Eigen::Vector3f& MrpPD::getKnownTorquePntB_B() const { return this->algorithm.getKnownTorquePntB_B(); }
+float MrpPD::getK() const { return this->K; }
 
-/*! Setter method for the proportional gain K.
- @return void
- @param K [rad/s] Proportional gain applied to MRP errors
-*/
-void MrpPD::setProportionalGainK(float K) { this->algorithm.setProportionalGainK(K); }
+void MrpPD::setP(float P) {
+    if (!MrpPDConfig::isValidDerivativeGainP(P)) {
+        FSW_THROW_INVALID_ARGUMENT("mrpPD: P must be non-negative");
+    }
+    this->P = P;
+    this->rebuildAlgorithmConfig();
+}
 
-/*! Getter method for the proportional gain K.
- @return float
-*/
-float MrpPD::getProportionalGainK() const { return this->algorithm.getProportionalGainK(); }
+float MrpPD::getP() const { return this->P; }
+
+void MrpPD::setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B) {
+    if (!MrpPDConfig::isValidKnownTorquePntB_B(knownTorquePntB_B)) {
+        FSW_THROW_INVALID_ARGUMENT("mrpPD: knownTorquePntB_B must be finite");
+    }
+    this->knownTorquePntB_B = knownTorquePntB_B;
+    this->rebuildAlgorithmConfig();
+}
+
+const Eigen::Vector3f& MrpPD::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }
+
+void MrpPD::rebuildAlgorithmConfig() {
+    const MrpPDConfig cfg = MrpPDConfig::create(this->K, this->P, this->knownTorquePntB_B, this->spacecraftInertia);
+    this->algorithm.setConfig(cfg);
+}

--- a/algorithms/mrpPD/mrpPD.h
+++ b/algorithms/mrpPD/mrpPD.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
 #ifndef XMERAF32_MRP_PD_H
 #define XMERAF32_MRP_PD_H
 
@@ -12,7 +15,6 @@
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
 
-/*! @brief MRP PD control class. */
 class MrpPD : public SysModel {
    public:
     MrpPD() = default;
@@ -20,19 +22,27 @@ class MrpPD : public SysModel {
 
     void reset(uint64_t currentSimNanos) override;
     void updateState(uint64_t currentSimNanos) override;
-    void setDerivativeGainP(float P);
-    float getDerivativeGainP() const;
+
+    void setK(float K);
+    float getK() const;
+    void setP(float P);
+    float getP() const;
     void setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B);
     const Eigen::Vector3f& getKnownTorquePntB_B() const;
-    void setProportionalGainK(float K);
-    float getProportionalGainK() const;
 
     ReadFunctor<AttGuidMsgF32Payload> guidInMsg;             //!< Attitude guidance input message
     ReadFunctor<VehicleConfigMsgF32Payload> vehConfigInMsg;  //!< Vehicle configuration input message
     Message<CmdTorqueBodyMsgF32Payload> cmdTorqueOutMsg;     //!< Commanded torque output message
 
    private:
-    MrpPDAlgorithm algorithm{};  //!< Algorithm for mrpPD control logic (BSK-agnostic)
+    void rebuildAlgorithmConfig();
+
+    float K = 0.0F;
+    float P = 0.0F;
+    Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Zero();
+    Eigen::Matrix3f spacecraftInertia = Eigen::Matrix3f::Identity();
+
+    MrpPDAlgorithm algorithm{MrpPDConfig::create(0.0F, 0.0F, Eigen::Vector3f::Zero(), Eigen::Matrix3f::Identity())};
 };
 
 #endif

--- a/algorithms/mrpPD/mrpPD.h
+++ b/algorithms/mrpPD/mrpPD.h
@@ -6,7 +6,9 @@
 
 #include <stdint.h>
 
-#include <Eigen/Dense>
+#include <memory>
+
+#include <Eigen/Core>
 
 #include "mrpPDAlgorithm.h"
 #include "msgPayloadDef/AttGuidMsgF32Payload.h"
@@ -15,34 +17,25 @@
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
 
-class MrpPD : public SysModel {
+class MrpPD final : public SysModel {
    public:
     MrpPD() = default;
-    ~MrpPD() = default;
+    ~MrpPD() override = default;
 
-    void reset(uint64_t currentSimNanos) override;
-    void updateState(uint64_t currentSimNanos) override;
+    void reset(uint64_t callTime) override;
+    void updateState(uint64_t callTime) override;
 
-    void setK(float K);
-    float getK() const;
-    void setP(float P);
-    float getP() const;
-    void setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B);
-    const Eigen::Vector3f& getKnownTorquePntB_B() const;
+    // Phase 1: public config properties -- set before reset().
+    float K = 0.0F;                                               //!< [N*m]    proportional gain on MRP error
+    float P = 0.0F;                                               //!< [N*m*s]  rate-error feedback gain
+    Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Zero();  //!< [N*m]    feedforward known external torque
 
     ReadFunctor<AttGuidMsgF32Payload> guidInMsg;             //!< Attitude guidance input message
     ReadFunctor<VehicleConfigMsgF32Payload> vehConfigInMsg;  //!< Vehicle configuration input message
     Message<CmdTorqueBodyMsgF32Payload> cmdTorqueOutMsg;     //!< Commanded torque output message
 
    private:
-    void rebuildAlgorithmConfig();
-
-    float K = 0.0F;
-    float P = 0.0F;
-    Eigen::Vector3f knownTorquePntB_B = Eigen::Vector3f::Zero();
-    Eigen::Matrix3f spacecraftInertia = Eigen::Matrix3f::Identity();
-
-    MrpPDAlgorithm algorithm{MrpPDConfig::create(0.0F, 0.0F, Eigen::Vector3f::Zero(), Eigen::Matrix3f::Identity())};
+    std::unique_ptr<MrpPDAlgorithm> algorithm = nullptr;
 };
 
 #endif

--- a/algorithms/mrpPD/mrpPD.rst
+++ b/algorithms/mrpPD/mrpPD.rst
@@ -1,53 +1,154 @@
+.. raw:: latex
+
+    {\LARGE \textbf{mrpPD}}
+
 Executive Summary
 -----------------
-This module provides a MRP based PD attitude control module. It is similar to :ref:`mrpFeedback`, but without the RW or the integral feedback option. The feedback control is able to asymptotically track a reference attitude if there are no unknown dynamics and the attitude control torque is implemented with a thruster set.
+This module provides an MRP-based proportional-derivative attitude control law. It is similar to :ref:`mrpFeedback`,
+but without reaction-wheel terms or integral feedback. Given perfect knowledge of the spacecraft inertia and no
+unmodeled dynamics, the control law asymptotically tracks a reference attitude. The output is an external body-frame
+control torque intended to be produced by a thruster cluster.
 
-Message Connection Descriptions
--------------------------------
-The following table lists all the module input and output messages.  The module msg variable name is set by the
-user from python.  The msg type contains a link to the message structure definition, while the description
-provides information on what this message is used for.
+This is the FP32 port of the Xmera ``mrpPD`` module.
+
+Module Architecture
+-------------------
+
+The module is split into a thin adapter (``MrpPD``) that handles framework integration and an algorithm class
+(``MrpPDAlgorithm``) that contains the pure math. The adapter inherits from ``SysModel`` and validates that the
+required input messages are connected at ``reset()`` time. It builds an ``MrpPDConfig`` from the public properties
+listed below plus the spacecraft inertia read from ``vehConfigInMsg``, then constructs the algorithm via the
+two-phase init pattern.
 
 .. list-table:: Module I/O Messages
-    :widths: 25 25 50
+    :widths: 25 30 45
     :header-rows: 1
 
     * - Msg Variable Name
       - Msg Type
       - Description
-    * - vehConfigInMsg
-      - :ref:`VehicleConfigMsgPayload`
-      - Attitude guidance input message
-    * - guidInMsg
-      - :ref:`AttGuidMsgPayload`
-      - Vehicle configuration input message
     * - cmdTorqueOutMsg
-      - :ref:`CmdTorqueBodyMsgPayload`
-      - Commanded torque output message
+      - :ref:`CmdTorqueBodyMsgF32Payload`
+      - Commanded control torque output
+    * - guidInMsg
+      - :ref:`AttGuidMsgF32Payload`
+      - Attitude guidance input (required)
+    * - vehConfigInMsg
+      - :ref:`VehicleConfigMsgF32Payload`
+      - Vehicle configuration input -- supplies the spacecraft inertia (required)
 
+Configuration
+~~~~~~~~~~~~~
 
-Detailed Module Description
----------------------------
-This attitude feedback module using the MRP feedback control related to the control in section 8.4.1 in `Analytical Mechanics of Space Systems <http://dx.doi.org/10.2514/4.105210>`_:
+User-configurable parameters are exposed as public properties on the adapter and validated at ``reset()`` time via
+``MrpPDConfig::create``. The spacecraft inertia is not user-set; it is sourced from ``vehConfigInMsg`` at ``reset()``
+and passes through the same validator before the algorithm is constructed.
+
+.. list-table:: Configuration parameters
+    :widths: 22 14 14 14 36
+    :header-rows: 1
+
+    * - Parameter
+      - Type
+      - Units
+      - Default
+      - Description / valid range
+    * - ``K``
+      - float
+      - [N*m]
+      - 0
+      - Proportional gain on the MRP error :math:`\boldsymbol{\sigma}_{B/R}`. Must be ``>= 0``.
+    * - ``P``
+      - float
+      - [N*m*s]
+      - 0
+      - Rate-error feedback gain on :math:`{}^{B}\boldsymbol{\omega}_{B/R}`. Must be ``>= 0``.
+    * - ``knownTorquePntB_B``
+      - ``Eigen::Vector3f``
+      - [N*m]
+      - ``[0,0,0]``
+      - Feedforward known external torque about point :math:`B` in body-frame components. Must be finite.
+    * - ``spacecraftInertia`` (from ``vehConfigInMsg``)
+      - ``Eigen::Matrix3f``
+      - [kg*m^2]
+      - ``I``
+      - Spacecraft inertia tensor about point :math:`B` in body-frame components. Must be a valid inertia tensor
+        (symmetric positive-definite, with principal moments satisfying the triangle inequality).
+
+Two-Phase Initialization
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Subscribe inputs and set the public configuration properties before ``reset()`` is invoked. ::
+
+    module = mrpPDF32.MrpPD()
+    module.modelTag = "mrpPD"
+    module.K = 0.15
+    module.P = 150.0
+    module.knownTorquePntB_B = [0.0, 0.0, 0.0]
+
+    module.guidInMsg.subscribeTo(guid_msg)
+    module.vehConfigInMsg.subscribeTo(veh_config_msg)
+
+    sim.AddModelToTask(task_name, module)
+    sim.InitializeSimulation()
+    sim.ExecuteSimulation()
+
+If a required input message has not been connected when ``reset()`` runs, an ``std::invalid_argument`` is thrown.
+If any of the configuration parameters fail validation, ``MrpPDConfig::create`` throws an ``fsw::invalid_argument``.
+If ``updateState()`` is called before ``reset()``, an ``XmeraLifecycleException`` is thrown.
+
+Mathematical Formulation
+------------------------
+
+The ``mrpPD`` module implements the proportional-derivative MRP attitude feedback control law from section 8.4.1 of
+`Analytical Mechanics of Space Systems <http://doi.org/10.2514/4.105210>`__. The control torque is
 
 .. math::
-    {\mathbf L}_{r} =  -K \mathbf\sigma - [P] \delta\mathbf\omega   + [I]\dot{\mathbf\omega}_{r}
-            - \mathbf L
 
-Note that this control solution creates an external control torque which must be produced with a cluster of thrusters.  No reaction wheel information is used here.  Further, the feedback control component is a simple proportional and derivative feedback formulation.  As shown in `Analytical Mechanics of Space Systems <http://dx.doi.org/10.2514/4.105210>`_, this control can asymptotically track a general reference trajectory given by the reference frame :math:`\mathcal R`.
-The torque provided does not compute gyroscopic terms.
+    \boldsymbol{L}_{r} = -K\, \boldsymbol{\sigma}_{B/R}
+                        - P\, {}^{B}\boldsymbol{\omega}_{B/R}
+                        + [I]\, {}^{B}\dot{\boldsymbol{\omega}}_{R/N}
+                        - \boldsymbol{L},
 
-Module Assumptions and Limitations
-----------------------------------
-This control assumes the spacecraft is rigid and that the inertia tensor does not vary with time.
-The module does not add gyroscopic terms to the output torque.
+where :math:`\boldsymbol{\sigma}_{B/R}` and :math:`{}^{B}\boldsymbol{\omega}_{B/R}` are the attitude and rate
+tracking errors of the body frame :math:`\mathcal{B}` relative to the reference frame :math:`\mathcal{R}`,
+:math:`{}^{B}\dot{\boldsymbol{\omega}}_{R/N}` is the inertial angular acceleration of the reference frame in
+body-frame components, :math:`[I]` is the spacecraft inertia tensor about point :math:`B`, and :math:`\boldsymbol{L}`
+is the feedforward known external torque (``knownTorquePntB_B``).
 
-User Guide
-----------
-The required module configuration is::
+This control output is an external control torque, intended to be produced by a cluster of thrusters. No reaction
+wheel terms are present and no gyroscopic terms (no :math:`\boldsymbol{\omega}\times[I]\boldsymbol{\omega}`
+contribution) are added. As shown in the reference, the law can asymptotically track an arbitrary reference
+trajectory generated by :math:`\mathcal{R}` provided perfect inertia knowledge and no unmodeled dynamics.
 
-    module = mrpPD.mrpPD()
-    module.modelTag = "mrpPD"
-    module.setProportionalGainK(K)
-    module.setDerivativeGainP(P)
-    module.setKnownTorquePntB_B(knownTorquePntB_B)
+Required guidance inputs (read every cycle via ``guidInMsg``):
+
+- :math:`\boldsymbol{\sigma}_{B/R}` (``sigma_BR``)
+- :math:`{}^{B}\boldsymbol{\omega}_{B/R}` (``omega_BR_B``)
+- :math:`{}^{B}\dot{\boldsymbol{\omega}}_{R/N}` (``domega_RN_B``)
+
+Note that :math:`{}^{B}\boldsymbol{\omega}_{R/N}` is also present on ``AttGuidMsgF32Payload`` but is not consumed by
+this module.
+
+Reset
+~~~~~
+
+At ``reset()`` the adapter:
+
+1. Verifies ``guidInMsg`` and ``vehConfigInMsg`` are linked; throws ``std::invalid_argument`` otherwise.
+2. Reads :math:`[I]` from ``vehConfigInMsg``.
+3. Builds an ``MrpPDConfig`` from ``K``, ``P``, ``knownTorquePntB_B``, and the captured inertia.
+4. Constructs a fresh ``MrpPDAlgorithm`` with that configuration.
+
+Each ``reset()`` therefore produces a fully revalidated configuration; mid-run changes to public properties take
+effect at the next ``reset()`` call.
+
+Assumptions and Limitations
+---------------------------
+
+- The spacecraft is treated as a rigid body and the inertia tensor :math:`[I]` does not vary with time.
+- The control output does not include any reaction-wheel or gyroscopic terms.
+- The reference acceleration ``domega_RN_B`` is included verbatim in the control torque -- discontinuities in the
+  reference trajectory will appear directly in the output.
+- The output is single-precision FP32. With FP32 inputs and bounded magnitudes, expect relative accuracy on the
+  attitude- and rate-feedback terms on the order of :math:`10^{-7}`.

--- a/algorithms/mrpPD/mrpPDAlgorithm.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm.cpp
@@ -1,80 +1,12 @@
-#include "mrpPDAlgorithm.h"
-#include "../utilities/validInertiaCheck.h"
-#include "utilities/freestandingInvalidArgument.h"
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
-/*! Update method for mrpPD control algorithm. This method takes the attitude and rate errors relative to the
- reference frame, as well as the reference frame angular rates and acceleration, and computes the required control
- torque Lr.
- @return Eigen::Vector3f
- @param sigma_BR Body to reference MRP
- @param omega_BR_B Body to reference rate
- @param domega_RN_B Body to reference acceleration
-*/
+#include "mrpPDAlgorithm.h"
+
 Eigen::Vector3f MrpPDAlgorithm::update(const Eigen::Vector3f& sigma_BR,
                                        const Eigen::Vector3f& omega_BR_B,
                                        const Eigen::Vector3f& domega_RN_B) const {
-    // Compute required attitude control torque vector
-    const Eigen::Vector3f Lr = -this->proportionalGain * sigma_BR - this->feedbackGain * omega_BR_B +
-                               this->ISCPntB_B * domega_RN_B - this->knownTorquePntB_B;  // [Nm]
-
-    return Lr;
+    // L_r = -K sigma_BR - P omega_BR_B + [I] domega_RN_B - L_known   [N*m]
+    return -this->cfg.getProportionalGainK() * sigma_BR - this->cfg.getDerivativeGainP() * omega_BR_B +
+           this->cfg.getSpacecraftInertia() * domega_RN_B - this->cfg.getKnownTorquePntB_B();
 }
-
-/*! This method sets the spacecraft inertia according to the vehicle configuration input message
- @return void
- @param inertia Inertia matrix
-*/
-void MrpPDAlgorithm::setSpacecraftInertia(const Eigen::Matrix3f& inertia) {
-    if (!inertiaIsValid(inertia)) {
-        FSW_THROW_INVALID_ARGUMENT("Matrix inertia did not pass validity checks");
-    }
-    this->ISCPntB_B = inertia;
-}
-
-/*! This method gets the spacecraft inertia matrix
- @return Eigen::Matrix3f
-*/
-Eigen::Matrix3f MrpPDAlgorithm::getSpacecraftInertia() const { return this->ISCPntB_B; }
-
-/*! Setter method for the derivative gain P.
- @return void
- @param P [N*m*s] Rate error feedback gain applied
-*/
-void MrpPDAlgorithm::setDerivativeGainP(float P) {
-    if (P < 0.0) {
-        FSW_THROW_INVALID_ARGUMENT("Feedback gain P must not be negative");
-    }
-    this->feedbackGain = P;
-}
-
-/*! Getter method for the derivative gain P.
- @return float
-*/
-float MrpPDAlgorithm::getDerivativeGainP() const { return this->feedbackGain; }
-
-/*! Setter method for the known external torque about point B.
- @return void
- @param knownTorque [N*m] Known external torque expressed in body frame components about point B
-*/
-void MrpPDAlgorithm::setKnownTorquePntB_B(const Eigen::Vector3f& knownTorque) { this->knownTorquePntB_B = knownTorque; }
-
-/*! Getter method for the known torque about point B.
- @return const Eigen::Vector3f&
-*/
-const Eigen::Vector3f& MrpPDAlgorithm::getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }
-
-/*! Setter method for the proportional gain K.
- @return void
- @param K [rad/s] Proportional gain applied to MRP errors
-*/
-void MrpPDAlgorithm::setProportionalGainK(float K) {
-    if (K < 0.0) {
-        FSW_THROW_INVALID_ARGUMENT("Feedback gain K must not be negative");
-    }
-    this->proportionalGain = K;
-}
-
-/*! Getter method for the proportional gain K.
- @return float
-*/
-float MrpPDAlgorithm::getProportionalGainK() const { return this->proportionalGain; }

--- a/algorithms/mrpPD/mrpPDAlgorithm.h
+++ b/algorithms/mrpPD/mrpPDAlgorithm.h
@@ -1,36 +1,24 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
 #ifndef XMERAF32_MRP_PD_ALGORITHM_H
 #define XMERAF32_MRP_PD_ALGORITHM_H
 
-#include "utilities/freestandingInvalidArgument.h"
-#include "utilities/validInertiaCheck.h"
-#include <stdint.h>
+#include "mrpPDTypes.h"
 #include <Eigen/Core>
 
-/*! @brief MRP PD control algorithm class. */
-class MrpPDAlgorithm {
+class MrpPDAlgorithm final {
    public:
-    MrpPDAlgorithm() = default;
-    ~MrpPDAlgorithm() = default;
+    explicit MrpPDAlgorithm(const MrpPDConfig& config) : cfg(config) {}
+
+    void setConfig(const MrpPDConfig& config) { this->cfg = config; }
 
     Eigen::Vector3f update(const Eigen::Vector3f& sigma_BR,
                            const Eigen::Vector3f& omega_BR_B,
                            const Eigen::Vector3f& domega_RN_B) const;
-    void setSpacecraftInertia(const Eigen::Matrix3f& inertia);
-    Eigen::Matrix3f getSpacecraftInertia() const;
-    void setDerivativeGainP(float P);
-    float getDerivativeGainP() const;
-    void setKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B);
-    const Eigen::Vector3f& getKnownTorquePntB_B() const;
-    void setProportionalGainK(float K);
-    float getProportionalGainK() const;
 
    private:
-    float proportionalGain{};  //!< [rad/s] Proportional gain applied to MRP errors
-    float feedbackGain{};      //!< [N*m*s] Rate error feedback gain applied
-    Eigen::Vector3f knownTorquePntB_B =
-        Eigen::Vector3f::Zero();  //!< [N*m] Known external torque expressed in body frame components
-    Eigen::Matrix3f ISCPntB_B =
-        Eigen::Matrix3f::Identity();  //!< [kg*m^2] Spacecraft inertia about point B expressed in body frame components
+    MrpPDConfig cfg;
 };
 
 #endif

--- a/algorithms/mrpPD/mrpPDAlgorithm_c.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm_c.cpp
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2026 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ */
+
+#include "mrpPDAlgorithm_c.h"
+#include "architecture/utilities/eigenSupport.h"
+#include "mrpPDAlgorithm.h"
+#include "mrpPDTypes.h"
+
+#include <Eigen/Core>
+
+namespace {
+MrpPDConfig configFromC(const MrpPDConfig_c& c) {
+    return MrpPDConfig::create(c.K,
+                               c.P,
+                               cArrayToEigenVector3<float>(c.knownTorquePntB_B.data),
+                               cArrayToEigenMatrix3<float>(&c.spacecraftInertia.data[0][0]));
+}
+}  // namespace
+
+MrpPDAlgorithm* MrpPDAlgorithm_create(const MrpPDConfig_c* config) {
+    // clang-format off
+    return reinterpret_cast<MrpPDAlgorithm*>(new ::MrpPDAlgorithm(configFromC(*config)));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
+    // clang-format on
+}
+
+void MrpPDAlgorithm_destroy(MrpPDAlgorithm* self) {
+    // clang-format off
+    delete reinterpret_cast<::MrpPDAlgorithm*>(self);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
+    // clang-format on
+}
+
+void MrpPDAlgorithm_setConfig(MrpPDAlgorithm* self, const MrpPDConfig_c* config) {
+    // clang-format off
+    reinterpret_cast<::MrpPDAlgorithm*>(self)->setConfig(configFromC(*config));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    // clang-format on
+}
+
+Vector3f_c MrpPDAlgorithm_update(MrpPDAlgorithm* self,
+                                 const Vector3f_c* sigma_BR,
+                                 const Vector3f_c* omega_BR_B,
+                                 const Vector3f_c* domega_RN_B) {
+    const Eigen::Vector3f sigma_BR_e = cArrayToEigenVector3<float>(sigma_BR->data);
+    const Eigen::Vector3f omega_BR_B_e = cArrayToEigenVector3<float>(omega_BR_B->data);
+    const Eigen::Vector3f domega_RN_B_e = cArrayToEigenVector3<float>(domega_RN_B->data);
+
+    // clang-format off
+    const Eigen::Vector3f Lr = reinterpret_cast<::MrpPDAlgorithm*>(self)->update(sigma_BR_e, omega_BR_B_e, domega_RN_B_e);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    // clang-format on
+
+    Vector3f_c result{};
+    eigenVectorToCArray(Lr, result.data);
+    return result;
+}

--- a/algorithms/mrpPD/mrpPDAlgorithm_c.h
+++ b/algorithms/mrpPD/mrpPDAlgorithm_c.h
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2026 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+ */
+
+#ifndef XMERAF32_MRPPDALGORITHM_C_H
+#define XMERAF32_MRPPDALGORITHM_C_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Opaque handle to the C++ MrpPDAlgorithm instance.
+ */
+typedef struct MrpPDAlgorithm MrpPDAlgorithm;
+
+/**
+ * @brief POD representation of a 3-vector (Eigen::Vector3f).
+ */
+typedef struct {
+    float data[3];
+} Vector3f_c;
+
+/**
+ * @brief POD representation of a 3x3 matrix (Eigen::Matrix3f).
+ */
+typedef struct {
+    float data[3][3];
+} Matrix3f_c;
+
+/**
+ * @brief Plain-old-data mirror of the C++ MrpPDConfig fields.
+ *
+ * Caller fills this struct and passes it to MrpPDAlgorithm_create or _setConfig. The C++ side
+ * validates each field via MrpPDConfig::create and throws on invalid input.
+ *  - K and P must be >= 0
+ *  - knownTorquePntB_B must be finite
+ *  - spacecraftInertia must be a valid inertia tensor (symmetric positive-definite, triangle
+ *    inequality on principal moments)
+ */
+typedef struct {
+    float K;
+    float P;
+    Vector3f_c knownTorquePntB_B;
+    Matrix3f_c spacecraftInertia;
+} MrpPDConfig_c;
+
+/**
+ * @brief Construct a new MrpPDAlgorithm instance from the supplied configuration.
+ * @param config Pointer to the configuration to apply (validated; throws on invalid input).
+ * @return Pointer to a new MrpPDAlgorithm (must be destroyed).
+ */
+MrpPDAlgorithm* MrpPDAlgorithm_create(const MrpPDConfig_c* config);
+
+/**
+ * @brief Destroy a previously created MrpPDAlgorithm.
+ * @param self Pointer to the instance to destroy.
+ */
+void MrpPDAlgorithm_destroy(MrpPDAlgorithm* self);
+
+/**
+ * @brief Replace the algorithm's configuration at runtime.
+ * @param self   Pointer to the instance.
+ * @param config Pointer to the configuration to apply (validated; throws on invalid input).
+ */
+void MrpPDAlgorithm_setConfig(MrpPDAlgorithm* self, const MrpPDConfig_c* config);
+
+/**
+ * @brief Compute the required attitude control torque Lr.
+ * @param self        Pointer to the instance.
+ * @param sigma_BR    Body-to-reference MRP attitude error.
+ * @param omega_BR_B  Body-to-reference angular rate error in B-frame components.
+ * @param domega_RN_B Reference frame inertial angular acceleration in B-frame components.
+ * @return Vector3f_c [N*m] commanded control torque about point B in B-frame components.
+ */
+Vector3f_c MrpPDAlgorithm_update(MrpPDAlgorithm* self,
+                                 const Vector3f_c* sigma_BR,
+                                 const Vector3f_c* omega_BR_B,
+                                 const Vector3f_c* domega_RN_B);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // XMERAF32_MRPPDALGORITHM_C_H

--- a/algorithms/mrpPD/mrpPDF32.i
+++ b/algorithms/mrpPD/mrpPDF32.i
@@ -5,8 +5,8 @@
 %}
 
 %include <attribute.i>
-%attribute(MrpPD, float, K, getProportionalGainK, setProportionalGainK)
-%attribute(MrpPD, float, P, getDerivativeGainP, setDerivativeGainP)
+%attribute(MrpPD, float, K, getK, setK)
+%attribute(MrpPD, float, P, getP, setP)
 %attribute(MrpPD, Eigen::Vector3f, knownTorquePntB_B, getKnownTorquePntB_B, setKnownTorquePntB_B)
 
 %include <std_string.i>

--- a/algorithms/mrpPD/mrpPDF32.i
+++ b/algorithms/mrpPD/mrpPDF32.i
@@ -4,16 +4,12 @@
    #include "utilities/timeConstants.h"
 %}
 
-%include <attribute.i>
-%attribute(MrpPD, float, K, getK, setK)
-%attribute(MrpPD, float, P, getP, setP)
-%attribute(MrpPD, Eigen::Vector3f, knownTorquePntB_B, getKnownTorquePntB_B, setKnownTorquePntB_B)
-
-%include <std_string.i>
+%include <architecture/_GeneralModuleFiles/sys_model.i>
 %include <architecture/_GeneralModuleFiles/swig_conly_data.i>
 %include <architecture/_GeneralModuleFiles/swig_eigen.i>
 
-%include <architecture/_GeneralModuleFiles/sys_model.i>
+%include "mrpPDTypes.h"
+%include "mrpPDAlgorithm.h"
 %include "mrpPD.h"
 
 %include "msgPayloadDef/AttGuidMsgF32Payload.h"

--- a/algorithms/mrpPD/mrpPDTypes.h
+++ b/algorithms/mrpPD/mrpPDTypes.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
+#ifndef XMERAF32_MRP_PD_TYPES_H
+#define XMERAF32_MRP_PD_TYPES_H
+
+#include "utilities/freestandingInvalidArgument.h"
+#include "utilities/validInertiaCheck.h"
+#include <Eigen/Core>
+
+class MrpPDConfig final {
+   public:
+    static MrpPDConfig create(float proportionalGainK,
+                              float derivativeGainP,
+                              const Eigen::Vector3f& knownTorquePntB_B,
+                              const Eigen::Matrix3f& spacecraftInertia) {
+        if (!isValidProportionalGainK(proportionalGainK)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpPD: proportionalGainK must be non-negative");
+        }
+        if (!isValidDerivativeGainP(derivativeGainP)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpPD: derivativeGainP must be non-negative");
+        }
+        if (!isValidKnownTorquePntB_B(knownTorquePntB_B)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpPD: knownTorquePntB_B must be finite");
+        }
+        if (!isValidSpacecraftInertia(spacecraftInertia)) {
+            FSW_THROW_INVALID_ARGUMENT("mrpPD: spacecraftInertia must pass inertia validity checks");
+        }
+        return {proportionalGainK, derivativeGainP, knownTorquePntB_B, spacecraftInertia};
+    }
+
+    static bool isValidProportionalGainK(float proportionalGainK) { return proportionalGainK >= 0.0F; }
+    static bool isValidDerivativeGainP(float derivativeGainP) { return derivativeGainP >= 0.0F; }
+    static bool isValidKnownTorquePntB_B(const Eigen::Vector3f& knownTorquePntB_B) {
+        return knownTorquePntB_B.allFinite();
+    }
+    static bool isValidSpacecraftInertia(const Eigen::Matrix3f& spacecraftInertia) {
+        return inertiaIsValid(spacecraftInertia);
+    }
+
+    float getProportionalGainK() const { return this->proportionalGainK; }
+    float getDerivativeGainP() const { return this->derivativeGainP; }
+    const Eigen::Vector3f& getKnownTorquePntB_B() const { return this->knownTorquePntB_B; }
+    const Eigen::Matrix3f& getSpacecraftInertia() const { return this->spacecraftInertia; }
+
+   private:
+    MrpPDConfig(float proportionalGainK,
+                float derivativeGainP,
+                const Eigen::Vector3f& knownTorquePntB_B,
+                const Eigen::Matrix3f& spacecraftInertia)
+        : proportionalGainK(proportionalGainK),
+          derivativeGainP(derivativeGainP),
+          knownTorquePntB_B(knownTorquePntB_B),
+          spacecraftInertia(spacecraftInertia) {}
+
+    float proportionalGainK;
+    float derivativeGainP;
+    Eigen::Vector3f knownTorquePntB_B;
+    Eigen::Matrix3f spacecraftInertia;
+};
+
+#endif


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR refactors mrpPD by adding the configuration validation object pattern of construction. This pattern allows the caller to construct an instance of the algorithm that is correct by construction. Additionally , the PR adds a C shim. Finally, the C++ tests (property, edge case, Config validation) are expanded.

## Verification
CI runs successfully.

## Documentation
NA

## Future work
None
