### PR TITLE
Feature/2154 stepper motor update

### DIFF
--- a/algorithms/msgPayloadDef/CMakeLists.txt
+++ b/algorithms/msgPayloadDef/CMakeLists.txt
@@ -24,6 +24,7 @@ xmera_add_swig_message(MimuPacketF32Payload
                        TEMPLATE
                        "${CMAKE_CURRENT_SOURCE_DIR}/MimuPacketF32Payload.i"
 )
+xmera_add_swig_message(MotorAngleRefMsgF32Payload)
 xmera_add_swig_message(NavAttMsgF32Payload)
 xmera_add_swig_message(NavTransMsgF32Payload)
 xmera_add_swig_message(RateCmdMsgF32Payload)

--- a/algorithms/msgPayloadDef/MotorAngleRefMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/MotorAngleRefMsgF32Payload.h
@@ -1,0 +1,9 @@
+#ifndef MOTOR_ANGLE_REF_MESSAGE_F32_H
+#define MOTOR_ANGLE_REF_MESSAGE_F32_H
+
+/*! @brief Structure used to define the motor angle reference data message */
+typedef struct {
+    float theta;  //!< [rad] motor reference angle
+} MotorAngleRefMsgF32Payload;
+
+#endif /* MOTOR_ANGLE_REF_MESSAGE_F32_H */

--- a/algorithms/solarArrayReference/_tests/test_solarArrayReference.py
+++ b/algorithms/solarArrayReference/_tests/test_solarArrayReference.py
@@ -70,7 +70,7 @@ def test_solarArrayReference(show_plots, rHat_SB_N, sigma_BN, sigma_RN, accuracy
 
     This unit test checks the correctness of the output attitude reference message
 
-    - ``hingedRigidBodyRefOutMsg``
+    - ``solarArrayRefOutMsg``
 
     in all its parts. The reference angle ``theta`` is checked versus the value computed by a python function that computes the same angle.
     The reference angle derivative ``thetaDot`` is checked versus zero, as the module is run for only one Update call.
@@ -125,7 +125,7 @@ def test_solarArrayReference(show_plots, rHat_SB_N, sigma_BN, sigma_RN, accuracy
     solar_array.hingedRigidBodyInMsg.subscribeTo(hinged_rigid_body_in_msg)
 
     # Setup logging on the test module output message so that we get all the writes to it
-    data_log = solar_array.hingedRigidBodyRefOutMsg.recorder()
+    data_log = solar_array.solarArrayRefOutMsg.recorder()
     unit_test_sim.AddModelToTask(unit_task_name, data_log)
 
     # Need to call the self-init and cross-init methods
@@ -198,7 +198,7 @@ def test_solarArrayReference_specifiedAngle(show_plots, specifiedAngle, offsetAn
     hinged_rigid_body_in_msg = messaging.HingedRigidBodyMsgF32().write(hinged_rigid_body_in_msg_data)
     solar_array.hingedRigidBodyInMsg.subscribeTo(hinged_rigid_body_in_msg)
 
-    data_log = solar_array.hingedRigidBodyRefOutMsg.recorder()
+    data_log = solar_array.solarArrayRefOutMsg.recorder()
     unit_test_sim.AddModelToTask(unit_task_name, data_log)
 
     unit_test_sim.InitializeSimulation()

--- a/algorithms/solarArrayReference/solarArrayReference.cpp
+++ b/algorithms/solarArrayReference/solarArrayReference.cpp
@@ -26,9 +26,9 @@ void SolarArrayReference::updateState(uint64_t callTime) {
 
     const float thetaRef = this->algorithm.update(sigma_BN, sigma_RN, rHatIn_SB_B, hingedRigidBodyIn.theta);
 
-    HingedRigidBodyMsgF32Payload hingedRigidBodyRefOut = {};
-    hingedRigidBodyRefOut.theta = thetaRef;
-    this->hingedRigidBodyRefOutMsg.write(&hingedRigidBodyRefOut, this->moduleID, callTime);
+    MotorAngleRefMsgF32Payload solarArrayRefOut = {};
+    solarArrayRefOut.theta = thetaRef;
+    this->solarArrayRefOutMsg.write(&solarArrayRefOut, this->moduleID, callTime);
 }
 
 /*! Set the solar array drive axis and surface normal in body frame coordinates.

--- a/algorithms/solarArrayReference/solarArrayReference.h
+++ b/algorithms/solarArrayReference/solarArrayReference.h
@@ -3,6 +3,7 @@
 
 #include "msgPayloadDef/AttRefMsgF32Payload.h"
 #include "msgPayloadDef/HingedRigidBodyMsgF32Payload.h"
+#include "msgPayloadDef/MotorAngleRefMsgF32Payload.h"
 #include "msgPayloadDef/NavAttMsgF32Payload.h"
 #include "solarArrayReferenceAlgorithm.h"
 #include <architecture/_GeneralModuleFiles/sys_model.h>
@@ -31,8 +32,7 @@ class SolarArrayReference : public SysModel {
     ReadFunctor<NavAttMsgF32Payload> attNavInMsg;                    //!< input msg measured attitude
     ReadFunctor<AttRefMsgF32Payload> attRefInMsg;                    //!< input attitude reference message
     ReadFunctor<HingedRigidBodyMsgF32Payload> hingedRigidBodyInMsg;  //!< input hinged rigid body message
-    Message<HingedRigidBodyMsgF32Payload>
-        hingedRigidBodyRefOutMsg;  //!< output msg containing hinged rigid body target angle and angle rate
+    Message<MotorAngleRefMsgF32Payload> solarArrayRefOutMsg;  //!< output msg containing the solar array reference angle
 
    private:
     SolarArrayReferenceAlgorithm algorithm{};  //!< algorithm instance

--- a/algorithms/solarArrayReference/solarArrayReference.rst
+++ b/algorithms/solarArrayReference/solarArrayReference.rst
@@ -33,9 +33,9 @@ provides information on what this message is used for.
     * - hingedRigidBodyInMsg
       - :ref:`HingedRigidBodyMsgF32Payload`
       - input hinged rigid body message containing the current panel angle :math:`\theta_C`
-    * - hingedRigidBodyRefOutMsg
-      - :ref:`HingedRigidBodyMsgF32Payload`
-      - output hinged rigid body reference message containing the reference angle :math:`\theta_R`
+    * - solarArrayRefOutMsg
+      - :ref:`MotorAngleRefMsgF32Payload`
+      - output solar array reference message containing the reference angle :math:`\theta_R`
 
 Module Parameters
 -------------------------------

--- a/algorithms/solarArrayReference/solarArrayReferenceF32.i
+++ b/algorithms/solarArrayReference/solarArrayReferenceF32.i
@@ -24,3 +24,4 @@
 %include "msgPayloadDef/NavAttMsgF32Payload.h"
 %include "msgPayloadDef/AttRefMsgF32Payload.h"
 %include "msgPayloadDef/HingedRigidBodyMsgF32Payload.h"
+%include "msgPayloadDef/MotorAngleRefMsgF32Payload.h"

--- a/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
+++ b/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
@@ -194,9 +194,10 @@ def test_stepper_motor_controller_interrupt(show_plots):
     **Validation Test Description**
 
     Verify that changing the reference angle mid-move causes the controller to transition to
-    STOPPING and wait for the motor to finish its original commanded steps, then re-plan from the
-    final position. The Xmera adapter does not propagate ``STOP`` to the motor (the motor cannot
-    stop mid-step), so the motor reaches the original target before the algorithm re-plans.
+    STOPPING and wait for the motor to halt, then re-plan from the final position. The adapter
+    propagates ``STOP`` as a command with ``stopMotorCommand=true``; the motor finishes its
+    current step before halting (it cannot stop mid-step), and the algorithm re-plans once the
+    motor reports ``isMotorMoving=false``.
 
     The "motor" is simulated here by writing the feedback message directly with chosen
     ``motorPosition`` and ``isMotorMoving`` values, so this test does not depend on the stepper

--- a/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
+++ b/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
@@ -36,6 +36,22 @@ def create_sim(process_rate_sec):
     return sim, process_rate
 
 
+def make_stepper_motor_msg_payload(motor_position=0, is_motor_moving=False):
+    """Create a StepperMotorMsg pre-written with the given feedback values."""
+    payload = messaging.StepperMotorMsgPayload()
+    payload.motorPosition = motor_position
+    payload.isMotorMoving = is_motor_moving
+    return messaging.StepperMotorMsg().write(payload)
+
+
+def write_stepper_motor_msg(msg, motor_position, is_motor_moving, time_ns):
+    """Overwrite a StepperMotorMsg with new feedback values at the given sim time."""
+    payload = messaging.StepperMotorMsgPayload()
+    payload.motorPosition = motor_position
+    payload.isMotorMoving = is_motor_moving
+    msg.write(payload, time_ns)
+
+
 @pytest.mark.parametrize("step_angle", [math.radians(1.8), math.radians(1.0), math.radians(0.9)])
 @pytest.mark.parametrize("theta_init_deg", [0.0, -45.0, 90.0])
 @pytest.mark.parametrize("theta_ref_deg", [10.0, -30.0, 50.5])
@@ -45,13 +61,7 @@ def test_stepper_motor_controller_nominal(show_plots, step_angle, theta_init_deg
 
     Verify that the stepper motor controller commands the correct number of steps
     (via shortest path wrapping) when moving from an initial step position to a reference angle.
-
-    **Test Parameters**
-
-    Args:
-        step_angle (float): [rad/step] Angle per motor step
-        theta_init_deg (float): [deg] Initial motor angle (converted to steps for the adapter)
-        theta_ref_deg (float): [deg] Reference motor angle
+    The motor's initial position is supplied via the feedback message's ``motorPosition`` field.
     """
     process_rate_sec = 0.1
     sim, process_rate = create_sim(process_rate_sec)
@@ -63,16 +73,15 @@ def test_stepper_motor_controller_nominal(show_plots, step_angle, theta_init_deg
     motor_controller.modelTag = "stepperMotorController"
     motor_controller.stepAngle = step_angle
     motor_controller.setMotorAngleRange(0.0, 2 * math.pi)
-    motor_controller.controlFrequency = 1.0 / process_rate_sec
-    motor_controller.motorFrequency = 100.0
     motor_controller.minStepCommand = 1
-    motor_controller.initialAngle = theta_init_deg * macros.D2R
     sim.AddModelToTask("unitTask", motor_controller)
 
     ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
     ref_msg_data.theta = theta_ref_deg * macros.D2R
     ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
+    feedback_msg = make_stepper_motor_msg_payload(motor_position=init_step)
+    motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)
 
     log = motor_controller.motorStepCommandOutMsg.recorder(process_rate)
     sim.AddModelToTask("unitTask", log)
@@ -102,13 +111,6 @@ def test_stepper_motor_controller_shortest_path(show_plots, theta_init_deg, thet
 
     Verify that the controller wraps step commands to always take the shortest path around the circle,
     rather than the naive (possibly longer) path.
-
-    **Test Parameters**
-
-    Args:
-        theta_init_deg (float): [deg] Initial motor angle (converted to steps for the adapter)
-        theta_ref_deg (float): [deg] Reference motor angle
-        expected_sign (int): Expected sign of the step command (-1 or +1)
     """
     step_angle = math.radians(1.0)  # 1 deg/step (= 360 steps/rev)
     steps_per_rev = round(2 * math.pi / step_angle)
@@ -121,16 +123,15 @@ def test_stepper_motor_controller_shortest_path(show_plots, theta_init_deg, thet
     motor_controller.modelTag = "stepperMotorController"
     motor_controller.stepAngle = step_angle
     motor_controller.setMotorAngleRange(0.0, 2 * math.pi)
-    motor_controller.controlFrequency = 1.0 / process_rate_sec
-    motor_controller.motorFrequency = 100.0
     motor_controller.minStepCommand = 1
-    motor_controller.initialAngle = theta_init_deg * macros.D2R
     sim.AddModelToTask("unitTask", motor_controller)
 
     ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
     ref_msg_data.theta = theta_ref_deg * macros.D2R
     ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
+    feedback_msg = make_stepper_motor_msg_payload(motor_position=init_step)
+    motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)
 
     log = motor_controller.motorStepCommandOutMsg.recorder(process_rate)
     sim.AddModelToTask("unitTask", log)
@@ -159,7 +160,6 @@ def test_stepper_motor_controller_below_min_step_command(show_plots):
     the current motor position is below ``minStepCommand``.
     """
     step_angle = math.radians(1.0)  # 1 deg/step (= 360 steps/rev)
-    steps_per_rev = round(2 * math.pi / step_angle)
     process_rate_sec = 0.1
     sim, process_rate = create_sim(process_rate_sec)
 
@@ -167,10 +167,7 @@ def test_stepper_motor_controller_below_min_step_command(show_plots):
     motor_controller.modelTag = "stepperMotorController"
     motor_controller.stepAngle = step_angle
     motor_controller.setMotorAngleRange(0.0, 2 * math.pi)
-    motor_controller.controlFrequency = 1.0 / process_rate_sec
-    motor_controller.motorFrequency = 100.0
     motor_controller.minStepCommand = 5
-    motor_controller.initialAngle = 0.0
     sim.AddModelToTask("unitTask", motor_controller)
 
     # Reference is 3 deg from init = 3 steps, below minStepCommand of 5
@@ -178,6 +175,8 @@ def test_stepper_motor_controller_below_min_step_command(show_plots):
     ref_msg_data.theta = 3.0 * macros.D2R
     ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
+    feedback_msg = make_stepper_motor_msg_payload(motor_position=0)
+    motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)
 
     log = motor_controller.motorStepCommandOutMsg.recorder(process_rate)
     sim.AddModelToTask("unitTask", log)
@@ -194,17 +193,17 @@ def test_stepper_motor_controller_interrupt(show_plots):
     r"""
     **Validation Test Description**
 
-    Verify that changing the reference angle mid-move causes the controller to stop, settle, and
-    then issue a new move command to the updated reference from the interrupted position.
+    Verify that changing the reference angle mid-move causes the controller to transition to
+    STOPPING and wait for the motor to finish its original commanded steps, then re-plan from the
+    final position. The Xmera adapter does not propagate ``STOP`` to the motor (the motor cannot
+    stop mid-step), so the motor reaches the original target before the algorithm re-plans.
 
-    The motor advances 1 step per tick (motorFrequency == controlFrequency) for predictable
-    intermediate positions.
+    The "motor" is simulated here by writing the feedback message directly with chosen
+    ``motorPosition`` and ``isMotorMoving`` values, so this test does not depend on the stepper
+    motor dynamics module.
     """
-    step_angle = math.radians(1.0)  # 1 deg/step (= 360 steps/rev)
-    steps_per_rev = round(2 * math.pi / step_angle)
+    step_angle = math.radians(1.0)  # 1 deg/step
     process_rate_sec = 0.1
-    control_freq = 1.0 / process_rate_sec  # 10 Hz
-    motor_freq = control_freq              # 1 step per tick
     settle_ticks = 2
     sim, process_rate = create_sim(process_rate_sec)
 
@@ -212,108 +211,103 @@ def test_stepper_motor_controller_interrupt(show_plots):
     motor_controller.modelTag = "stepperMotorController"
     motor_controller.stepAngle = step_angle
     motor_controller.setMotorAngleRange(0.0, 2 * math.pi)
-    motor_controller.controlFrequency = control_freq
-    motor_controller.motorFrequency = motor_freq
     motor_controller.minStepCommand = 1
     motor_controller.settleCountMax = settle_ticks
-    motor_controller.initialAngle = 0.0
     sim.AddModelToTask("unitTask", motor_controller)
 
-    # First reference: 20 deg = 20 steps from init
+    # First reference: 20 deg = 20 steps from motorPosition=0
     ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
     ref_msg_data.theta = 20.0 * macros.D2R
     ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
 
+    # Feedback: stand in for "motor already moving" so the algorithm doesn't transition out of
+    # MOVING during Phase 1's second tick (the test can't update the feedback between two ticks
+    # of the same ExecuteSimulation; in a real sim the dynamics would set isMotorMoving=True as
+    # soon as it received the MOVE).
+    feedback_msg = make_stepper_motor_msg_payload(motor_position=0, is_motor_moving=True)
+    motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)
+
     log = motor_controller.motorStepCommandOutMsg.recorder(process_rate)
     sim.AddModelToTask("unitTask", log)
 
-    # Run 7 ticks (t=0.0, 0.1, ... 0.6):
-    #   Tick at t=0.0: IDLE -> MOVE(20), enter MOVING, then advance 1 step (current=1)
-    #   Ticks at t=0.1-0.6: MOVING, advancing 1 step/tick -> current = 7 after t=0.6
+    # Phase 1: controller emits MOVE(20) at tick 0; tick 0.1 stays in MOVING
     sim.InitializeSimulation()
+    sim.ConfigureStopTime(process_rate)
+    sim.ExecuteSimulation()
+    np.testing.assert_allclose(log.stepsCommanded[0], 20, atol=0, rtol=0)
+
+    # Phase 2: motor is moving (mid-actuation, motorPosition=5)
+    write_stepper_motor_msg(feedback_msg, motor_position=5, is_motor_moving=True, time_ns=sim.TotalSim.getCurrentNanos())
+    sim.ConfigureStopTime(macros.sec2nano(0.4))
+    sim.ExecuteSimulation()
+
+    # Phase 3: reference changes to 10 deg mid-move → algorithm transitions to STOPPING
+    ref_msg_data.theta = 10.0 * macros.D2R
+    ref_msg.write(ref_msg_data, sim.TotalSim.getCurrentNanos())
     sim.ConfigureStopTime(macros.sec2nano(0.6))
     sim.ExecuteSimulation()
 
-    # Verify first MOVE command
-    np.testing.assert_allclose(log.stepsCommanded[0], 20, atol=0, rtol=0)
-
-    # Change reference to 10 deg = 10 steps from origin
-    ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
-    ref_msg_data.theta = 10.0 * macros.D2R
-    ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data, sim.TotalSim.getCurrentNanos())
-    motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
-
-    # Run enough ticks for: MOVING(detect change)->STOPPING->SETTLING(2 ticks)->IDLE->MOVE
-    #   Tick at t=0.7: MOVING, sees changed ref -> STOP, commanded frozen at current=7
-    #   Tick at t=0.8: STOPPING -> SETTLING (settleCount=0)
-    #   Tick at t=0.9: SETTLING (settleCount=0 < 2 -> settleCount=1)
-    #   Tick at t=1.0: SETTLING (settleCount=1 < 2 -> settleCount=2)
-    #   Tick at t=1.1: SETTLING (settleCount=2 >= 2 -> IDLE)
-    #   Tick at t=1.2: IDLE -> MOVE(wrap_delta(10 - 7, 360) = 3)
-    sim.ConfigureStopTime(macros.sec2nano(1.3))
+    # Phase 4: motor finishes original move at motorPosition=20 and stops → STOPPING → SETTLING → IDLE → MOVE(-10)
+    write_stepper_motor_msg(feedback_msg, motor_position=20, is_motor_moving=False, time_ns=sim.TotalSim.getCurrentNanos())
+    sim.ConfigureStopTime(macros.sec2nano(1.5))
     sim.ExecuteSimulation()
 
-    # The second MOVE command writes 3 (interrupted at 7, target 10) and is the last value held by the message.
-    np.testing.assert_allclose(log.stepsCommanded[-1], 3, atol=0, rtol=0)
+    # Second MOVE must be -10 (motor reached 20 first, then re-planned to 10)
+    np.testing.assert_allclose(log.stepsCommanded[-1], -10, atol=0, rtol=0)
 
 
-def test_stepper_motor_controller_fractional_step_accumulation(show_plots):
+def test_stepper_motor_controller_position_tracking(show_plots):
     r"""
     **Validation Test Description**
 
-    Verify that the step accumulator correctly handles a non-integer motor/control frequency ratio.
-    With motorFrequency=15 Hz and controlFrequency=10 Hz the ratio is 1.5 steps per tick, producing
-    the pattern 1, 2, 1, 2, ... steps per tick. After commanding 9 steps the motor must land exactly
-    on step 9 (not 8 or 10). This is verified by commanding a return to the origin and checking
-    that the return command is exactly -9 steps.
+    Verify the controller correctly uses the absolute ``motorPosition`` feedback across
+    successive MOVE commands. Commanding a forward move followed by a return to the origin must
+    produce exactly opposite step counts, which is only true if the controller reads the motor's
+    absolute position from the feedback message.
     """
-    step_angle = math.radians(1.0)  # 1 deg/step (= 360 steps/rev)
-    steps_per_rev = round(2 * math.pi / step_angle)
+    step_angle = math.radians(1.0)
     process_rate_sec = 0.1
-    control_freq = 1.0 / process_rate_sec  # 10 Hz
-    motor_freq = 15.0                      # 15 Hz -> 1.5 steps/tick
     sim, process_rate = create_sim(process_rate_sec)
 
     motor_controller = stepperMotorControllerF32.StepperMotorController()
     motor_controller.modelTag = "stepperMotorController"
     motor_controller.stepAngle = step_angle
     motor_controller.setMotorAngleRange(0.0, 2 * math.pi)
-    motor_controller.controlFrequency = control_freq
-    motor_controller.motorFrequency = motor_freq
     motor_controller.minStepCommand = 1
     motor_controller.settleCountMax = 0
-    motor_controller.initialAngle = 0.0
     sim.AddModelToTask("unitTask", motor_controller)
 
-    # Command 9 steps (9 deg with 360 steps/rev)
+    # First reference: 9 deg = 9 steps
     ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
     ref_msg_data.theta = 9.0 * macros.D2R
     ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
 
+    feedback_msg = make_stepper_motor_msg_payload(motor_position=0, is_motor_moving=False)
+    motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)
+
     log = motor_controller.motorStepCommandOutMsg.recorder(process_rate)
     sim.AddModelToTask("unitTask", log)
 
-    # Run enough ticks for the full cycle to complete
+    # Tick 0: motor at rest → MOVE(9)
     sim.InitializeSimulation()
-    sim.ConfigureStopTime(macros.sec2nano(1.0))
+    sim.ConfigureStopTime(process_rate)
     sim.ExecuteSimulation()
-
-    # Verify first MOVE command
     np.testing.assert_allclose(log.stepsCommanded[0], 9, atol=0, rtol=0)
 
-    # Now command return to origin — if accumulator was correct, current position is exactly 9
-    ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
-    ref_msg_data.theta = 0.0
-    ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data, sim.TotalSim.getCurrentNanos())
-    motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
+    # Simulate motor reaching motorPosition=9 and stopping
+    write_stepper_motor_msg(feedback_msg, motor_position=9, is_motor_moving=False, time_ns=sim.TotalSim.getCurrentNanos())
 
-    # Run more ticks for IDLE -> MOVE
-    sim.ConfigureStopTime(macros.sec2nano(1.2))
+    # Change reference back to origin
+    ref_msg_data.theta = 0.0
+    ref_msg.write(ref_msg_data, sim.TotalSim.getCurrentNanos())
+
+    # Run a few ticks for SETTLING (settleCountMax=0) → IDLE → MOVE(-9)
+    sim.ConfigureStopTime(macros.sec2nano(0.5))
     sim.ExecuteSimulation()
 
-    # Return command should be exactly -9 (proves motor landed on step 9, not 8 or 10)
+    # Return command must be exactly -9 (proves controller read absolute motorPosition=9 from feedback)
     np.testing.assert_allclose(log.stepsCommanded[-1], -9, atol=0, rtol=0)
 
 
@@ -334,16 +328,18 @@ def test_stepper_motor_controller_out_of_range(show_plots, ref_deg):
     motor_controller.modelTag = "stepperMotorController"
     motor_controller.stepAngle = step_angle
     motor_controller.setMotorAngleRange(math.radians(45.0), math.radians(90.0))
-    motor_controller.controlFrequency = 1.0 / process_rate_sec
-    motor_controller.motorFrequency = 100.0
     motor_controller.minStepCommand = 1
-    motor_controller.initialAngle = math.radians(60.0)  # in-range start
     sim.AddModelToTask("unitTask", motor_controller)
+
+    # Motor starts in-range at 60 deg = 60 steps
+    init_step = angle_to_steps(math.radians(60.0), round(2 * math.pi / step_angle))
 
     ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
     ref_msg_data.theta = math.radians(ref_deg)
     ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
+    feedback_msg = make_stepper_motor_msg_payload(motor_position=init_step)
+    motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)
 
     log = motor_controller.motorStepCommandOutMsg.recorder(process_rate)
     sim.AddModelToTask("unitTask", log)
@@ -356,9 +352,9 @@ def test_stepper_motor_controller_out_of_range(show_plots, ref_deg):
 
 
 if __name__ == "__main__":
-    test_stepper_motor_controller_nominal(False, 360, 0.0, 10.0)
+    test_stepper_motor_controller_nominal(False, math.radians(1.0), 0.0, 10.0)
     test_stepper_motor_controller_shortest_path(False, -162.0, 162.0, -1)
     test_stepper_motor_controller_below_min_step_command(False)
     test_stepper_motor_controller_interrupt(False)
-    test_stepper_motor_controller_fractional_step_accumulation(False)
+    test_stepper_motor_controller_position_tracking(False)
     test_stepper_motor_controller_out_of_range(False, 200.0)

--- a/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
+++ b/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
@@ -91,11 +91,11 @@ def test_stepper_motor_controller_nominal(show_plots, step_angle, theta_init_deg
     sim.ExecuteSimulation()
 
     # Compute expected steps via shortest path
-    refSteps = angle_to_steps(theta_ref_deg * macros.D2R, steps_per_rev)
-    expectedSteps = wrap_delta(refSteps - init_step, steps_per_rev)
+    ref_steps = angle_to_steps(theta_ref_deg * macros.D2R, steps_per_rev)
+    expected_steps = wrap_delta(ref_steps - init_step, steps_per_rev)
 
-    if expectedSteps != 0:
-        np.testing.assert_allclose(log.stepsCommanded[0], expectedSteps, atol=0, rtol=0)
+    if expected_steps != 0:
+        np.testing.assert_allclose(log.stepsCommanded[0], expected_steps, atol=0, rtol=0)
     else:
         np.testing.assert_allclose(log.stepsCommanded[0], 0, atol=0, rtol=0)
 
@@ -144,9 +144,9 @@ def test_stepper_motor_controller_shortest_path(show_plots, theta_init_deg, thet
     np.testing.assert_equal(np.sign(log.stepsCommanded[0]), expected_sign)
 
     # Verify magnitude via truth computation
-    refSteps = angle_to_steps(theta_ref_deg * macros.D2R, steps_per_rev)
-    expectedSteps = wrap_delta(refSteps - init_step, steps_per_rev)
-    np.testing.assert_allclose(log.stepsCommanded[0], expectedSteps, atol=0, rtol=0)
+    ref_steps = angle_to_steps(theta_ref_deg * macros.D2R, steps_per_rev)
+    expected_steps = wrap_delta(ref_steps - init_step, steps_per_rev)
+    np.testing.assert_allclose(log.stepsCommanded[0], expected_steps, atol=0, rtol=0)
 
     # Verify the magnitude is at most half a revolution (shortest path guarantee)
     np.testing.assert_array_less(np.abs(log.stepsCommanded[0]), steps_per_rev // 2 + 1)

--- a/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
+++ b/algorithms/stepperMotorController/_tests/test_stepperMotorController.py
@@ -76,9 +76,9 @@ def test_stepper_motor_controller_nominal(show_plots, step_angle, theta_init_deg
     motor_controller.minStepCommand = 1
     sim.AddModelToTask("unitTask", motor_controller)
 
-    ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
+    ref_msg_data = messaging.MotorAngleRefMsgF32Payload()
     ref_msg_data.theta = theta_ref_deg * macros.D2R
-    ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
+    ref_msg = messaging.MotorAngleRefMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
     feedback_msg = make_stepper_motor_msg_payload(motor_position=init_step)
     motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)
@@ -126,9 +126,9 @@ def test_stepper_motor_controller_shortest_path(show_plots, theta_init_deg, thet
     motor_controller.minStepCommand = 1
     sim.AddModelToTask("unitTask", motor_controller)
 
-    ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
+    ref_msg_data = messaging.MotorAngleRefMsgF32Payload()
     ref_msg_data.theta = theta_ref_deg * macros.D2R
-    ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
+    ref_msg = messaging.MotorAngleRefMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
     feedback_msg = make_stepper_motor_msg_payload(motor_position=init_step)
     motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)
@@ -171,9 +171,9 @@ def test_stepper_motor_controller_below_min_step_command(show_plots):
     sim.AddModelToTask("unitTask", motor_controller)
 
     # Reference is 3 deg from init = 3 steps, below minStepCommand of 5
-    ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
+    ref_msg_data = messaging.MotorAngleRefMsgF32Payload()
     ref_msg_data.theta = 3.0 * macros.D2R
-    ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
+    ref_msg = messaging.MotorAngleRefMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
     feedback_msg = make_stepper_motor_msg_payload(motor_position=0)
     motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)
@@ -217,9 +217,9 @@ def test_stepper_motor_controller_interrupt(show_plots):
     sim.AddModelToTask("unitTask", motor_controller)
 
     # First reference: 20 deg = 20 steps from motorPosition=0
-    ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
+    ref_msg_data = messaging.MotorAngleRefMsgF32Payload()
     ref_msg_data.theta = 20.0 * macros.D2R
-    ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
+    ref_msg = messaging.MotorAngleRefMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
 
     # Feedback: stand in for "motor already moving" so the algorithm doesn't transition out of
@@ -280,9 +280,9 @@ def test_stepper_motor_controller_position_tracking(show_plots):
     sim.AddModelToTask("unitTask", motor_controller)
 
     # First reference: 9 deg = 9 steps
-    ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
+    ref_msg_data = messaging.MotorAngleRefMsgF32Payload()
     ref_msg_data.theta = 9.0 * macros.D2R
-    ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
+    ref_msg = messaging.MotorAngleRefMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
 
     feedback_msg = make_stepper_motor_msg_payload(motor_position=0, is_motor_moving=False)
@@ -335,9 +335,9 @@ def test_stepper_motor_controller_out_of_range(show_plots, ref_deg):
     # Motor starts in-range at 60 deg = 60 steps
     init_step = angle_to_steps(math.radians(60.0), round(2 * math.pi / step_angle))
 
-    ref_msg_data = messaging.HingedRigidBodyMsgF32Payload()
+    ref_msg_data = messaging.MotorAngleRefMsgF32Payload()
     ref_msg_data.theta = math.radians(ref_deg)
-    ref_msg = messaging.HingedRigidBodyMsgF32().write(ref_msg_data)
+    ref_msg = messaging.MotorAngleRefMsgF32().write(ref_msg_data)
     motor_controller.motorRefAngleInMsg.subscribeTo(ref_msg)
     feedback_msg = make_stepper_motor_msg_payload(motor_position=init_step)
     motor_controller.stepperMotorInMsg.subscribeTo(feedback_msg)

--- a/algorithms/stepperMotorController/stepperMotorController.cpp
+++ b/algorithms/stepperMotorController/stepperMotorController.cpp
@@ -22,7 +22,7 @@ void StepperMotorController::reset(const uint64_t callTime) {
 void StepperMotorController::updateState(const uint64_t callTime) {
     float referenceAngle{};
     if (this->motorRefAngleInMsg.isWritten()) {
-        const HingedRigidBodyMsgF32Payload motorRefAngleIn = this->motorRefAngleInMsg();
+        const MotorAngleRefMsgF32Payload motorRefAngleIn = this->motorRefAngleInMsg();
         referenceAngle = motorRefAngleIn.theta;
     }
 

--- a/algorithms/stepperMotorController/stepperMotorController.cpp
+++ b/algorithms/stepperMotorController/stepperMotorController.cpp
@@ -39,6 +39,12 @@ void StepperMotorController::updateState(const uint64_t callTime) {
     if (output.commandType == StepperMotorCommandType::MOVE) {
         MotorStepCommandMsgPayload motorStepCommandOut{};
         motorStepCommandOut.stepsCommanded = output.stepsToMove;
+        motorStepCommandOut.stopMotorCommand = false;
+        this->motorStepCommandOutMsg.write(&motorStepCommandOut, moduleID, callTime);
+    } else if (output.commandType == StepperMotorCommandType::STOP) {
+        MotorStepCommandMsgPayload motorStepCommandOut{};
+        motorStepCommandOut.stepsCommanded = 0;
+        motorStepCommandOut.stopMotorCommand = true;
         this->motorStepCommandOutMsg.write(&motorStepCommandOut, moduleID, callTime);
     }
 }

--- a/algorithms/stepperMotorController/stepperMotorController.cpp
+++ b/algorithms/stepperMotorController/stepperMotorController.cpp
@@ -1,8 +1,7 @@
 #include "stepperMotorController.h"
-#include <math.h>
 #include <stdexcept>
 
-/*! Reset the module. Checks that the input message is linked.
+/*! Reset the module. Checks that the input messages are linked.
  @return void
  @param callTime [ns] Time the method is called
 */
@@ -10,11 +9,9 @@ void StepperMotorController::reset(const uint64_t callTime) {
     if (!this->motorRefAngleInMsg.isLinked()) {
         throw std::invalid_argument("StepperMotorController.motorRefAngleInMsg wasn't connected.");
     }
-
-    const int initialStep = this->algorithm.angleToSteps(this->initialAngle);
-    this->currentPosition = initialStep;
-    this->commandedPosition = initialStep;
-    this->stepAccumulator = 0.0F;
+    if (!this->stepperMotorInMsg.isLinked()) {
+        throw std::invalid_argument("StepperMotorController.stepperMotorInMsg wasn't connected.");
+    }
     this->algorithm.reset();
 }
 
@@ -29,46 +26,20 @@ void StepperMotorController::updateState(const uint64_t callTime) {
         referenceAngle = motorRefAngleIn.theta;
     }
 
-    const bool isMotorMoving = (this->currentPosition != this->commandedPosition);
-    const StepperMotorControllerOutput output =
-        this->algorithm.update(this->currentPosition, referenceAngle, isMotorMoving);
+    int currentPosition = 0;
+    bool isMotorMoving = false;
+    if (this->stepperMotorInMsg.isWritten()) {
+        const StepperMotorMsgPayload stepperMotorIn = this->stepperMotorInMsg();
+        currentPosition = stepperMotorIn.motorPosition;
+        isMotorMoving = stepperMotorIn.isMotorMoving;
+    }
+
+    const StepperMotorControllerOutput output = this->algorithm.update(currentPosition, referenceAngle, isMotorMoving);
 
     if (output.commandType == StepperMotorCommandType::MOVE) {
-        this->commandedPosition = this->currentPosition + output.stepsToMove;
-        this->stepAccumulator = 0.0F;
         MotorStepCommandMsgPayload motorStepCommandOut{};
         motorStepCommandOut.stepsCommanded = output.stepsToMove;
         this->motorStepCommandOutMsg.write(&motorStepCommandOut, moduleID, callTime);
-    } else if (output.commandType == StepperMotorCommandType::STOP) {
-        // Freeze the motor at its current position; ignore any remaining commanded steps
-        this->commandedPosition = this->currentPosition;
-    }
-
-    this->advanceMotor();
-}
-
-/*! Advance the tracked motor position toward the commanded target, respecting the motor/control
- * frequency ratio via a fractional-step accumulator.
- @return void
-*/
-void StepperMotorController::advanceMotor() {
-    if (this->currentPosition == this->commandedPosition) {
-        return;
-    }
-
-    // Accumulate fractional steps based on motor/control frequency ratio.
-    // E.g. if ratio is 1.5, steps per tick alternate 1, 2, 1, 2, ...
-    this->stepAccumulator += this->motorFrequency / this->controlFrequency;
-    const auto wholeSteps = static_cast<int>(this->stepAccumulator);
-    this->stepAccumulator -= static_cast<float>(wholeSteps);
-
-    const int remaining = abs(this->commandedPosition - this->currentPosition);
-    const int stepsToAdvance = (wholeSteps < remaining) ? wholeSteps : remaining;
-
-    if (this->currentPosition < this->commandedPosition) {
-        this->currentPosition += stepsToAdvance;
-    } else {
-        this->currentPosition -= stepsToAdvance;
     }
 }
 
@@ -81,28 +52,6 @@ void StepperMotorController::setMotorAngleRange(const float minAngleIn, const fl
 }
 
 std::array<float, 2> StepperMotorController::getMotorAngleRange() const { return this->algorithm.getMotorAngleRange(); }
-
-void StepperMotorController::setInitialAngle(const float initialAngleIn) { this->initialAngle = initialAngleIn; }
-
-float StepperMotorController::getInitialAngle() const { return this->initialAngle; }
-
-void StepperMotorController::setControlFrequency(const float controlFrequencyIn) {
-    if (controlFrequencyIn <= 0.0F) {
-        throw std::invalid_argument("controlFrequency must be positive");
-    }
-    this->controlFrequency = controlFrequencyIn;
-}
-
-float StepperMotorController::getControlFrequency() const { return this->controlFrequency; }
-
-void StepperMotorController::setMotorFrequency(const float motorFrequencyIn) {
-    if (motorFrequencyIn <= 0.0F) {
-        throw std::invalid_argument("motorFrequency must be positive");
-    }
-    this->motorFrequency = motorFrequencyIn;
-}
-
-float StepperMotorController::getMotorFrequency() const { return this->motorFrequency; }
 
 void StepperMotorController::setSettleCountMax(const uint32_t settleCountMaxIn) {
     this->algorithm.setSettleCountMax(settleCountMaxIn);

--- a/algorithms/stepperMotorController/stepperMotorController.h
+++ b/algorithms/stepperMotorController/stepperMotorController.h
@@ -1,7 +1,7 @@
 #ifndef F32XMERA_STEPPER_MOTOR_CONTROLLER_H
 #define F32XMERA_STEPPER_MOTOR_CONTROLLER_H
 
-#include "msgPayloadDef/HingedRigidBodyMsgF32Payload.h"
+#include "msgPayloadDef/MotorAngleRefMsgF32Payload.h"
 #include "stepperMotorControllerAlgorithm.h"
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
@@ -31,7 +31,7 @@ class StepperMotorController : public SysModel {
     void setMinStepCommand(uint32_t minStepCommandIn);
     uint32_t getMinStepCommand() const;
 
-    ReadFunctor<HingedRigidBodyMsgF32Payload> motorRefAngleInMsg;  //!< Input msg for the motor reference angle
+    ReadFunctor<MotorAngleRefMsgF32Payload> motorRefAngleInMsg;  //!< Input msg for the motor reference angle
     ReadFunctor<StepperMotorMsgPayload>
         stepperMotorInMsg;  //!< Input msg from the stepper motor dynamics (motorPosition, isMotorMoving)
     Message<MotorStepCommandMsgPayload> motorStepCommandOutMsg;  //!< Output msg for commanded motor steps

--- a/algorithms/stepperMotorController/stepperMotorController.h
+++ b/algorithms/stepperMotorController/stepperMotorController.h
@@ -6,12 +6,13 @@
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
 #include <architecture/msgPayloadDef/MotorStepCommandMsgPayload.h>
+#include <architecture/msgPayloadDef/StepperMotorMsgPayload.h>
 #include <array>
 
 /*! @brief Stepper Motor Controller Xmera Adapter
  *
- * Tracks the motor's current position and simulates its step-wise motion toward the commanded
- * target, then delegates controller decisions to StepperMotorControllerAlgorithm.
+ * Reads the motor's absolute step position and motion status from the stepper motor dynamics
+ * module and delegates controller decisions to StepperMotorControllerAlgorithm.
  */
 class StepperMotorController : public SysModel {
    public:
@@ -25,30 +26,18 @@ class StepperMotorController : public SysModel {
     float getStepAngle() const;
     void setMotorAngleRange(float minAngleIn, float maxAngleIn);
     std::array<float, 2> getMotorAngleRange() const;
-    void setInitialAngle(float initialAngleIn);
-    float getInitialAngle() const;
-    void setControlFrequency(float controlFrequencyIn);
-    float getControlFrequency() const;
-    void setMotorFrequency(float motorFrequencyIn);
-    float getMotorFrequency() const;
     void setSettleCountMax(uint32_t settleCountMaxIn);
     uint32_t getSettleCountMax() const;
     void setMinStepCommand(uint32_t minStepCommandIn);
     uint32_t getMinStepCommand() const;
 
     ReadFunctor<HingedRigidBodyMsgF32Payload> motorRefAngleInMsg;  //!< Input msg for the motor reference angle
-    Message<MotorStepCommandMsgPayload> motorStepCommandOutMsg;    //!< Output msg for commanded motor steps
+    ReadFunctor<StepperMotorMsgPayload>
+        stepperMotorInMsg;  //!< Input msg from the stepper motor dynamics (motorPosition, isMotorMoving)
+    Message<MotorStepCommandMsgPayload> motorStepCommandOutMsg;  //!< Output msg for commanded motor steps
 
    private:
-    void advanceMotor();
-
     StepperMotorControllerAlgorithm algorithm{};
-    float initialAngle{};          //!< [rad] Initial motor angle
-    float controlFrequency{1.0F};  //!< [Hz] Rate at which updateState() is called
-    float motorFrequency{1.0F};    //!< [Hz] Motor step rate (steps per second)
-    int currentPosition{};         //!< [steps] Tracked current motor position
-    int commandedPosition{};       //!< [steps] Target the motor is currently driving toward
-    float stepAccumulator{};       //!< [steps] Fractional step accumulator for sub-tick motor advancement
 };
 
 #endif

--- a/algorithms/stepperMotorController/stepperMotorController.rst
+++ b/algorithms/stepperMotorController/stepperMotorController.rst
@@ -31,7 +31,8 @@ Python.
       - Stepper motor dynamics feedback (uses ``motorPosition`` and ``isMotorMoving``)
     * - motorStepCommandOutMsg
       - :ref:`MotorStepCommandMsgPayload`
-      - Commanded motor steps output message (uses ``stepsCommanded``). Written only when a new ``MOVE`` command is issued.
+      - Commanded motor steps output message. Written on a ``MOVE`` (sets ``stepsCommanded``,
+        ``stopMotorCommand=false``) or a ``STOP`` (sets ``stepsCommanded=0``, ``stopMotorCommand=true``).
 
 Algorithm Parameters
 -------------------------------
@@ -200,9 +201,10 @@ angle), and :math:`n_m` the position most recently commanded (stored internally)
 - ``MOVING`` — the motor is executing a commanded move. Two conditions are checked each tick, in priority order:
 
   1. *Reference changed.* If :math:`\left| \text{stepDelta}(n_m - n_d) \right| \ge \tau`, the algorithm emits a ``STOP``
-     command and transitions to ``STOPPING``. The Xmera adapter does NOT propagate the ``STOP`` to the motor dynamics —
-     because a stepper motor cannot stop mid-step — so the motor continues to execute the original step command.
-     The algorithm waits in ``STOPPING`` for the motor to finish, then re-plans from the resulting final position.
+     command and transitions to ``STOPPING``. The Xmera adapter forwards the ``STOP`` to the motor dynamics
+     (``stopMotorCommand=true``); because a stepper motor cannot stop mid-step, the motor finishes its current step
+     before halting. The algorithm waits in ``STOPPING`` for the motor to report ``isMotorMoving == false``, then
+     re-plans from the resulting final position.
   2. *Move complete.* Otherwise, if the caller reports ``isMotorMoving == false``, the algorithm transitions directly
      to ``SETTLING`` and resets the settle counter (skipping ``STOPPING``, since no ``STOP`` command needs to be
      issued — the motor has already come to rest at the commanded target).
@@ -232,8 +234,8 @@ Algorithm Assumptions and Limitations
 - Motor motion is assumed to be quantized at the step level; reference angles that fall between steps are rounded to
   the nearest step.
 - The caller is responsible for tracking the motor's current position and passing it to ``update()`` each tick.
-- When a ``STOP`` is issued mid-move, the Xmera adapter does not interrupt the motor; the motor completes its original
-  commanded steps and the algorithm re-plans from the resulting final position.
+- When a ``STOP`` is issued mid-move, the Xmera adapter forwards the stop to the motor; the motor completes its
+  current step before halting, and the algorithm re-plans from the resulting final position.
 - The ``OFF`` state is entered only via caller intervention; there is no transition into ``OFF`` from within the
   state machine.
 - The motor's travel range ``[minAngle, maxAngle]`` must satisfy :math:`-2\pi \le \text{minAngle} < \text{maxAngle} \le 2\pi`.
@@ -250,9 +252,10 @@ The ``StepperMotorController`` Xmera adapter provides the simulation integration
 - On ``reset()``, requires both input messages to be linked and resets the underlying algorithm state.
 - On each ``updateState()``, calls the algorithm with the feedback ``motorPosition``, the reference angle, and the
   feedback ``isMotorMoving``.
-- On a ``MOVE`` output, writes ``motorStepCommandOutMsg`` with the commanded step delta.
-- On a ``STOP`` output, takes no action toward the motor; the algorithm transitions to ``STOPPING`` and waits for the
-  motor to settle naturally.
+- On a ``MOVE`` output, writes ``motorStepCommandOutMsg`` with the commanded step delta and ``stopMotorCommand=false``.
+- On a ``STOP`` output, writes ``motorStepCommandOutMsg`` with ``stopMotorCommand=true`` and ``stepsCommanded=0``; the
+  motor halts after finishing its current step. The algorithm transitions to ``STOPPING`` and waits for
+  ``isMotorMoving == false``.
 
 User Guide
 ----------

--- a/algorithms/stepperMotorController/stepperMotorController.rst
+++ b/algorithms/stepperMotorController/stepperMotorController.rst
@@ -24,7 +24,7 @@ Python.
       - Msg Type
       - Description
     * - motorRefAngleInMsg
-      - :ref:`HingedRigidBodyMsgF32Payload`
+      - :ref:`MotorAngleRefMsgF32Payload`
       - Reference motor angle input message (uses ``theta``, [rad])
     * - stepperMotorInMsg
       - :ref:`StepperMotorMsgPayload`

--- a/algorithms/stepperMotorController/stepperMotorController.rst
+++ b/algorithms/stepperMotorController/stepperMotorController.rst
@@ -8,7 +8,8 @@ This module drives a stepper motor toward a reference angle by issuing integer s
 runs a small state machine (OFF / IDLE / MOVING / STOPPING / SETTLING) that decides when to command a new move, when a
 changed reference should interrupt the current move, and how long to wait after a stop before accepting new commands.
 The controller always commands the shortest path around a full revolution, so a reference on the opposite side of the
-motor is reached via the smaller of the two directions.
+motor is reached via the smaller of the two directions. The current motor position and motion status are read each tick
+from a stepper motor dynamics module via the ``stepperMotorInMsg`` input.
 
 Message Connection Descriptions
 -------------------------------
@@ -25,6 +26,9 @@ Python.
     * - motorRefAngleInMsg
       - :ref:`HingedRigidBodyMsgF32Payload`
       - Reference motor angle input message (uses ``theta``, [rad])
+    * - stepperMotorInMsg
+      - :ref:`StepperMotorMsgPayload`
+      - Stepper motor dynamics feedback (uses ``motorPosition`` and ``isMotorMoving``)
     * - motorStepCommandOutMsg
       - :ref:`MotorStepCommandMsgPayload`
       - Commanded motor steps output message (uses ``stepsCommanded``). Written only when a new ``MOVE`` command is issued.
@@ -81,43 +85,14 @@ adapter re-exposes all of these parameters through same-named setters/getters th
 
 Module Parameters
 -------------------------------
-The following table lists the parameters that live only on the Xmera adapter (``StepperMotorController``) — they
-configure the motor-motion simulator and the initial conditions applied on ``reset()``. The adapter additionally
-re-exposes every algorithm parameter from the table above.
-
-.. list-table:: Module Parameters (Xmera adapter only)
-    :widths: 32 15 10 10 40 30
-    :header-rows: 1
-
-    * - Parameter Name
-      - Type
-      - Units
-      - Default
-      - Description
-      - Bounds
-    * - initialAngle
-      - float
-      - [rad]
-      - 0.0
-      - Initial motor angle, used to seed the tracked current position on reset
-      - N/A
-    * - controlFrequency
-      - float
-      - [Hz]
-      - 1.0
-      - Rate at which ``updateState()`` is called by the simulation task
-      - Must be strictly positive (checked in setter)
-    * - motorFrequency
-      - float
-      - [Hz]
-      - 1.0
-      - Maximum motor step rate (steps per second) used by the Xmera motor-motion simulator
-      - Must be strictly positive (checked in setter)
+The Xmera adapter (``StepperMotorController``) exposes only the algorithm parameters listed in the previous table; it
+has no additional parameters of its own. The motor's absolute position is read each tick from
+``stepperMotorInMsg.motorPosition``, so the adapter does not need to be configured with an initial angle.
 
 Algorithm Input/Output
 -------------------------------
 The following tables list the inputs and outputs of the pure algorithm ``update()`` method, independent of the Xmera
-messaging layer and the motor-motion simulation.
+messaging layer.
 
 .. list-table:: Algorithm Inputs
     :widths: 25 20 10 45
@@ -225,8 +200,9 @@ angle), and :math:`n_m` the position most recently commanded (stored internally)
 - ``MOVING`` — the motor is executing a commanded move. Two conditions are checked each tick, in priority order:
 
   1. *Reference changed.* If :math:`\left| \text{stepDelta}(n_m - n_d) \right| \ge \tau`, the algorithm emits a ``STOP``
-     command and transitions to ``STOPPING``. The caller is expected to halt the motor at its current position; the
-     controller will re-plan from that position once it returns to ``IDLE``.
+     command and transitions to ``STOPPING``. The Xmera adapter does NOT propagate the ``STOP`` to the motor dynamics —
+     because a stepper motor cannot stop mid-step — so the motor continues to execute the original step command.
+     The algorithm waits in ``STOPPING`` for the motor to finish, then re-plans from the resulting final position.
   2. *Move complete.* Otherwise, if the caller reports ``isMotorMoving == false``, the algorithm transitions directly
      to ``SETTLING`` and resets the settle counter (skipping ``STOPPING``, since no ``STOP`` command needs to be
      issued — the motor has already come to rest at the commanded target).
@@ -243,22 +219,21 @@ positioning repeatability). From ``MOVING`` the same threshold gates whether a c
 interrupt the in-progress move (tuned to avoid interrupting on noise in the reference signal). Move completion in
 ``MOVING`` is detected via the caller's ``isMotorMoving`` signal rather than this threshold.
 
-Motor-Motion Simulation (Xmera Adapter)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The algorithm itself does not simulate the motor. The Xmera adapter advances the tracked current position toward the
-commanded position each tick using a fractional-step accumulator. Given ``motorFrequency`` :math:`f_m` and
-``controlFrequency`` :math:`f_c`, each tick adds :math:`f_m / f_c` to a running accumulator; the integer part is taken
-as the number of whole steps advanced that tick and the fractional remainder carries over. This produces the expected
-patterns for non-integer ratios (e.g. a 1.5 ratio alternates 1, 2, 1, 2, …). The advance never overshoots the commanded
-position.
+Position Tracking via Feedback (Xmera Adapter)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The adapter reads the motor's absolute step position directly from ``stepperMotorInMsg.motorPosition`` each tick
+(:math:`n_c = \text{motorPosition}_{\text{feedback}}`). The dynamics module maintains this as a cumulative net signed
+step count from the angular zero (``motorPosition * stepAngle`` ≈ :math:`\theta`) and never resets it across commands,
+so the adapter does not need to track command-start baselines or initialize a position. ``isMotorMoving`` is read
+directly from the same message.
 
 Algorithm Assumptions and Limitations
 -------------------------------------
 - Motor motion is assumed to be quantized at the step level; reference angles that fall between steps are rounded to
   the nearest step.
 - The caller is responsible for tracking the motor's current position and passing it to ``update()`` each tick.
-- When a ``STOP`` is issued mid-move, the Xmera adapter freezes the commanded position at the current step; any
-  remaining steps from the prior ``MOVE`` are discarded.
+- When a ``STOP`` is issued mid-move, the Xmera adapter does not interrupt the motor; the motor completes its original
+  commanded steps and the algorithm re-plans from the resulting final position.
 - The ``OFF`` state is entered only via caller intervention; there is no transition into ``OFF`` from within the
   state machine.
 - The motor's travel range ``[minAngle, maxAngle]`` must satisfy :math:`-2\pi \le \text{minAngle} < \text{maxAngle} \le 2\pi`.
@@ -271,13 +246,13 @@ Module Description (Xmera Usage)
 The ``StepperMotorController`` Xmera adapter provides the simulation integration layer for the algorithm. It:
 
 - Reads ``motorRefAngleInMsg`` to obtain the reference angle each tick.
-- Tracks the motor's current step position, the commanded position, and a fractional-step accumulator.
-- On ``reset()``, seeds the current and commanded positions from ``initialAngle`` (converted to steps).
-- On each ``updateState()``, calls the algorithm with the tracked current position and the reference angle.
-- On a ``MOVE`` output, writes ``motorStepCommandOutMsg`` with the commanded step delta and sets the new commanded
-  position.
-- On a ``STOP`` output, freezes the commanded position at the current position.
-- Advances the tracked current position toward the commanded position via the fractional-step accumulator.
+- Reads ``stepperMotorInMsg`` to obtain the motor's absolute ``motorPosition`` and ``isMotorMoving`` each tick.
+- On ``reset()``, requires both input messages to be linked and resets the underlying algorithm state.
+- On each ``updateState()``, calls the algorithm with the feedback ``motorPosition``, the reference angle, and the
+  feedback ``isMotorMoving``.
+- On a ``MOVE`` output, writes ``motorStepCommandOutMsg`` with the commanded step delta.
+- On a ``STOP`` output, takes no action toward the motor; the algorithm transitions to ``STOPPING`` and waits for the
+  motor to settle naturally.
 
 User Guide
 ----------
@@ -287,13 +262,11 @@ Typical usage in Python is::
     module.modelTag = "stepperMotorController"
     module.stepAngle = math.radians(1.0)             # [rad/step] (1 deg/step = 360 steps/rev)
     module.setMotorAngleRange(0.0, 2 * math.pi)      # full circle (default); use a partial range for bounded steppers
-    module.initialAngle = 0.0                        # [rad]
-    module.controlFrequency = 10.0                   # [Hz]
-    module.motorFrequency = 100.0                    # [Hz]
     module.settleCountMax = 2
     module.minStepCommand = 1
 
     module.motorRefAngleInMsg.subscribeTo(ref_msg)
+    module.stepperMotorInMsg.subscribeTo(stepper_motor.stepperMotorOutMsg)
 
 The commanded step delta is available on ``motorStepCommandOutMsg`` each time a new ``MOVE`` is issued.
 

--- a/algorithms/stepperMotorController/stepperMotorControllerF32.i
+++ b/algorithms/stepperMotorController/stepperMotorControllerF32.i
@@ -20,6 +20,6 @@
 %include "stepperMotorController.h"
 %include "stepperMotorControllerAlgorithm.h"
 
-%include "msgPayloadDef/HingedRigidBodyMsgF32Payload.h"
+%include "msgPayloadDef/MotorAngleRefMsgF32Payload.h"
 %include <architecture/msgPayloadDef/MotorStepCommandMsgPayload.h>
 %include <architecture/msgPayloadDef/StepperMotorMsgPayload.h>

--- a/algorithms/stepperMotorController/stepperMotorControllerF32.i
+++ b/algorithms/stepperMotorController/stepperMotorControllerF32.i
@@ -12,10 +12,7 @@
 %template(FloatArray2) std::array<float, 2>;
 
 %include <attribute.i>
-%attribute(StepperMotorController, float, initialAngle, getInitialAngle, setInitialAngle)
 %attribute(StepperMotorController, float, stepAngle, getStepAngle, setStepAngle)
-%attribute(StepperMotorController, float, controlFrequency, getControlFrequency, setControlFrequency)
-%attribute(StepperMotorController, float, motorFrequency, getMotorFrequency, setMotorFrequency)
 %attribute(StepperMotorController, uint32_t, settleCountMax, getSettleCountMax, setSettleCountMax)
 %attribute(StepperMotorController, uint32_t, minStepCommand, getMinStepCommand, setMinStepCommand)
 
@@ -25,3 +22,4 @@
 
 %include "msgPayloadDef/HingedRigidBodyMsgF32Payload.h"
 %include <architecture/msgPayloadDef/MotorStepCommandMsgPayload.h>
+%include <architecture/msgPayloadDef/StepperMotorMsgPayload.h>


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2154
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
Three updates were made to `stepperMotorController`:

1. `stepperMotorController` now receives the motor position from `stepperMotor`
2. `stepperMotorController` now issues a stop command to `stepperMotor`
3. A new `MotorAngleRefMsg` is now used instead of `HingedRigidBodyMsg`

All of these changes are only on the adapter level and did not change the `stepperMotorController` algorithm.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't
add or update any tests justify this choice. -->
Tests pass.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and
completeness? -->
Updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None