### PR TITLE
Change max num css sensors back to 32

### DIFF
--- a/algorithms/cssComm/_tests/test_cssComm.py
+++ b/algorithms/cssComm/_tests/test_cssComm.py
@@ -13,7 +13,7 @@ path = os.path.dirname(os.path.abspath(filename))
 
 # Tracks `kMaxNumCssSensors` in algorithms/msgPayloadDef/definitions.h.
 # Keep in sync if that constant changes.
-_MAX_CSS = 16
+_MAX_CSS = 32
 
 @pytest.mark.parametrize("num_sensors, sensor_data", [
     (4, [-100e-6, 200e-6, 600e-6, 300e-6]),  # Subset of sensors; verifies trailing entries are zeroed.

--- a/algorithms/msgPayloadDef/definitions.h
+++ b/algorithms/msgPayloadDef/definitions.h
@@ -3,10 +3,10 @@
 
 #include <cstdint>
 
-#define MAX_NUM_CSS_SENSORS 16
+#define MAX_NUM_CSS_SENSORS 32
 inline constexpr std::uint32_t kMaxNumCssSensors = MAX_NUM_CSS_SENSORS;
 #define MAX_EFF_CNT 36
-inline constexpr std::uint32_t kMaxThrusterCount = 36U;
+inline constexpr std::uint32_t kMaxThrusterCount = MAX_EFF_CNT;
 inline constexpr std::uint32_t kMimuCount = 3U;
 #define RW_EFF_CNT 36
 

--- a/algorithms/stepperMotorController/stepperMotorControllerAlgorithm.cpp
+++ b/algorithms/stepperMotorController/stepperMotorControllerAlgorithm.cpp
@@ -1,7 +1,8 @@
 #include "stepperMotorControllerAlgorithm.h"
 #include "utilities/freestandingInvalidArgument.h"
-#include <math.h>
 
+#include <math.h>
+#include <stdlib.h>
 #include <numbers>
 #include <utility>
 


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
I shortsightedly changed the `MAX_NUM_CSS_SENSORS` to 16. This caused adhoc message write failures when trying to write more message bytes into a message not sized to receive those bytes. This is insufficient given this macro and the others to which it's value must match are not compile time checks.

## Verification
This should satisfy https://github.com/lasp/fp32-fsw-xmera/pull/145 

## Documentation
NA

## Future work
We need to work a redesign for these macros throughout this code base and Xmera in general.
