### PR TITLE
Add Jenkins CI workflow for Renode unit tests

### DIFF
--- a/.github/workflows/trigger_jenkins_renode.yml
+++ b/.github/workflows/trigger_jenkins_renode.yml
@@ -1,0 +1,288 @@
+# Triggers the Jenkins Renode unit-test job and waits for its result.
+# The GH Action's pass/fail mirrors the Jenkins build, so the check on
+# the PR is the commit status -- no separate Jenkins -> GitHub callback
+# is required.
+#
+# Required repository secrets:
+#   JENKINS_URL               Jenkins instance base URL (no trailing slash)
+#   JENKINS_WEBHOOK_TOKEN     Generic Webhook Trigger token on the Jenkins job
+#   JENKINS_USER              Jenkins service-account username (for API polling)
+#   JENKINS_API_TOKEN         Jenkins API token for that user
+#   CF_ACCESS_CLIENT_ID       Cloudflare Access service token client ID
+#   CF_ACCESS_CLIENT_SECRET   Cloudflare Access service token client secret
+name: Trigger Jenkins Renode Unit Tests
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+    inputs:
+      fp32_fsw_xmera_ref:
+        description: "fp32-fsw-xmera ref (default: PR head SHA / push SHA)"
+        required: false
+        type: string
+      adamant_xmera_components_ref:
+        description: "adamant-xmera-components ref (default: Jenkins job's hardcoded fallback)"
+        required: false
+        type: string
+      adamant_ref:
+        description: "adamant ref (default: Jenkins job's hardcoded fallback)"
+        required: false
+        type: string
+      adamant_example_ref:
+        description: "adamant_example ref (default: Jenkins job's hardcoded fallback)"
+        required: false
+        type: string
+      project_ref:
+        description: "downstream project repo ref (default: Jenkins job's hardcoded fallback)"
+        required: false
+        type: string
+# Cancel any in-flight run on the same ref when a new push arrives. The
+# cleanup step at the end of the job propagates the cancellation to
+# Jenkins so the superseded build doesn't keep occupying an executor.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  trigger_job:
+    name: trigger_jenkins_renode
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      JENKINS_URL: ${{ secrets.JENKINS_URL }}
+      CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+      CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+      # === Per-CI-run pins ============================================
+      # Uncomment a line below to pin a sibling repo's ref for THIS
+      # branch's CI runs (e.g. one-off DROP / integration testing without
+      # touching Jenkins UI). workflow_dispatch inputs still win over a
+      # PIN; revert (or comment back) before merging.
+      # ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/your-branch-here'
+      # ADAMANT_REF_PIN: 'feature/your-branch-here'
+      # ADAMANT_EXAMPLE_REF_PIN: 'feature/your-branch-here'
+      # PROJECT_REF_PIN: 'feature/your-branch-here'
+    steps:
+      - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
+      - name: Resolve commit SHA
+        id: sha
+        run: |
+          set -euo pipefail
+          SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          if [ -z "$SHA" ]; then
+            echo "Could not resolve a commit SHA from this event."
+            exit 1
+          fi
+          echo "Resolved SHA: $SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+      - name: Trigger Jenkins generic-webhook
+        id: trigger
+        env:
+          JENKINS_WEBHOOK_TOKEN: ${{ secrets.JENKINS_WEBHOOK_TOKEN }}
+          COMMIT_SHA: ${{ steps.sha.outputs.sha }}
+          # FP32 has no PIN: PR builds must always test the PR head SHA.
+          FP32_REF_OVERRIDE: ${{ inputs.fp32_fsw_xmera_ref || '' }}
+          AXC_REF_OVERRIDE: ${{ inputs.adamant_xmera_components_ref || env.ADAMANT_XMERA_COMPONENTS_REF_PIN || '' }}
+          ADAMANT_REF_OVERRIDE: ${{ inputs.adamant_ref || env.ADAMANT_REF_PIN || '' }}
+          ADAMANT_EXAMPLE_REF_OVERRIDE: ${{ inputs.adamant_example_ref || env.ADAMANT_EXAMPLE_REF_PIN || '' }}
+          PROJECT_REF_OVERRIDE: ${{ inputs.project_ref || env.PROJECT_REF_PIN || '' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${JENKINS_URL:-}" ]; then
+            echo "JENKINS_URL secret is not set on this repository."
+            exit 1
+          fi
+          if [ -z "${JENKINS_WEBHOOK_TOKEN:-}" ]; then
+            echo "JENKINS_WEBHOOK_TOKEN secret is not set on this repository."
+            exit 1
+          fi
+          # fp32-fsw-xmera ref defaults to the resolved PR/push SHA;
+          # workflow_dispatch can override it explicitly.
+          FP32_REF="${FP32_REF_OVERRIDE:-$COMMIT_SHA}"
+          # Build the payload, omitting any optional override that wasn't set.
+          BODY=$(jq -n \
+            --arg fp32 "$FP32_REF" \
+            --arg axc "$AXC_REF_OVERRIDE" \
+            --arg adamant "$ADAMANT_REF_OVERRIDE" \
+            --arg ax_ex "$ADAMANT_EXAMPLE_REF_OVERRIDE" \
+            --arg project "$PROJECT_REF_OVERRIDE" \
+            '{fp32_fsw_xmera_ref: $fp32}
+             + (if $axc != "" then {adamant_xmera_components_ref: $axc} else {} end)
+             + (if $adamant != "" then {adamant_ref: $adamant} else {} end)
+             + (if $ax_ex != "" then {adamant_example_ref: $ax_ex} else {} end)
+             + (if $project != "" then {project_ref: $project} else {} end)')
+          TRIGGER_URL="${JENKINS_URL}/generic-webhook-trigger/invoke"
+          echo "POST ${TRIGGER_URL}?token=***"
+          echo "Body: ${BODY}"
+          # Intentionally no --retry: Jenkins's Generic Webhook Trigger has no
+          # idempotency key, so a retried POST after a lost response would queue
+          # a duplicate build. Network failure should fail the workflow loudly.
+          RESPONSE=$(curl --max-time 120 \
+            -sS -w '\n__HTTP_STATUS__:%{http_code}' \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            --data-binary "${BODY}" \
+            "${TRIGGER_URL}?token=${JENKINS_WEBHOOK_TOKEN}")
+          HTTP_CODE="${RESPONSE##*__HTTP_STATUS__:}"
+          RESP_BODY="${RESPONSE%__HTTP_STATUS__:*}"
+          RESP_BODY="${RESP_BODY%$'\n'}"
+          echo "HTTP ${HTTP_CODE}"
+          echo "${RESP_BODY}"
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Jenkins returned non-200 status."
+            exit 1
+          fi
+          QUEUE_PATH=$(echo "${RESP_BODY}" | jq -r '[.jobs | to_entries[] | select(.value.triggered == true)][0].value.url // empty')
+          JOB_NAME=$(echo "${RESP_BODY}" | jq -r '[.jobs | to_entries[] | select(.value.triggered == true)][0].key // empty')
+          if [ -z "${QUEUE_PATH}" ]; then
+            echo "Jenkins accepted the request but no jobs reported triggered=true."
+            echo "  Likely a regexpFilter mismatch in the Generic Webhook Trigger config."
+            exit 1
+          fi
+          QUEUE_URL="${JENKINS_URL}/${QUEUE_PATH}"
+          echo "Triggered: ${JOB_NAME}"
+          echo "Queue:     ${QUEUE_URL}"
+          echo "queue_url=${QUEUE_URL}" >> "$GITHUB_OUTPUT"
+          echo "job_name=${JOB_NAME}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Jenkins job triggered"
+            echo ""
+            echo "- **Job:** \`${JOB_NAME}\`"
+            echo "- **Commit:** \`${COMMIT_SHA}\`"
+            echo "- **Queue:** ${QUEUE_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Wait for Jenkins build to start
+        id: wait_start
+        env:
+          JENKINS_USER: ${{ secrets.JENKINS_USER }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+          QUEUE_URL: ${{ steps.trigger.outputs.queue_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${JENKINS_USER:-}" ] || [ -z "${JENKINS_API_TOKEN:-}" ]; then
+            echo "JENKINS_USER and JENKINS_API_TOKEN secrets must be set to poll build status."
+            exit 1
+          fi
+          if [ -z "${CF_ACCESS_CLIENT_ID:-}" ] || [ -z "${CF_ACCESS_CLIENT_SECRET:-}" ]; then
+            echo "CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET must be set to reach Jenkins API through Cloudflare Access."
+            exit 1
+          fi
+          echo "Polling queue: ${QUEUE_URL}"
+          # Wait up to 45 minutes for an executor to pick up the build (540 * 5s).
+          # Renode builds can't run in parallel on this Jenkins, so concurrent
+          # PR triggers from this and sibling repos serialize through the queue.
+          for i in $(seq 1 540); do
+            Q=$(curl -sS --max-time 30 \
+              -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+              -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+              --user "${JENKINS_USER}:${JENKINS_API_TOKEN}" \
+              "${QUEUE_URL}api/json")
+            CANCELLED=$(echo "$Q" | jq -r '.cancelled // false')
+            if [ "$CANCELLED" = "true" ]; then
+              echo "Build was cancelled while in queue."
+              exit 1
+            fi
+            EXEC_URL=$(echo "$Q" | jq -r '.executable.url // empty')
+            if [ -n "$EXEC_URL" ]; then
+              # Jenkins advertises itself with its internal address; rewrite to the
+              # Cloudflare-fronted host so the runner can actually reach it.
+              EXEC_PATH="${EXEC_URL#http*://*/}"
+              BUILD_URL="${JENKINS_URL}/${EXEC_PATH}"
+              echo "Build started: ${BUILD_URL}"
+              echo "build_url=${BUILD_URL}" >> "$GITHUB_OUTPUT"
+              {
+                echo ""
+                echo "### Build started"
+                echo "${BUILD_URL}"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            REASON=$(echo "$Q" | jq -r '.why // "queued"')
+            echo "Waiting for executor ($i/540): ${REASON}"
+            sleep 5
+          done
+          echo "Build never started within 45 minutes."
+          exit 1
+      - name: Wait for Jenkins build to finish
+        env:
+          JENKINS_USER: ${{ secrets.JENKINS_USER }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+          BUILD_URL: ${{ steps.wait_start.outputs.build_url }}
+        run: |
+          set -euo pipefail
+          # Poll the build's result field. Cap total wait at 60 minutes (120 * 30s).
+          for i in $(seq 1 120); do
+            B=$(curl -sS --max-time 30 \
+              -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+              -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+              --user "${JENKINS_USER}:${JENKINS_API_TOKEN}" \
+              "${BUILD_URL}api/json")
+            RESULT=$(echo "$B" | jq -r '.result // "null"')
+            if [ "$RESULT" != "null" ]; then
+              echo "Build finished: ${RESULT}"
+              {
+                echo ""
+                echo "### Build finished: ${RESULT}"
+                echo "${BUILD_URL}"
+              } >> "$GITHUB_STEP_SUMMARY"
+              case "$RESULT" in
+                SUCCESS)
+                  exit 0
+                  ;;
+                *)
+                  echo "--- Tail of Jenkins console log ---"
+                  curl -sS --max-time 60 \
+                    -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+                    -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+                    --user "${JENKINS_USER}:${JENKINS_API_TOKEN}" \
+                    "${BUILD_URL}consoleText" | tail -200 \
+                    || echo "(could not fetch Jenkins console log — check Jenkins UI: ${BUILD_URL})"
+                  exit 1
+                  ;;
+              esac
+            fi
+            echo "Building ($i/120)..."
+            sleep 30
+          done
+          echo "Build did not finish within 60 minutes."
+          exit 1
+      # Propagate GH-side cancellation / failure to Jenkins so the agent is
+      # freed for the new build. Only runs if the trigger step produced a queue
+      # URL (otherwise there's nothing on the Jenkins side to clean up).
+      - name: Cancel Jenkins build on cancellation / failure
+        if: always() && steps.trigger.outputs.queue_url != ''
+        env:
+          JENKINS_USER: ${{ secrets.JENKINS_USER }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+          QUEUE_URL: ${{ steps.trigger.outputs.queue_url }}
+          BUILD_URL: ${{ steps.wait_start.outputs.build_url }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set +e
+          # Success path: nothing to clean up.
+          if [ "${JOB_STATUS}" = "success" ]; then exit 0; fi
+
+          auth=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}"
+                -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}"
+                --user "${JENKINS_USER}:${JENKINS_API_TOKEN}")
+
+          if [ -n "${BUILD_URL:-}" ]; then
+            echo "Stopping Jenkins build: ${BUILD_URL}"
+            curl -fsS --max-time 30 -X POST "${auth[@]}" "${BUILD_URL}stop" \
+              || echo "(stop request failed; build may still be running)"
+          else
+            # Build never started — cancel the queue item.
+            QUEUE_ID=$(echo "${QUEUE_URL}" | grep -oP 'queue/item/\K[0-9]+')
+            if [ -n "${QUEUE_ID}" ]; then
+              echo "Cancelling Jenkins queue item: ${QUEUE_ID}"
+              curl -fsS --max-time 30 -X POST "${auth[@]}" \
+                "${JENKINS_URL}/queue/cancelItem?id=${QUEUE_ID}" \
+                || echo "(queue cancel failed; build may have started)"
+            fi
+          fi
+      - run: echo "Finished with status - ${{ job.status }}."
+        if: always()


### PR DESCRIPTION
## Summary

Adds the GitHub Actions workflow that triggers our Jenkins renode unit-test job on PRs and `push: develop`, polls Jenkins until the build finishes, and mirrors the Jenkins result back to the PR check. The workflow's pass/fail IS the commit status — no separate Jenkins → GitHub callback is needed.

Mirrors the workflow already in adamant-xmera-components, adapted to make `fp32_fsw_xmera_ref` the auto-defaulted ref (PR head SHA) instead of `adamant_xmera_components_ref`.

## How it works

- **Trigger**: webhook to Jenkins's Generic Webhook Trigger plugin, sending `fp32_fsw_xmera_ref` (= the PR head SHA on PR builds, or `github.sha` on push) and any optional ref overrides supplied via `workflow_dispatch`.
- **Auth**: Cloudflare Access service token on every Jenkins API call — the public webhook endpoint is allowlisted at the edge, but everything else is gated.
- **Polling**: queue API → `executable.url` → build API → `result`. Jenkins's internal-IP `executable.url` is rewritten to the Cloudflare-fronted host so the GH runner can reach it.
- **On failure**: last 200 lines of Jenkins console log are dumped into the GH log so reviewers don't need Jenkins UI access to see why a build failed.

## Override capability

For DROP / integration testing, `workflow_dispatch` accepts optional ref inputs for any of the parameterized repos:

- `fp32_fsw_xmera_ref` (default: PR head SHA)
- `adamant_xmera_components_ref`
- `adamant_ref`
- `adamant_example_ref`
- `project_ref`

Empty inputs use the Jenkins job's hardcoded fallback. The workflow file also exposes commented-out `*_REF_PIN` env vars for branch-wide pinning (uncomment to pin a sibling repo for THIS branch's CI runs without touching Jenkins UI).

## Required repository secrets

| Secret | Purpose |
|---|---|
| \`JENKINS_WEBHOOK_TOKEN\` | Generic Webhook Trigger token on the Jenkins job |
| \`JENKINS_USER\` | Jenkins service-account username for API polling |
| \`JENKINS_API_TOKEN\` | API token for that user |
| \`CF_ACCESS_CLIENT_ID\` | Cloudflare Access service token client ID |
| \`CF_ACCESS_CLIENT_SECRET\` | Cloudflare Access service token client secret |