### PR TITLE
Remove unused include in attTrackingError tests

### DIFF
--- a/algorithms/attTrackingError/_tests/test_attTrackingError.cpp
+++ b/algorithms/attTrackingError/_tests/test_attTrackingError.cpp
@@ -1,8 +1,6 @@
 #include "attTrackingErrorTestHelpers.hpp"
-#include "fp32-fsw-xmera/algorithms/attTrackingError/attTrackingErrorTypes.h"
 
 #include <gtest/gtest.h>
-#include <cmath>
 
 TEST(attTrackingErrorTest, RegressionTest) {
     regressionTestAttTrackingError(Eigen::Vector3f{0.2f, -0.1f, -0.4f},


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
The file `test_attTrackingError.cpp` includes a file at an incorrect path which it doesn't use. The unused includes were removed.

## Verification
Tests pass.

## Documentation
None

## Future work
None
