### PR TITLE
Add freestanding isfinite

### DIFF
--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -171,6 +171,10 @@ jobs:
           XMERA_FUZZTEST_REPLAY_FOR: inf
         run: ctest --output-on-failure -L fuzz
 
+      - name: Run exhaustive equivalence scans (CTest)
+        working-directory: xmera/build/fp32-fsw-xmera/algorithms
+        run: ctest --output-on-failure -L exhaustive
+
       - name: Run extended fuzz sessions
         working-directory: xmera/build/fp32-fsw-xmera/algorithms
         env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -288,7 +288,11 @@ jobs:
         working-directory: xmera/build/fp32-fsw-xmera/algorithms
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/junit"
-          ctest --output-on-failure --output-junit "${GITHUB_WORKSPACE}/junit/ctest-${{ matrix.os }}.xml"
+          # Exclude the exhaustive is_finite scans: under --coverage their ~4.3e9
+          # iterations make gcov emit an overflow-range hit count that aborts gcovr
+          # (gcc bug 68080). They add no line coverage (the fast suite covers every
+          # line) and run uninstrumented in daily-fuzz instead.
+          ctest --output-on-failure -LE exhaustive --output-junit "${GITHUB_WORKSPACE}/junit/ctest-${{ matrix.os }}.xml"
 
       - name: Run Python Tests
         run: |

--- a/algorithms/utilities/CMakeLists.txt
+++ b/algorithms/utilities/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(AlgorithmUtilities INTERFACE
   chebyshevUtilities.h
   orbitalMotion.hpp
   safeMath.h
+  freestandingIsFinite.hpp
 )
 
 target_link_libraries(AlgorithmUtilities INTERFACE

--- a/algorithms/utilities/_tests/CMakeLists.txt
+++ b/algorithms/utilities/_tests/CMakeLists.txt
@@ -73,6 +73,38 @@ target_link_libraries(test_orbitalMotion_degenerate PRIVATE
 
 gtest_discover_tests(test_orbitalMotion_degenerate)
 
+add_executable(test_freestandingIsFinite
+               test_freestandingIsFinite.cpp
+  freestandingIsFinite_static_tests.hpp
+)
+
+target_include_directories(test_freestandingIsFinite PRIVATE "..")
+
+# main() is defined in the source, so link gtest (NOT gtest_main).
+target_link_libraries(test_freestandingIsFinite PRIVATE
+    GTest::gtest
+)
+
+# Fast suite: equivalence classes, boundary, FP-flag, and the compile-time
+# static_asserts. Excludes the two long-running brute-force scans.
+gtest_discover_tests(test_freestandingIsFinite
+  TEST_FILTER "-FloatExhaustive.*:DoubleDifferential.*"
+  # Keep the generator-produced names (pos_zero, snan, ...); without this CMake
+  # rewrites the ctest label from gtest's "# GetParam() = 16-byte object <hex>"
+  # comment, since FCase/DCase have no operator<<.
+  NO_PRETTY_VALUES
+)
+
+# Brute-force scans (2^32 float + 50M double): registered separately and
+# labeled so the default ctest run can skip them (run with `ctest -L exhaustive`).
+gtest_discover_tests(test_freestandingIsFinite
+  TEST_FILTER "FloatExhaustive.*:DoubleDifferential.*"
+  TEST_PREFIX "exhaustive."
+  NO_PRETTY_VALUES
+  PROPERTIES
+    LABELS "exhaustive"
+)
+
 if(XMERA_ENABLE_FUZZTESTS)
   fuzztest_setup_fuzzing_flags()
 

--- a/algorithms/utilities/_tests/README.md
+++ b/algorithms/utilities/_tests/README.md
@@ -1,0 +1,41 @@
+# `utilities/_tests`
+
+Host-side gtest (and FuzzTest) suites for the header-only helpers in `algorithms/utilities/`
+(`validDcm`, `validateInertia`, `chebyshevUtilities`, `safeMath`, `orbitalMotion`,
+`freestandingIsFinite`). `CMakeLists.txt` in this directory is the source of truth for what is built
+and how each suite is registered.
+
+For the general CTest label vocabulary, fuzz presets, and CI behavior shared across the repo,
+see [`docs/TESTING.md`](../../../docs/TESTING.md). This file covers only what is specific to
+this directory.
+
+## The `exhaustive` label
+
+`test_freestandingIsFinite` is the one suite here that registers an `exhaustive`-labeled bucket: a
+brute-force equivalence proof against the standard-library oracle over **all 2³² float
+patterns** plus **50M random doubles**. It is cheap (~5 s total) and runs by default, but can
+be selected or skipped on its own:
+
+```bash
+# from the algorithms build dir, e.g. build/fp32-fsw-xmera/algorithms
+ctest -L exhaustive                              # only the brute-force scans
+ctest -R freestandingIsFinite                          # the whole freestandingIsFinite suite
+ctest -R freestandingIsFinite --label-exclude exhaustive   # its fast subset only
+ctest -R freestandingIsFinite -N                        # list, don't run
+```
+
+`exhaustive` is currently unique to this directory; everywhere else the only labels are
+`fuzz`/`fuzz-smoke`.
+
+## `test_freestandingIsFinite` registration notes
+
+The suite is registered twice from a single executable (`test_freestandingIsFinite.cpp`):
+
+- a **fast** bucket — the parameterized equivalence-class, boundary, and FP-flag cases; and
+- an **`exhaustive`** bucket — the two brute-force scans, given the `exhaustive.` test prefix.
+
+Both registrations pass `NO_PRETTY_VALUES` so CTest keeps the generator-produced case names
+(`pos_zero`, `snan`, …) instead of gtest's `# GetParam() = 16-byte object <hex>` parameter
+dump (the `FCase`/`DCase` structs have no `operator<<`). The executable defines its own
+`main()`, so it links `GTest::gtest` rather than `GTest::gtest_main`. The compile-time
+`static_assert` evidence lives in `freestandingIsFinite_static_tests.hpp` and fires during the build.

--- a/algorithms/utilities/_tests/freestandingIsFinite_static_tests.hpp
+++ b/algorithms/utilities/_tests/freestandingIsFinite_static_tests.hpp
@@ -1,0 +1,62 @@
+#ifndef FREESTANDING_IS_FINITE_STATIC_TESTS_HPP
+#define FREESTANDING_IS_FINITE_STATIC_TESTS_HPP
+
+//============================================================================
+//  freestandingIsFinite_static_tests.hpp
+//
+//  Compile-time (static_assert) tests for fsw::is_finite over every IEEE-754
+//  equivalence class. Freestanding-safe: no runtime, no harness, no <cmath>.
+//
+//  Include this from BOTH:
+//    - your freestanding build  -> these are your on-target compile-time
+//      evidence (they need no runtime and run on the actual toolchain), and
+//    - the host gtest build      -> so the same evidence is reproduced there.
+//
+//  Because the calls are constant-evaluated, any UB inside is_finite would make
+//  these ill-formed, so this header is also a partial UB check.
+//============================================================================
+
+#include "freestandingIsFinite.hpp"
+#include <bit>
+#include <cstdint>
+
+namespace fsw_static_tests {
+
+inline constexpr float f_from(std::uint32_t b) noexcept { return std::bit_cast<float>(b); }
+inline constexpr double d_from(std::uint64_t b) noexcept { return std::bit_cast<double>(b); }
+
+// ---- float (binary32): finite classes ----
+static_assert(fsw::is_finite(f_from(0x0000'0000u)), "+0");
+static_assert(fsw::is_finite(f_from(0x8000'0000u)), "-0");
+static_assert(fsw::is_finite(f_from(0x0000'0001u)), "smallest subnormal");
+static_assert(fsw::is_finite(f_from(0x007F'FFFFu)), "largest subnormal");
+static_assert(fsw::is_finite(f_from(0x0080'0000u)), "smallest normal");
+static_assert(fsw::is_finite(f_from(0x3F80'0000u)), "1.0");
+static_assert(fsw::is_finite(f_from(0xBF80'0000u)), "-1.0");
+static_assert(fsw::is_finite(f_from(0x7F7F'FFFFu)), "FLT_MAX");
+
+// ---- float: non-finite classes (the finite/non-finite boundary) ----
+static_assert(!fsw::is_finite(f_from(0x7F80'0000u)), "+Inf");
+static_assert(!fsw::is_finite(f_from(0xFF80'0000u)), "-Inf");
+static_assert(!fsw::is_finite(f_from(0x7FC0'0000u)), "qNaN");
+static_assert(!fsw::is_finite(f_from(0xFFC0'0000u)), "-qNaN");
+static_assert(!fsw::is_finite(f_from(0x7F80'0001u)), "sNaN");
+
+// ---- double (binary64): finite classes ----
+static_assert(fsw::is_finite(d_from(0x0000'0000'0000'0000ull)), "+0");
+static_assert(fsw::is_finite(d_from(0x8000'0000'0000'0000ull)), "-0");
+static_assert(fsw::is_finite(d_from(0x0000'0000'0000'0001ull)), "smallest subnormal");
+static_assert(fsw::is_finite(d_from(0x000F'FFFF'FFFF'FFFFull)), "largest subnormal");
+static_assert(fsw::is_finite(d_from(0x0010'0000'0000'0000ull)), "smallest normal");
+static_assert(fsw::is_finite(d_from(0x3FF0'0000'0000'0000ull)), "1.0");
+static_assert(fsw::is_finite(d_from(0x7FEF'FFFF'FFFF'FFFFull)), "DBL_MAX");
+
+// ---- double: non-finite classes ----
+static_assert(!fsw::is_finite(d_from(0x7FF0'0000'0000'0000ull)), "+Inf");
+static_assert(!fsw::is_finite(d_from(0xFFF0'0000'0000'0000ull)), "-Inf");
+static_assert(!fsw::is_finite(d_from(0x7FF8'0000'0000'0000ull)), "qNaN");
+static_assert(!fsw::is_finite(d_from(0x7FF0'0000'0000'0001ull)), "sNaN");
+
+}  // namespace fsw_static_tests
+
+#endif  // FREESTANDING_IS_FINITE_STATIC_TESTS_HPP

--- a/algorithms/utilities/_tests/test_freestandingIsFinite.cpp
+++ b/algorithms/utilities/_tests/test_freestandingIsFinite.cpp
@@ -1,0 +1,201 @@
+//============================================================================
+//  test_freestandingIsFinite.cpp
+//
+//  Host-side Google Test suite for fsw::is_finite. (gtest is a hosted
+//  framework, so this is host verification only -- it does not run on the
+//  freestanding target. The compile-time evidence lives in
+//  freestandingIsFinite_static_tests.hpp, which is included below and also
+//  compiled into the freestanding build.)
+//
+//  Suites:
+//    FloatClass / DoubleClass  -- parameterized: one named case per IEEE-754
+//                                 equivalence class, run through the emitted
+//                                 (non-constant-folded) code path.
+//    FloatExhaustive           -- compares against the oracle over all 2^32
+//                                 float patterns: a complete equivalence proof.
+//    DoubleDifferential        -- randomized + boundary sweep for double.
+//    FpEnvironment             -- is_finite must raise NO IEEE exception flag
+//                                 on Inf / signaling NaN.
+//
+//  Build (link gtest, not gtest_main, since main() is defined here):
+//    g++ -std=c++23 -O2 -Wall -Wextra test_freestandingIsFinite.cpp \
+//        -lgtest -pthread -o run_tests && ./run_tests
+//  Skip the slow exhaustive scan with:
+//    ./run_tests --gtest_filter=-FloatExhaustive.*
+//============================================================================
+
+#include "freestandingIsFinite.hpp"
+#include "freestandingIsFinite_static_tests.hpp"  // compile-time checks fire here too
+
+#include <gtest/gtest.h>
+
+#include <bit>
+#include <cfenv>  // feclearexcept / fetestexcept
+#include <cmath>  // std::isfinite (reference oracle)
+#include <cstdint>
+#include <random>
+#include <string>
+
+namespace {
+
+//----------------------------------------------------------------------------
+//  Launder inputs through a volatile INTEGER, then reinterpret the bits.
+//  (a) Defeats constant folding so is_finite's emitted code path is exercised.
+//  (b) Laundering in the integer domain means reconstructing a signaling NaN
+//      raises no FP exception during setup -- important on x87 targets and a
+//      prerequisite for the FpEnvironment test below to be meaningful.
+//----------------------------------------------------------------------------
+[[gnu::noinline]] float runtime_f(std::uint32_t b) noexcept {
+    volatile std::uint32_t v = b;
+    return std::bit_cast<float>(v);
+}
+[[gnu::noinline]] double runtime_d(std::uint64_t b) noexcept {
+    volatile std::uint64_t v = b;
+    return std::bit_cast<double>(v);
+}
+
+// Two independent oracles to guard against common-mode oracle error.
+bool oracle_finite(float x) { return std::isfinite(x) && __builtin_isfinite(x); }
+bool oracle_finite(double x) { return std::isfinite(x) && __builtin_isfinite(x); }
+
+struct FCase {
+    std::uint32_t bits;
+    bool finite;
+    const char* name;
+};
+struct DCase {
+    std::uint64_t bits;
+    bool finite;
+    const char* name;
+};
+
+const FCase kFloatCases[] = {
+    {0x0000'0000u, true, "pos_zero"},
+    {0x8000'0000u, true, "neg_zero"},
+    {0x0000'0001u, true, "smallest_subnormal"},
+    {0x007F'FFFFu, true, "largest_subnormal"},
+    {0x0080'0000u, true, "smallest_normal"},
+    {0x3F80'0000u, true, "one"},
+    {0xBF80'0000u, true, "neg_one"},
+    {0x7F7F'FFFFu, true, "flt_max"},
+    {0x7F80'0000u, false, "pos_inf"},
+    {0xFF80'0000u, false, "neg_inf"},
+    {0x7FC0'0000u, false, "qnan"},
+    {0xFFC0'0000u, false, "neg_qnan"},
+    {0x7F80'0001u, false, "snan"},
+};
+
+const DCase kDoubleCases[] = {
+    {0x0000'0000'0000'0000ull, true, "pos_zero"},
+    {0x8000'0000'0000'0000ull, true, "neg_zero"},
+    {0x0000'0000'0000'0001ull, true, "smallest_subnormal"},
+    {0x000F'FFFF'FFFF'FFFFull, true, "largest_subnormal"},
+    {0x0010'0000'0000'0000ull, true, "smallest_normal"},
+    {0x3FF0'0000'0000'0000ull, true, "one"},
+    {0x7FEF'FFFF'FFFF'FFFFull, true, "dbl_max"},
+    {0x7FF0'0000'0000'0000ull, false, "pos_inf"},
+    {0xFFF0'0000'0000'0000ull, false, "neg_inf"},
+    {0x7FF8'0000'0000'0000ull, false, "qnan"},
+    {0x7FF0'0000'0000'0001ull, false, "snan"},
+};
+
+}  // namespace
+
+//----------------------------------------------------------------------------
+//  Parameterized equivalence-class tests (one reported case per class).
+//----------------------------------------------------------------------------
+class FloatClass : public ::testing::TestWithParam<FCase> {};
+class DoubleClass : public ::testing::TestWithParam<DCase> {};
+
+TEST_P(FloatClass, ClassifiesCorrectly) {
+    const FCase c = GetParam();
+    const float x = runtime_f(c.bits);
+    EXPECT_EQ(fsw::is_finite(x), c.finite) << "bits=0x" << std::hex << c.bits;
+    EXPECT_EQ(fsw::is_finite(x), oracle_finite(x)) << "disagrees with oracle";
+}
+
+TEST_P(DoubleClass, ClassifiesCorrectly) {
+    const DCase c = GetParam();
+    const double x = runtime_d(c.bits);
+    EXPECT_EQ(fsw::is_finite(x), c.finite) << "bits=0x" << std::hex << c.bits;
+    EXPECT_EQ(fsw::is_finite(x), oracle_finite(x)) << "disagrees with oracle";
+}
+
+INSTANTIATE_TEST_SUITE_P(EquivalenceClasses,
+                         FloatClass,
+                         ::testing::ValuesIn(kFloatCases),
+                         [](const ::testing::TestParamInfo<FCase>& i) { return std::string(i.param.name); });
+
+INSTANTIATE_TEST_SUITE_P(EquivalenceClasses,
+                         DoubleClass,
+                         ::testing::ValuesIn(kDoubleCases),
+                         [](const ::testing::TestParamInfo<DCase>& i) { return std::string(i.param.name); });
+
+//----------------------------------------------------------------------------
+//  Exhaustive float: complete equivalence to the oracle over all 2^32 patterns.
+//  Long-running; filter out with --gtest_filter=-FloatExhaustive.* if needed.
+//----------------------------------------------------------------------------
+TEST(FloatExhaustive, EquivalentToOracle) {
+    std::uint64_t mismatches = 0;
+    int reported = 0;
+    for (std::uint64_t i = 0; i <= 0xFFFF'FFFFull; ++i) {
+        const auto bits = static_cast<std::uint32_t>(i);
+        const float x = runtime_f(bits);
+        if (fsw::is_finite(x) != oracle_finite(x)) {
+            ++mismatches;
+            if (reported++ < 20) ADD_FAILURE() << "float mismatch bits=0x" << std::hex << bits;
+        }
+    }
+    EXPECT_EQ(mismatches, 0u);
+}
+
+//----------------------------------------------------------------------------
+//  Randomized differential + exponent-boundary sweep for double.
+//----------------------------------------------------------------------------
+TEST(DoubleDifferential, EquivalentToOracle) {
+    std::mt19937_64 rng(0xC0FFEEULL);  // fixed seed -> reproducible
+    std::uint64_t mismatches = 0;
+    int reported = 0;
+    for (long n = 0; n < 50'000'000L; ++n) {
+        const std::uint64_t bits = rng();
+        const double x = runtime_d(bits);
+        if (fsw::is_finite(x) != oracle_finite(x)) {
+            ++mismatches;
+            if (reported++ < 20) ADD_FAILURE() << "double mismatch bits=0x" << std::hex << bits;
+        }
+    }
+    EXPECT_EQ(mismatches, 0u);
+}
+
+TEST(DoubleBoundary, ExponentEdge) {
+    // exp == all-ones  -> Inf/NaN (non-finite);  exp == all-ones - 1 -> finite.
+    for (std::uint64_t frac = 0; frac < 64; ++frac) {
+        EXPECT_FALSE(fsw::is_finite(runtime_d((0x7FFull << 52) | frac))) << "frac=" << frac;
+        EXPECT_TRUE(fsw::is_finite(runtime_d((0x7FEull << 52) | frac))) << "frac=" << frac;
+    }
+}
+
+//----------------------------------------------------------------------------
+//  FP status-flag NON-INTERFERENCE: is_finite must raise no IEEE exception flag
+//  on Inf or signaling NaN. (A value-level check like (x - x == 0) would set
+//  FE_INVALID and fail this test.)
+//----------------------------------------------------------------------------
+TEST(FpEnvironment, IsFiniteRaisesNoException) {
+    const float snan = runtime_f(0x7F80'0001u);
+    const float inf = runtime_f(0x7F80'0000u);
+    const double dsnan = runtime_d(0x7FF0'0000'0000'0001ull);
+
+    ASSERT_EQ(std::feclearexcept(FE_ALL_EXCEPT), 0);
+    volatile bool sink = false;
+    sink ^= fsw::is_finite(snan);
+    sink ^= fsw::is_finite(inf);
+    sink ^= fsw::is_finite(dsnan);
+    (void)sink;
+
+    EXPECT_EQ(std::fetestexcept(FE_ALL_EXCEPT), 0) << "is_finite must not raise IEEE floating-point exception flags";
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/algorithms/utilities/freestandingIsFinite.hpp
+++ b/algorithms/utilities/freestandingIsFinite.hpp
@@ -1,0 +1,108 @@
+#ifndef FREESTANDING_IS_FINITE_HPP
+#define FREESTANDING_IS_FINITE_HPP
+
+//  Freestanding, IEEE-754 bit-pattern replacement for std::isfinite.
+//
+//  Why This Exists
+//  ---------------
+//  std::isfinite lives in <cmath>, which is not a freestanding header.
+//  In a freestanding build std::isfinite may be absent. This header
+//  reimplements the check using only freestanding facilities so it
+//  is always available.
+//
+//  How It Works
+//  ------------
+//  An IEEE-754 binary float is non-finite (Inf or NaN) exactly when its exponent
+//  field is all-ones:
+//      - exponent all-ones, fraction == 0  -> +/- infinity
+//      - exponent all-ones, fraction != 0  -> NaN (quiet or signaling)
+//  Every other bit pattern is a finite value. We therefore isolate the exponent
+//  field and test whether it is all-ones. No floating-point comparison or
+//  arithmetic is performed.
+//
+//  Why But Inspection Rather Than Value Checks
+//  -------------------------------------------
+//  Value-level idioms such as (x == x) or ((x - x) == 0) execute floating-point
+//  operations. On Inf-Inf, or on any operation involving a signaling NaN, those
+//  can set the IEEE invalid-operation status flag and may trap if the system
+//  enables FP exception trapping. std::bit_cast performs NO floating-point
+//  operation: GCC lowers it in the integer domain (load + and + compare), so it
+//  never perturbs the FPU status flags and never signals on an sNaN. In a
+//  critical system that monitors fetestexcept() or traps on FP exceptions, this
+//  non-interference is a correctness property, not just a convenience.
+//
+//  Toolchain and Runtime Notes
+//  ---------------------------
+//  - In libstdc++, std::bit_cast is a header-only wrapper over the
+//    __builtin_bit_cast intrinsic: no out-of-line symbol, no runtime support
+//    required. Safe with no libstdc++ runtime linked (typical freestanding case).
+//  - Target / build assumptions: IEEE-754 ("is_iec559") float and double, and
+//    -ffast-math / -ffinite-math-only NOT in effect. (Under -ffinite-math-only
+//    the compiler is told Inf/NaN cannot occur and may corrupt values upstream
+//    of this check; this header assumes that flag is off.)
+//
+//  Guaranteed Correct For All Inputs
+//  ---------------------------------
+//      +0.0 / -0.0      -> finite      (exponent field == 0)
+//      subnormals       -> finite      (exponent field == 0)
+//      largest normal   -> finite      (exponent field == all-ones minus one)
+//      +/- infinity     -> NOT finite
+//      NaN (q and s)    -> NOT finite
+//
+//  Standard: C++23 (freestanding)   Compiler: GCC / GNAT Pro (g++)
+
+#include <bit>          // std::bit_cast                  (freestanding)
+#include <cstdint>      // std::uint32_t, std::uint64_t   (freestanding)
+#include <limits>       // std::numeric_limits            (freestanding)
+#include <type_traits>  // std::is_floating_point_v, etc. (freestanding)
+
+namespace fsw {
+
+//----------------------------------------------------------------------------
+//  is_finite
+//
+//  Returns true if and only if `x` is a finite IEEE-754 value (i.e. it is
+//  neither an infinity nor a NaN). Performs no floating-point operation and
+//  does not touch the FPU status flags. constexpr and noexcept.
+//
+//  Preconditions (enforced at compile time):
+//    - T is a floating-point type.
+//    - T uses the IEC 559 / IEEE-754 representation.
+//    - T is 32-bit (binary32) or 64-bit (binary64).
+//
+//  long double is deliberately rejected by the size assertion: depending on the
+//  target it may be 80-bit x87 extended (with an explicit integer bit and a
+//  different field layout), 128-bit quad, or PowerPC double-double, none of
+//  which match the simple single-field layout assumed here. Provide a
+//  target-specific overload if you must classify long double.
+//----------------------------------------------------------------------------
+template <typename T>
+[[nodiscard]] constexpr bool is_finite(T x) noexcept {
+    static_assert(std::is_floating_point_v<T>, "floating-point only");
+    static_assert(std::numeric_limits<T>::is_iec559, "requires IEEE-754");
+    static_assert(sizeof(T) == 4 || sizeof(T) == 8, "unsupported FP size");
+
+    // Unsigned integer type with the same width as T, used to view its bits.
+    using bits_t = std::conditional_t<sizeof(T) == 4, std::uint32_t, std::uint64_t>;
+
+    // Derive the IEEE-754 field widths from the type's own properties so there
+    // are no unexplained magic constants to audit:
+    //   total    = sign(1) + exponent + mantissa(stored)
+    //   mantissa = digits - 1   (the leading 1 bit is implicit for normals)
+    //   exponent = total - 1 - mantissa
+    constexpr int total_bits = static_cast<int>(sizeof(T)) * 8;
+    constexpr int mantissa_bits = std::numeric_limits<T>::digits - 1;
+    constexpr int exponent_bits = total_bits - 1 - mantissa_bits;
+
+    // Mask selecting only the exponent field (all-ones exponent, zero elsewhere).
+    //   binary32 -> 0x7F80'0000
+    //   binary64 -> 0x7FF0'0000'0000'0000
+    constexpr bits_t exponent_mask = ((bits_t{1} << exponent_bits) - 1U) << mantissa_bits;
+
+    // Reinterpret the bits (no FP op), then: finite iff exponent is NOT all-ones.
+    return (std::bit_cast<bits_t>(x) & exponent_mask) != exponent_mask;
+}
+
+}  // namespace fsw
+
+#endif  // FREESTANDING_IS_FINITE_HPP

--- a/algorithms/utilities/timeConstants.h
+++ b/algorithms/utilities/timeConstants.h
@@ -7,7 +7,7 @@ inline constexpr float kNano2SecF = 1e-9F;
 inline constexpr double kSec2Nano = 1e9;
 inline constexpr float kSec2NanoF = 1e9F;
 
-inline constexpr float kSec2Hour = 1.0 / 3600.0;
+inline constexpr double kSec2Hour = 1.0 / 3600.0;
 inline constexpr float kSec2HourF = 1.0F / 3600.0F;
 
 #endif

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,69 @@
+# Running the C++ Tests
+
+**Adamant-Xmera Flight Software Algorithms (fp32-fsw-xmera)**
+
+This document describes how the C++ host tests are organized and how to run subsets of
+them with CTest. Each algorithm keeps its host gtest (and FuzzTest) suites in an `_tests/`
+directory beside the code; tests are bucketed with CTest **labels** so the slow and optional
+suites can be included or excluded explicitly.
+
+For fuzz-testing *methodology* (when and how to write fuzz targets), see
+[`PRECISION_GUIDELINES.md` §9](PRECISION_GUIDELINES.md#9-fuzz-testing-for-precision-validation).
+
+---
+
+## 1. Label vocabulary
+
+| Label                 | What it is                                                        | Built by default? | Run in PR CI? |
+|-----------------------|-------------------------------------------------------------------|-------------------|---------------|
+| *(unlabeled)*         | Fast unit / validation tests — the common case                    | yes               | yes           |
+| `fuzz` + `fuzz-smoke` | FuzzTest targets (both labels applied together)                   | only when fuzzing is enabled | smoke subset only |
+| `exhaustive`          | Long brute-force scans (currently only `utilities/_tests`)        | yes               | yes (cheap, ~5 s) |
+
+`fuzz`/`fuzz-smoke` are used across most algorithm `_tests/` directories. `exhaustive` is
+currently specific to `algorithms/utilities/_tests` — see that directory's `README.md`.
+
+> CTest's `-L` (include) and `-LE` (exclude) take **regexes**, and a bare `ctest` runs
+> *everything configured in the build* — it does not skip `exhaustive`. Exclude long buckets
+> explicitly.
+
+## 2. Running tests
+
+Run CTest from the algorithms build directory, e.g. `build/fp32-fsw-xmera/algorithms`:
+
+```bash
+# Everything that is configured
+ctest --output-on-failure
+
+# Fast suites only — skip the long buckets
+ctest --output-on-failure -LE "exhaustive|fuzz"
+
+# A single module's tests
+ctest --output-on-failure -R <moduleName>
+
+# Just list matching tests without running them
+ctest -N -R <moduleName>
+```
+
+## 3. Fuzz tests
+
+The `*_fuzz` targets are gated behind the CMake option `XMERA_ENABLE_FUZZTESTS` (defined in
+`src/cmake/XmeraGoogleTest.cmake`, **OFF** by default) and are not built otherwise. Enable
+them with a preset (`src/CMakePresets.json`):
+
+```bash
+cmake --preset fuzz-smoke-test    # builds fuzz targets; short smoke runs
+cmake --preset fuzz-test          # adds FUZZTEST_FUZZING_MODE for long corpus runs
+
+# then, from the algorithms build dir:
+ctest --output-on-failure -L fuzz-smoke    # quick fuzz smoke pass
+ctest --output-on-failure -L fuzz          # all fuzz targets
+```
+
+## 4. What CI runs
+
+- **Pull request** (`.github/workflows/pull-request.yml`): configures `fuzz-smoke-test`, then
+  `ctest --output-on-failure -LE fuzz`. This excludes fuzz but **not** `exhaustive`, so the
+  (cheap) brute-force scans run on every PR.
+- **Nightly** (`.github/workflows/nightly-long-tests.yml`): configures `fuzz-test`, then
+  `ctest --output-on-failure` (all suites), followed by a separate long fuzzing run.


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2278
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
`std::isfinite` is not available in freestanding C++. This PR adds a replacement version of the function that suitable for freestanding environments.

## Verification
Tests are added.

## Documentation
Is updated for this repo. In particular the testing setup and build toggles available.

## Future work
None
