### PR TITLE
Fix path for eigenFuzzDomain include

### DIFF
--- a/algorithms/rateControl/_tests/test_rateControl_fuzz.cpp
+++ b/algorithms/rateControl/_tests/test_rateControl_fuzz.cpp
@@ -1,4 +1,4 @@
-#include "fp32-fsw-xmera/architecture/testUtilities/eigenFuzzDomains.hpp"
+#include "../architecture/testUtilities/eigenFuzzDomains.hpp"
 #include "rateControlTestHelpers.hpp"
 #include <fuzztest/fuzztest.h>
 


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
Building for fuzz tests is not working on our local machines due to a path issue in test_rateControl_fuzz. It builds on the CI because of how Eigen is included for the CI build. This commit matches the mrpRotation pattern. mrpRotation and rateControl will be the only two that follow this pattern. The other 13 algorithms use this pattern: `target_include_directories(test_dvGuidance_fuzz PRIVATE "../../..")` in their CMakeLists.txt and keep the include the fuzz test like this: `#include "architecture/testUtilities/eigenFuzzDomains.hpp`. 

## Verification
None

## Documentation
None

## Future work
Could make a PR that make us consistent across the board?
