### PR TITLE
Remove C++ types from c-shim interface

### DIFF
--- a/.github/workflows/downstream-build.yml
+++ b/.github/workflows/downstream-build.yml
@@ -1,0 +1,65 @@
+name: "Downstream Build (adamant-xmera-components)"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  downstream-test:
+    name: adamant-xmera-components test_all
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false }}
+    container:
+      image: ghcr.io/lasp/adamant:0.2
+      options: --user root
+    steps:
+      - name: Check out adamant-xmera-components
+        uses: actions/checkout@v4
+        with:
+          set-safe-directory: true
+          repository: lasp/adamant-xmera-components
+          path: adamant-xmera-components
+          persist-credentials: false
+
+      - name: Check out fp32-fsw-xmera at PR head
+        uses: actions/checkout@v4
+        with:
+          set-safe-directory: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: fp32-fsw-xmera
+          persist-credentials: false
+
+      - name: Clone adamant repository
+        uses: actions/checkout@v4
+        with:
+          set-safe-directory: true
+          repository: lasp/adamant
+          path: adamant
+          persist-credentials: false
+
+      - name: Clone Eigen with freestanding support
+        uses: actions/checkout@v4
+        with:
+          set-safe-directory: true
+          repository: lasp/eigen
+          path: eigen
+          ref: feature/freestanding
+          persist-credentials: false
+
+      - name: Run downstream unit tests and coverage
+        run: bash adamant-xmera-components/env/github_run.sh "redo adamant-xmera-components/coverage_all"
+
+      - name: Archive build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: downstream-test-logs
+          path: ${{ github.workspace }}/adamant-xmera-components/build
+          if-no-files-found: ignore

--- a/algorithms/rateControl/rateControlAlgorithm_c.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm_c.cpp
@@ -1,5 +1,5 @@
 #include "rateControlAlgorithm_c.h"
-
+#include "architecture/utilities/eigenSupport.h"
 #include "rateControlAlgorithm.h"
 
 #include <Eigen/Core>
@@ -12,17 +12,24 @@ void RateControlAlgorithm_destroy(RateControlAlgorithm* self) {
     delete reinterpret_cast<::RateControlAlgorithm*>(self);
 }
 
-Eigen::Vector3f RateControlAlgorithm_update(const RateControlAlgorithm* self,
-                                            const Eigen::Vector3f& omega_BR_B,
-                                            const Eigen::Vector3f& domega_RN_B) {
-    return reinterpret_cast<const ::RateControlAlgorithm*>(self)->update(omega_BR_B, domega_RN_B);
+Vector3f_c RateControlAlgorithm_update(const RateControlAlgorithm* self,
+                                       const Vector3f_c& omega_BR_B,
+                                       const Vector3f_c& domega_RN_B) {
+    const Eigen::Vector3f vec_omega_BR_B = cArrayToEigenVector3(omega_BR_B.data);
+    const Eigen::Vector3f vec_domega_RN_B = cArrayToEigenVector3(domega_RN_B.data);
+    const Eigen::Vector3f vec =
+        reinterpret_cast<const ::RateControlAlgorithm*>(self)->update(vec_omega_BR_B, vec_domega_RN_B);
+    Vector3f_c out{};
+    eigenVectorToCArray(vec, out.data);
+    return out;
 }
 
-void RateControlAlgorithm_setSpacecraftInertia(RateControlAlgorithm* self, const Eigen::Matrix3f& spacecraftInertia) {
-    reinterpret_cast<::RateControlAlgorithm*>(self)->setSpacecraftInertia(spacecraftInertia);
+void RateControlAlgorithm_setSpacecraftInertia(RateControlAlgorithm* self, const Matrix3f_c& spacecraftInertia) {
+    reinterpret_cast<::RateControlAlgorithm*>(self)->setSpacecraftInertia(
+        c2DArrayToEigenMatrix3(spacecraftInertia.data));
 }
 
-void RateControlAlgorithm_setDerivativeGainP(RateControlAlgorithm* self, float P) {
+void RateControlAlgorithm_setDerivativeGainP(RateControlAlgorithm* self, const float P) {
     reinterpret_cast<::RateControlAlgorithm*>(self)->setDerivativeGainP(P);
 }
 
@@ -30,17 +37,14 @@ float RateControlAlgorithm_getDerivativeGainP(const RateControlAlgorithm* self) 
     return reinterpret_cast<const ::RateControlAlgorithm*>(self)->getDerivativeGainP();
 }
 
-void RateControlAlgorithm_setKnownTorquePntB_B(RateControlAlgorithm* self, Vector3f_c knownTorquePntB_B) {
-    Eigen::Vector3f eigenVec;
-    eigenVec << knownTorquePntB_B.data[0], knownTorquePntB_B.data[1], knownTorquePntB_B.data[2];
+void RateControlAlgorithm_setKnownTorquePntB_B(RateControlAlgorithm* self, const Vector3f_c knownTorquePntB_B) {
+    const Eigen::Vector3f eigenVec = cArrayToEigenVector3(knownTorquePntB_B.data);
     reinterpret_cast<::RateControlAlgorithm*>(self)->setKnownTorquePntB_B(eigenVec);
 }
 
 Vector3f_c RateControlAlgorithm_getKnownTorquePntB_B(const RateControlAlgorithm* self) {
     const Eigen::Vector3f& eigenVec = reinterpret_cast<const ::RateControlAlgorithm*>(self)->getKnownTorquePntB_B();
-    Vector3f_c out;
-    out.data[0] = eigenVec[0];
-    out.data[1] = eigenVec[1];
-    out.data[2] = eigenVec[2];
+    Vector3f_c out{};
+    eigenVectorToCArray(eigenVec, out.data);
     return out;
 }

--- a/algorithms/rateControl/rateControlAlgorithm_c.h
+++ b/algorithms/rateControl/rateControlAlgorithm_c.h
@@ -1,8 +1,6 @@
 #ifndef F32XIMERA_RATE_CONTROL_ALGORITHM_C_H
 #define F32XIMERA_RATE_CONTROL_ALGORITHM_C_H
 
-#include <Eigen/Core>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -11,6 +9,13 @@ extern "C" {
  * @brief Opaque handle to the C++ RateControlAlgorithm instance.
  */
 typedef struct RateControlAlgorithm RateControlAlgorithm;
+
+/**
+ * @brief POD representation of a 3x3 matrix (Eigen::Matrix3f).
+ */
+typedef struct {
+    float data[3][3];
+} Matrix3f_c;
 
 /**
  * @brief POD representation of a 3-vector (Eigen::Vector3f).
@@ -38,16 +43,16 @@ void RateControlAlgorithm_destroy(RateControlAlgorithm* self);
  * @param domega_RN_B  Time derivative of reference frame angular velocity in body frame components [rad/s^2].
  * @return Eigen::Vector3f Required control torque about point B [Nm].
  */
-Eigen::Vector3f RateControlAlgorithm_update(const RateControlAlgorithm* self,
-                                            const Eigen::Vector3f& omega_BR_B,
-                                            const Eigen::Vector3f& domega_RN_B);
+Vector3f_c RateControlAlgorithm_update(const RateControlAlgorithm* self,
+                                       const Vector3f_c& omega_BR_B,
+                                       const Vector3f_c& domega_RN_B);
 
 /**
  * @brief Set the spacecraft inertia configuration.
  * @param self Pointer to the instance.
  * @param vehicleConfigIn Pointer to the vehicle configuration payload.
  */
-void RateControlAlgorithm_setSpacecraftInertia(RateControlAlgorithm* self, const Eigen::Matrix3f& spacecraftInertia);
+void RateControlAlgorithm_setSpacecraftInertia(RateControlAlgorithm* self, const Matrix3f_c& spacecraftInertia);
 
 /**
  * @brief Set the derivative gain P.

--- a/architecture/utilities/eigenSupport.h
+++ b/architecture/utilities/eigenSupport.h
@@ -1,10 +1,79 @@
+// SPDX-License-Identifier: ISC
+// Copyright (c) 2015, Autonomous Vehicle System Lab, University of Colorado at Boulder
+// Copyright (c) 2025, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
+
 #ifndef EIGEN_SUPPORT
 #define EIGEN_SUPPORT
 
 #include <architecture/utilities/eigenMRP.h>
 
 #include <Eigen/Core>
+#include <cstring>
 #include <exception>
+
+// =============================================================================
+// Design goals for this header
+// =============================================================================
+//
+// This header bridges Eigen types and plain C arrays at the boundary with
+// Ada/SWIG/message-buffer code. The functions below already follow a small
+// set of conventions; the rules are stated here so that future contributions
+// stay consistent and so deviations are easy to spot.
+//
+// 1. Two directions, two parameter conventions.
+//    Output-side functions (Eigen -> C array) take the destination as a sized
+//    array reference `T (&out)[N]` so the buffer length is deduced and bounds
+//    are checked at compile time. Input-side functions (C array -> Eigen)
+//    take a `const ScalarT*` because callers commonly hand them stride-indexed
+//    offsets into larger buffers (e.g. `&GsMatrix_B[i * 3]`) or struct member
+//    arrays - array-reference parameters would force those callers into
+//    awkward casts. The `cArrayToEigenVector` overload is the exception (its
+//    size is part of the contract) and accepts `const ScalarT (&)[size]`.
+//
+// 2. Compile-time shape enforcement when the type carries it.
+//    Fixed-size variants (`eigenMatrixToCArray`, `eigenMatrixToCArray2D`,
+//    `eigenVectorToCArray`, `cArrayToEigenMatrix`, `cArrayToEigenVector3`,
+//    `cArrayToEigenMatrix3`, `c2DArrayToEigenMatrix3`, `eigenTilde`) use
+//    `static_assert` on `RowsAtCompileTime` / `ColsAtCompileTime` and on
+//    destination size. Compile-time fixed sizes are regularly valuable in
+//    embedded / flight-software contexts - they enable static stack
+//    reasoning, eliminate heap allocation, and surface shape mismatches
+//    before the binary leaves the developer's machine - and the FSW side
+//    of this codebase prefers them by default. Dynamic-size variants (named
+//    with an `X` infix: `eigenMatrixXToCArray`, `eigenMatrixXToCArray2D`,
+//    `eigenMatrixXInsertCArray`, `cArrayToEigenMatrixX`) fall back to runtime
+//    checks and `std::terminate()` on shape or capacity violations. The
+//    dynamic variants exist for host-PC / Xmera simulation modules where
+//    shapes legitimately depend on runtime configuration (variable-length
+//    sensor arrays, scenario-driven reaction wheel counts, etc.) and the
+//    FSW compile-time guarantees aren't applicable.
+//
+// 3. Row-major C array convention, regardless of Eigen storage order.
+//    All matrix <-> C-array conversions read and write row-major. Column-
+//    major Eigen inputs are transposed internally; row-major inputs go
+//    through unchanged. Callers don't need to reason about Eigen's default
+//    storage order.
+//
+// 4. Accept any Eigen expression on the output side.
+//    Output-side functions take `const Eigen::MatrixBase<Derived>&`, not
+//    concrete `Eigen::Matrix`/`Vector`. This admits `Zero()`, `Ones()`,
+//    `Constant(...)`, `transpose()`, `block<...>()`, and segment views in
+//    addition to plain matrix/vector variables. Internal evaluation to a
+//    `PlainObject` handles non-contiguous expressions safely.
+//
+// 5. Const correctness on inputs.
+//    Input parameters are const-qualified (`const ScalarT*`,
+//    `const ScalarT (&)[N]`, `const Eigen::MatrixBase<Derived>&`).
+//    `const`-qualified C arrays must be acceptable - regression tests in
+//    `tests/test_eigenSupport.cpp` enforce this for each input-side
+//    function, so removing `const` somewhere will fail to compile.
+//
+// 6. Fail loudly.
+//    Compile-time violations use `static_assert` with a message identifying
+//    which constraint failed. Runtime violations on dynamic variants call
+//    `std::terminate()` rather than throwing or silently truncating.
+//
+// =============================================================================
 
 template <class Derived>
 inline constexpr bool is_row_major_v = (Eigen::internal::traits<Derived>::Flags & Eigen::RowMajorBit) != 0;
@@ -184,16 +253,28 @@ void eigenMatrixXInsertCArray(const Eigen::MatrixBase<Derived>& inMat,
 }
 
 /**
- * @brief Copy a fixed-size Eigen vector into a contiguous C array.
+ * @brief Copy a fixed-size Eigen column-vector expression into a C array.
  *
- * @tparam ScalarT Scalar type stored in the vector.
- * @tparam size Compile-time number of elements.
- * @param inVec Vector whose contents should be copied.
- * @param outArray Pointer to a C array with at least `size` elements.
+ * Accepts any fixed-size Eigen expression that resolves to a column vector
+ * (concrete `Eigen::Vector<T, N>`, `Vector::Zero()`, `block<N, 1>()`, etc.).
+ * The destination is a sized C array; its length is enforced at compile time
+ * to match the vector length.
+ *
+ * @tparam Derived Fixed-size Eigen column-vector expression type.
+ * @tparam size Extent of the destination array (must equal vector length).
+ * @param inVec Vector expression whose contents should be copied.
+ * @param out Destination array that receives the entries.
  */
-template <typename ScalarT, int size>
-void eigenVectorToCArray(const Eigen::Vector<ScalarT, size>& inVec, ScalarT* outArray) {
-    std::copy(inVec.data(), inVec.data() + size, outArray);
+template <class Derived, std::size_t size>
+void eigenVectorToCArray(const Eigen::MatrixBase<Derived>& inVec, typename Derived::Scalar (&out)[size]) {
+    static_assert(Derived::RowsAtCompileTime != Eigen::Dynamic && Derived::ColsAtCompileTime != Eigen::Dynamic,
+                  "Input must be a fixed-size Eigen type.");
+    static_assert(Derived::ColsAtCompileTime == 1, "Input must be a column vector.");
+    static_assert(static_cast<std::size_t>(Derived::RowsAtCompileTime) == size,
+                  "Output array size must equal vector length.");
+
+    const typename Derived::PlainObject evaluated = inVec;
+    std::copy(evaluated.data(), evaluated.data() + size, out);
 }
 
 /**
@@ -281,14 +362,17 @@ Eigen::Matrix3<ScalarT> cArrayToEigenMatrix3(const ScalarT* inArray) {
 /**
  * @brief Copy a 3×3 C two-dimensional array into an Eigen 3×3 matrix.
  *
+ * Both dimensions are enforced at compile time via the array reference
+ * parameter, and the input is const-qualified for consistency with the rest
+ * of the input-side conversion functions.
+ *
  * @tparam ScalarT Scalar type of the matrix.
  * @param in2DArray Source array with bounds `[3][3]`.
  * @return Eigen::Matrix3 containing the same entries.
  */
 template <typename ScalarT>
-Eigen::Matrix3<ScalarT> c2DArrayToEigenMatrix3(ScalarT in2DArray[3][3]) {
-    Eigen::Matrix3<ScalarT> outMat = Eigen::Map<const Eigen::Matrix<ScalarT, 3, 3, Eigen::RowMajor>>(&in2DArray[0][0]);
-    return outMat;
+Eigen::Matrix3<ScalarT> c2DArrayToEigenMatrix3(const ScalarT (&in2DArray)[3][3]) {
+    return Eigen::Map<const Eigen::Matrix<ScalarT, 3, 3, Eigen::RowMajor>>(&in2DArray[0][0]);
 }
 
 /**
@@ -351,12 +435,28 @@ Eigen::Matrix3<ScalarT> eigenM3(ScalarT angle) {
 /**
  * @brief Construct the skew-symmetric matrix such that `[tilde(vec)] * b = vec × b`.
  *
- * @tparam Derived Eigen vector expression type.
+ * Accepts either a fixed-size 3-element column vector (shape checked at
+ * compile time via `static_assert`) or a dynamic-size expression that is
+ * 3×1 at runtime (shape checked via `std::terminate()`). This mirrors the
+ * suite-wide split between fixed and dynamic variants documented at the
+ * top of this header.
+ *
+ * @tparam Derived Eigen 3-vector expression type.
  * @param vec Vector whose associated tilde matrix is requested.
  * @return Eigen::Matrix3 representing the skew-symmetric cross-product matrix.
  */
 template <typename Derived>
 Eigen::Matrix3<typename Eigen::MatrixBase<Derived>::Scalar> eigenTilde(const Eigen::MatrixBase<Derived>& vec) {
+    static_assert((Derived::RowsAtCompileTime == 3 || Derived::RowsAtCompileTime == Eigen::Dynamic) &&
+                      (Derived::ColsAtCompileTime == 1 || Derived::ColsAtCompileTime == Eigen::Dynamic),
+                  "eigenTilde requires a 3-element column vector (fixed-size or dynamic).");
+
+    if constexpr (Derived::RowsAtCompileTime == Eigen::Dynamic || Derived::ColsAtCompileTime == Eigen::Dynamic) {
+        if (vec.rows() != 3 || vec.cols() != 1) {
+            std::terminate();
+        }
+    }
+
     using Scalar = Eigen::MatrixBase<Derived>::Scalar;
 
     const Scalar vx = vec(0);


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The rateControl C-shim had C++ types on the C-shim interface. This PR removes those types from the interface.

## Verification
CI builds and runs.

## Documentation
NA

## Future work
None
