### PR TITLE
Add vector input guards dvguidance

### DIFF
--- a/algorithms/dvGuidance/_tests/dvGuidanceTestHelpers.hpp
+++ b/algorithms/dvGuidance/_tests/dvGuidanceTestHelpers.hpp
@@ -18,23 +18,39 @@ struct ReferenceDvGuidanceOutput {
 
 // Independent reference implementation kept in pure double precision, used to verify the
 // algorithm's FP32 output to within float tolerance. Attitude is returned as a DCM (not an MRP)
-// so the test comparison is robust at the MRP shadow-set boundary (|sigma|=1 at 180 deg).
+// so the test comparison is robust at the MRP shadow-set boundary (|sigma|=1 at 180 deg). The
+// degenerate-input and small-angle guards mirror DvGuidanceAlgorithm::update() (reusing the same
+// threshold constants) so the reference stays in lockstep with the algorithm.
 inline ReferenceDvGuidanceOutput referenceDvGuidance(const Eigen::Vector3d& dvInrtlCmd,
                                                      const Eigen::Vector3d& dvRotVecUnit,
                                                      double dvRotVecMag,
                                                      uint64_t burnStartTime,
                                                      uint64_t callTime) {
+    const ReferenceDvGuidanceOutput safeDefault = {
+        Eigen::Matrix3d::Identity(), Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero()};
+
+    if (dvInrtlCmd.squaredNorm() < static_cast<double>(DvGuidanceAlgorithm::kMinNormSq)) {
+        return safeDefault;
+    }
     const Eigen::Vector3d dvHat_N = dvInrtlCmd.normalized();
+
+    const Eigen::Vector3d cross = dvRotVecUnit.normalized().cross(dvHat_N);
+    if (!(cross.squaredNorm() >= static_cast<double>(DvGuidanceAlgorithm::kMinCrossSq))) {
+        return safeDefault;
+    }
     Eigen::Matrix3d dcm_BubN;
     dcm_BubN.row(0) = dvHat_N;
-    dcm_BubN.row(1) = dvRotVecUnit.cross(dvHat_N).normalized();
+    dcm_BubN.row(1) = cross.normalized();
     dcm_BubN.row(2) = dcm_BubN.row(0).cross(dcm_BubN.row(1)).normalized();
 
     const double burnTime =
         static_cast<double>(static_cast<int64_t>(callTime) - static_cast<int64_t>(burnStartTime)) * 1e-9;
 
-    const Eigen::Vector3d prv = {0.0, 0.0, dvRotVecMag * burnTime};
-    const Eigen::Matrix3d dcm_ButBub = prvToDcm(prv);
+    const double angle = dvRotVecMag * burnTime;
+    Eigen::Matrix3d dcm_ButBub = Eigen::Matrix3d::Identity();
+    if (std::abs(angle) >= static_cast<double>(DvGuidanceAlgorithm::kSmallAngle)) {
+        dcm_ButBub = prvToDcm(Eigen::Vector3d{0.0, 0.0, angle});
+    }
     const Eigen::Matrix3d dcm_ButN = dcm_ButBub * dcm_BubN;
 
     return {
@@ -54,12 +70,34 @@ inline void testDvGuidance(const Eigen::Vector3f& dvInrtlCmd,
     DvGuidanceOutput out;
     EXPECT_NO_THROW(out = alg.update(dvInrtlCmd, dvRotVecUnit, dvRotVecMag, burnStartTime, callTime));
 
+    // Robustness: the output is finite for any input in the domain (the degenerate-input guards
+    // return a safe default instead of propagating NaN).
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_TRUE(std::isfinite(out.sigma_RN[i]));
+        EXPECT_TRUE(std::isfinite(out.omega_RN_N[i]));
+        EXPECT_TRUE(std::isfinite(out.domega_RN_N[i]));
+    }
+
+    // Accuracy: only compare against the double reference where the inputs are unambiguously on one
+    // side of every guard (evaluated in double, with margin) so a FP32-vs-double boundary
+    // disagreement can't pit a guarded path against an unguarded one. The guard regions and the
+    // snap boundary themselves are covered by explicit edge tests.
+    const Eigen::Vector3d cmd_d = dvInrtlCmd.cast<double>();
+    const Eigen::Vector3d rot_d = dvRotVecUnit.cast<double>();
+    const double sinSq = rot_d.normalized().cross(cmd_d.normalized()).squaredNorm();
+    const double burnTime =
+        static_cast<double>(static_cast<int64_t>(callTime) - static_cast<int64_t>(burnStartTime)) * 1e-9;
+    const double absAngle = std::abs(static_cast<double>(dvRotVecMag) * burnTime);
+    const double kSmallAngle = static_cast<double>(DvGuidanceAlgorithm::kSmallAngle);
+    const bool nonDegenerate = cmd_d.squaredNorm() > 1.5 * static_cast<double>(DvGuidanceAlgorithm::kMinNormSq) &&
+                               sinSq > 1.5 * static_cast<double>(DvGuidanceAlgorithm::kMinCrossSq) &&
+                               (absAngle <= 0.5 * kSmallAngle || absAngle >= 2.0 * kSmallAngle);
+    if (!nonDegenerate) {
+        return;
+    }
+
     ReferenceDvGuidanceOutput ref;
-    EXPECT_NO_THROW(ref = referenceDvGuidance(dvInrtlCmd.cast<double>(),
-                                              dvRotVecUnit.cast<double>(),
-                                              static_cast<double>(dvRotVecMag),
-                                              burnStartTime,
-                                              callTime));
+    EXPECT_NO_THROW(ref = referenceDvGuidance(cmd_d, rot_d, static_cast<double>(dvRotVecMag), burnStartTime, callTime));
 
     constexpr float tol = 1e-5F;
     const Eigen::Matrix3f outDcm = mrpToDcm<float>(out.sigma_RN);
@@ -70,10 +108,6 @@ inline void testDvGuidance(const Eigen::Vector3f& dvInrtlCmd,
         }
         EXPECT_NEAR(out.omega_RN_N[i], static_cast<float>(ref.omega_RN_N[i]), tol);
         EXPECT_NEAR(out.domega_RN_N[i], static_cast<float>(ref.domega_RN_N[i]), tol);
-
-        EXPECT_TRUE(std::isfinite(out.sigma_RN[i]));
-        EXPECT_TRUE(std::isfinite(out.omega_RN_N[i]));
-        EXPECT_TRUE(std::isfinite(out.domega_RN_N[i]));
     }
 }
 

--- a/algorithms/dvGuidance/_tests/test_dvGuidance.cpp
+++ b/algorithms/dvGuidance/_tests/test_dvGuidance.cpp
@@ -94,3 +94,91 @@ TEST(DvGuidanceTest, MrpStaysWithinShadowSwitch) {
         EXPECT_TRUE(std::isfinite(out.omega_RN_N[i]));
     }
 }
+
+// Asserts the degenerate-input guard returns the safe default (identity attitude, zero rates).
+static void expectSafeDefault(const DvGuidanceOutput& out) {
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FLOAT_EQ(out.sigma_RN[i], 0.0F);
+        EXPECT_FLOAT_EQ(out.omega_RN_N[i], 0.0F);
+        EXPECT_FLOAT_EQ(out.domega_RN_N[i], 0.0F);
+        EXPECT_TRUE(std::isfinite(out.sigma_RN[i]));
+    }
+}
+
+TEST(DvGuidanceTest, ZeroDeltaVCommand) {
+    // |dvInrtlCmd| = 0: no burn direction -> safe default instead of NaN from the first normalize.
+    DvGuidanceAlgorithm alg(DvGuidanceConfig::create());
+    DvGuidanceOutput out;
+    EXPECT_NO_THROW(out = alg.update(Eigen::Vector3f{0.0F, 0.0F, 0.0F},
+                                     Eigen::Vector3f{0.0F, 1.0F, 0.0F},
+                                     /* dvRotVecMag  = */ 0.5F,
+                                     /* burnStartTime= */ 0U,
+                                     /* callTime     = */ 1000000000U));
+    expectSafeDefault(out);
+}
+
+TEST(DvGuidanceTest, RotAxisParallelToDeltaV) {
+    // dvRotVecUnit parallel to dvInrtlCmd: cross product collapses -> safe default instead of NaN.
+    DvGuidanceAlgorithm alg(DvGuidanceConfig::create());
+    DvGuidanceOutput out;
+    EXPECT_NO_THROW(out = alg.update(Eigen::Vector3f{1.0F, 2.0F, -3.0F},
+                                     Eigen::Vector3f{2.0F, 4.0F, -6.0F},  // same direction
+                                     /* dvRotVecMag  = */ 0.3F,
+                                     /* burnStartTime= */ 0U,
+                                     /* callTime     = */ 1000000000U));
+    expectSafeDefault(out);
+}
+
+TEST(DvGuidanceTest, ZeroRotationAxis) {
+    // |dvRotVecUnit| = 0: stableNormalized() is NaN and the cross product is degenerate. The
+    // NaN-safe guard must still return the safe default rather than propagate NaN.
+    DvGuidanceAlgorithm alg(DvGuidanceConfig::create());
+    DvGuidanceOutput out;
+    EXPECT_NO_THROW(out = alg.update(Eigen::Vector3f{1.0F, 2.0F, -3.0F},
+                                     Eigen::Vector3f{0.0F, 0.0F, 0.0F},
+                                     /* dvRotVecMag  = */ 0.3F,
+                                     /* burnStartTime= */ 0U,
+                                     /* callTime     = */ 1000000000U));
+    expectSafeDefault(out);
+}
+
+TEST(DvGuidanceTest, RotAxisAntiParallelToDeltaV) {
+    // dvRotVecUnit antiparallel to dvInrtlCmd: same collapse -> safe default.
+    DvGuidanceAlgorithm alg(DvGuidanceConfig::create());
+    DvGuidanceOutput out;
+    EXPECT_NO_THROW(out = alg.update(Eigen::Vector3f{1.0F, 2.0F, -3.0F},
+                                     Eigen::Vector3f{-1.0F, -2.0F, 3.0F},  // opposite direction
+                                     /* dvRotVecMag  = */ 0.3F,
+                                     /* burnStartTime= */ 0U,
+                                     /* callTime     = */ 1000000000U));
+    expectSafeDefault(out);
+}
+
+TEST(DvGuidanceTest, SubThresholdRotationSnapsToIdentity) {
+    // A rotation below kSmallAngle (here dvRotVecMag * dt = 1e-4 * 0.01 s = 1e-6 rad < 1e-5) is
+    // reported as identity, so the attitude matches the zero-elapsed-time result exactly rather
+    // than carrying FP32 noise from prvToDcm.
+    DvGuidanceAlgorithm alg(DvGuidanceConfig::create());
+    const Eigen::Vector3f dvInrtlCmd{2.0F, -1.0F, 4.0F};
+    const Eigen::Vector3f dvRotVecUnit{0.0F, 0.0F, 1.0F};
+    constexpr float dvRotVecMag = 1.0e-4F;
+
+    DvGuidanceOutput outZero;
+    DvGuidanceOutput outTiny;
+    EXPECT_NO_THROW(outZero = alg.update(dvInrtlCmd,
+                                         dvRotVecUnit,
+                                         dvRotVecMag,
+                                         /* burnStartTime= */ 0U,
+                                         /* callTime = */ 0U));
+    EXPECT_NO_THROW(outTiny = alg.update(dvInrtlCmd,
+                                         dvRotVecUnit,
+                                         dvRotVecMag,
+                                         /* burnStartTime= */ 0U,
+                                         /* callTime = */ 10000000U));  // 0.01 s
+
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FLOAT_EQ(outTiny.sigma_RN[i], outZero.sigma_RN[i]);
+        EXPECT_FLOAT_EQ(outTiny.omega_RN_N[i], outZero.omega_RN_N[i]);
+        EXPECT_TRUE(std::isfinite(outTiny.sigma_RN[i]));
+    }
+}

--- a/algorithms/dvGuidance/_tests/test_dvGuidance_fuzz.cpp
+++ b/algorithms/dvGuidance/_tests/test_dvGuidance_fuzz.cpp
@@ -5,26 +5,15 @@
 
 namespace {
 
-// Fuzz the burn command inputs and the (callTime - burnStartTime) elapsed-time delta. We bound:
-//   |dvInrtlCmd|    >= 1e-3  -- avoid normalize() producing NaN (Xmera semantic, not robustified).
-//   |dvRotVecUnit|  >= 1e-3  -- same reason: cross(dvRotVecUnit, dvHat).normalized() needs a non-zero
-//                               cross product, which also requires the seed not be parallel to dvHat.
-//   The angle between dvInrtlCmd and dvRotVecUnit cannot drop below ~1e-4 rad without the cross
-//   product collapsing in float; filter that case out.
-//   dvRotVecMag    -- bounded to a reasonable burn rate envelope; magnitude only.
-//   burnTime       -- bounded so the accumulated PRV doesn't grow unbounded; the dcm/MRP conversions
-//                     are well-defined for any rotation, but very large rotations stress shadow-set
-//                     switching and produce noise that exceeds the 1e-5 reference tolerance.
+/// Fuzzes the burn-command inputs and the (callTime - burnStartTime) elapsed-time delta across the
+/// full domain, including the degenerate cases the algorithm now guards (zero-norm dvInrtlCmd and
+/// dvRotVecUnit (anti)parallel to it). testDvGuidance asserts the output is always finite and
+/// reference-matches at 1e-5 only where the inputs are non-degenerate by margin. See dvGuidance.rst
+/// ("Numerical conditioning") for why the guard thresholds bound the FP32 reference error.
 void fuzzDvGuidance(const Eigen::Vector3f& dvInrtlCmd,
                     const Eigen::Vector3f& dvRotVecUnit,
                     float dvRotVecMag,
                     int64_t burnTime_ns) {
-    // Joint precondition: dvRotVecUnit must not be parallel to dvInrtlCmd, otherwise
-    // cross(dvRotVecUnit, dvHat).normalized() yields NaN. Require sin(angle) >= 1e-3.
-    if (dvRotVecUnit.cross(dvInrtlCmd).norm() < 1.0e-3F * dvRotVecUnit.norm() * dvInrtlCmd.norm()) {
-        return;
-    }
-
     constexpr uint64_t burnStartTime = 1'000'000'000ULL;  // arbitrary 1 s anchor
     const uint64_t callTime = static_cast<uint64_t>(static_cast<int64_t>(burnStartTime) + burnTime_ns);
     testDvGuidance(dvInrtlCmd, dvRotVecUnit, dvRotVecMag, burnStartTime, callTime);
@@ -34,14 +23,12 @@ void fuzzDvGuidance(const Eigen::Vector3f& dvInrtlCmd,
 
 FUZZ_TEST(DvGuidanceFuzz, fuzzDvGuidance)
     .WithDomains(
-        // dvInrtlCmd [m/s]: realistic delta-V envelope, rejected if too close to zero.
-        fuzztest::Filter([](const Eigen::Vector3f& v) { return v.norm() >= 1.0e-3F; },
-                         xmera::fuzz::Vector3fInRange(-1.0e4F, 1.0e4F)),
-        // dvRotVecUnit: physically a unit vector but the algorithm only uses its direction. Allow
-        // any finite non-degenerate direction; the cross product with dvHat must remain large
-        // enough that .normalized() doesn't blow up.
-        fuzztest::Filter([](const Eigen::Vector3f& v) { return v.norm() >= 1.0e-3F; },
-                         xmera::fuzz::Vector3fInRange(-1.0F, 1.0F)),
+        // dvInrtlCmd [m/s]: realistic delta-V envelope, unfiltered so near-/zero-norm inputs exercise
+        // the zero-norm guard (the algorithm returns a safe default instead of NaN).
+        xmera::fuzz::Vector3fInRange(-1.0e4F, 1.0e4F),
+        // dvRotVecUnit: only its direction is used. Unfiltered so (anti)parallel-to-dvInrtlCmd seeds
+        // exercise the collapsed-cross-product guard.
+        xmera::fuzz::Vector3fInRange(-1.0F, 1.0F),
         // dvRotVecMag [rad/s]: bounded to a generous burn-rate envelope.
         fuzztest::InRange(-1.0F, 1.0F),
         // burnTime [ns]: +/- 30 s so the accumulated rotation stays within ~30 rad, well within

--- a/algorithms/dvGuidance/dvGuidance.rst
+++ b/algorithms/dvGuidance/dvGuidance.rst
@@ -191,13 +191,32 @@ Assumptions and Limitations
 
 * The commanded delta-V direction is assumed to drive the spacecraft's downstream body 1 axis. Pair this module with
   :ref:`attTrackingError` (or analogous) when a different body axis must align with :math:`\mathcal{R}`.
-* :math:`\hat{\boldsymbol{r}}` (``dvRotVecUnit``) must not be parallel to :math:`\Delta\boldsymbol{v}`; otherwise
-  :math:`\hat{\boldsymbol{r}} \times \Delta\boldsymbol{v}` collapses to zero and the normalize step propagates
-  ``NaN`` through the output. The module does **not** guard against this case (it preserves the original Xmera
-  semantics).
-* :math:`\Delta\boldsymbol{v}` must have nonzero norm. A zero-magnitude commanded delta-V causes the same NaN
-  propagation through the first normalize step.
+* :math:`\hat{\boldsymbol{r}}` (``dvRotVecUnit``) (anti)parallel to :math:`\Delta\boldsymbol{v}` (or itself
+  near-zero) makes :math:`\hat{\boldsymbol{r}} \times \Delta\boldsymbol{v}` collapse, leaving the base burn frame
+  undefined. The module **guards** this case: when :math:`\sin^2(\text{angle})` falls below ``kMinCrossSq`` (or the
+  cross product is otherwise degenerate) it returns a safe default output
+  (:math:`\boldsymbol{\sigma}_{R/N}=\boldsymbol{0}`, i.e. the identity :math:`\mathcal{R}/\mathcal{N}` attitude, with
+  zero rates) instead of propagating ``NaN``.
+* :math:`\Delta\boldsymbol{v}` near-zero norm leaves the burn direction undefined. The module **guards** this case:
+  when :math:`\lVert\Delta\boldsymbol{v}\rVert^2` falls below ``kMinNormSq`` it returns the same safe default
+  instead of propagating ``NaN`` through the first normalize step.
 * :math:`\dot\theta` is constant for the entire burn; the module does not support time-varying rotation rates.
 * All math is single-precision (FP32). For burns with very small :math:`\dot\theta\,\Delta t` rotations, numerical
-  noise on :math:`[B_{u,t}B_{u,b}]` can dominate the small-angle deviation; downstream consumers should apply their
-  own threshold logic if needed.
+  noise on :math:`[B_{u,t}B_{u,b}]` would dominate the small-angle deviation, so the module **guards** this case
+  too: a rotation magnitude :math:`\lvert\dot\theta\,\Delta t\rvert` below ``kSmallAngle`` is reported as the
+  identity rotation (the clean base burn frame :math:`[B_{u,b}\mathcal{N}]`) rather than the noise.
+
+Numerical conditioning
+----------------------
+
+The guard thresholds bound the FP32 reference error rather than being arbitrary cutoffs. The base-frame
+construction normalizes :math:`\hat{\boldsymbol{r}} \times \hat{\boldsymbol{v}}`, whose magnitude is
+:math:`\sin(\text{angle})`; this amplifies the relative round-off by :math:`\sim 1/\sin(\text{angle})`. With a
+float epsilon of :math:`\sim 1.2\times10^{-7}` and the additional amplification of the second Gram-Schmidt
+normalization, the matrix product, and the DCM\ :math:`\leftrightarrow`\ MRP round-trip, the per-element DCM error
+reaches :math:`\sim 10^{-5}` near :math:`\sin(\text{angle}) \approx 1.7\times10^{-2}`. ``kMinCrossSq`` =
+:math:`9\times10^{-4}` (i.e. :math:`\sin(\text{angle}) \approx 3\times10^{-2}`, about :math:`1.7^\circ`) is the
+boundary below which the frame is no longer trusted to FP32 reference accuracy; the unit tests verify the algorithm
+matches a double-precision reference to :math:`10^{-5}` only outside this guard region. ``kSmallAngle`` =
+:math:`10^{-5}` rad is the corresponding rotation-magnitude floor (at the module's FP32 precision), and
+``kMinNormSq`` = :math:`10^{-12}` (\ :math:`\sim 10^{-6}` m/s) flags an effectively zero commanded delta-V.

--- a/algorithms/dvGuidance/dvGuidanceAlgorithm.cpp
+++ b/algorithms/dvGuidance/dvGuidanceAlgorithm.cpp
@@ -1,6 +1,7 @@
 #include "dvGuidanceAlgorithm.h"
 #include "architecture/utilities/rigidBodyKinematics.hpp"
 #include "utilities/timeConstants.h"
+#include <math.h>
 
 DvGuidanceAlgorithm::DvGuidanceAlgorithm(const DvGuidanceConfig& config) : cfg(config) {}
 
@@ -16,20 +17,40 @@ DvGuidanceOutput DvGuidanceAlgorithm::update(const Eigen::Vector3f& dvInrtlCmd,
                                              const float dvRotVecMag,
                                              const uint64_t burnStartTime,
                                              const uint64_t callTime) const {
+    // Guard: a near-zero delta-V has no defined direction. Hold attitude (identity, zero rates)
+    // rather than propagating NaN through dvInrtlCmd.stableNormalized().
+    if (dvInrtlCmd.squaredNorm() < kMinNormSq) {
+        return DvGuidanceOutput{};
+    }
+
     // base burn frame Bub: 1st axis along dvHat_N, 2nd axis perpendicular to {dvHat_N, dvRotVecUnit},
     // 3rd axis completes the right-handed triad. The DCM rows are the Bub axes in N coordinates.
-    const Eigen::Vector3f dvHat_N = dvInrtlCmd.normalized();
+    const Eigen::Vector3f dvHat_N = dvInrtlCmd.stableNormalized();
+
+    // Guard: when dvRotVecUnit is (anti)parallel to dvHat_N (or itself near-zero) the cross product
+    // collapses, so the base frame is ill-defined and FP32-noise-dominated. Hold attitude rather
+    // than emit noise/NaN. The negated form also rejects the NaN a zero-axis stableNormalized()
+    // produces (NaN >= kMinCrossSq is false).
+    const Eigen::Vector3f cross = dvRotVecUnit.stableNormalized().cross(dvHat_N);
+    if (!(cross.squaredNorm() >= kMinCrossSq)) {
+        return DvGuidanceOutput{};
+    }
     Eigen::Matrix3f dcm_BubN;
     dcm_BubN.row(0) = dvHat_N;
-    dcm_BubN.row(1) = dvRotVecUnit.cross(dvHat_N).normalized();
+    dcm_BubN.row(1) = cross.normalized();
     dcm_BubN.row(2) = dcm_BubN.row(0).cross(dcm_BubN.row(1)).normalized();
 
     const float burnTime =
         static_cast<float>(static_cast<int64_t>(callTime) - static_cast<int64_t>(burnStartTime)) * kNano2SecF;
 
-    // current burn frame Bu = base burn frame rotated about its 3rd axis by (dvRotVecMag * burnTime)
-    const Eigen::Vector3f prv = {0.0F, 0.0F, dvRotVecMag * burnTime};
-    const Eigen::Matrix3f dcm_ButBub = prvToDcm(prv);
+    // current burn frame Bu = base burn frame rotated about its 3rd axis by (dvRotVecMag * burnTime).
+    // Below kSmallAngle the rotation is reported as identity: the FP32 noise on prvToDcm * dcm_BubN
+    // would otherwise dominate the sub-threshold deviation.
+    const float angle = dvRotVecMag * burnTime;
+    Eigen::Matrix3f dcm_ButBub = Eigen::Matrix3f::Identity();
+    if (fabsf(angle) >= kSmallAngle) {
+        dcm_ButBub = prvToDcm(Eigen::Vector3f{0.0F, 0.0F, angle});
+    }
     const Eigen::Matrix3f dcm_ButN = dcm_ButBub * dcm_BubN;
 
     DvGuidanceOutput out;

--- a/algorithms/dvGuidance/dvGuidanceAlgorithm.h
+++ b/algorithms/dvGuidance/dvGuidanceAlgorithm.h
@@ -5,14 +5,16 @@
 #include <stdint.h>
 #include <Eigen/Core>
 
+/// Burn-frame attitude guidance output. On degenerate input the algorithm returns the
+/// default (all-zero) value: @c sigma_RN = 0 is the identity R/N attitude with zero rates.
 struct DvGuidanceOutput {
-    Eigen::Vector3f sigma_RN = Eigen::Vector3f::Zero();
-    Eigen::Vector3f omega_RN_N = Eigen::Vector3f::Zero();
-    Eigen::Vector3f domega_RN_N = Eigen::Vector3f::Zero();
+    Eigen::Vector3f sigma_RN = Eigen::Vector3f::Zero();     ///< MRP of the reference frame w.r.t. inertial.
+    Eigen::Vector3f omega_RN_N = Eigen::Vector3f::Zero();   ///< Reference angular rate, inertial frame [rad/s].
+    Eigen::Vector3f domega_RN_N = Eigen::Vector3f::Zero();  ///< Reference angular acceleration, inertial frame.
 };
 
-// dvGuidance has no tunable parameters; the Config class is intentionally empty so the
-// algorithm can still follow the standard two-phase init pattern.
+/// Configuration for DvGuidanceAlgorithm. dvGuidance has no tunable parameters; this class is
+/// intentionally empty so the algorithm still follows the standard two-phase init pattern.
 class DvGuidanceConfig final {
    public:
     static DvGuidanceConfig create() { return {}; }
@@ -21,12 +23,33 @@ class DvGuidanceConfig final {
     DvGuidanceConfig() = default;
 };
 
+/// Computes the delta-V burn-frame attitude reference from a commanded delta-V, a rotation axis,
+/// and a rotation rate. All math is single-precision (FP32). Degenerate inputs are guarded so the
+/// module never propagates NaN or numerical noise downstream; see dvGuidance.rst for the rationale
+/// behind the threshold constants below.
 class DvGuidanceAlgorithm final {
    public:
+    /// @c |dvInrtlCmd|^2 floor (~1e-6 m/s): at or below this the delta-V direction is undefined.
+    static constexpr float kMinNormSq = 1e-12F;
+    /// @c |rHat x dvHat|^2 = sin^2(angle) floor (sin ~ 3e-2, ~1.7 deg): below this the base burn
+    /// frame is ill-defined / FP32-noise-dominated, so the rotation axis is treated as (anti)parallel.
+    static constexpr float kMinCrossSq = 9e-4F;
+    /// @c |dvRotVecMag * burnTime| (rad) floor: smaller rotations are reported as identity rather
+    /// than the FP32 noise that would otherwise dominate the sub-threshold deviation.
+    static constexpr float kSmallAngle = 1e-5F;
+
     explicit DvGuidanceAlgorithm(const DvGuidanceConfig& config);
 
     void setConfig(const DvGuidanceConfig& config);
 
+    /// Computes the burn-frame attitude reference.
+    /// @param dvInrtlCmd    Commanded delta-V in inertial frame [m/s]; defines the 1st burn-frame axis.
+    /// @param dvRotVecUnit  Rotation axis seed; only its direction is used (need not be unit).
+    /// @param dvRotVecMag   Burn-frame rotation rate about the 3rd axis [rad/s].
+    /// @param burnStartTime Burn epoch [ns].
+    /// @param callTime      Evaluation time [ns]; (callTime - burnStartTime) is the elapsed burn time.
+    /// @return The attitude reference, or a default (identity, zero-rate) DvGuidanceOutput when
+    ///         @p dvInrtlCmd is near-zero or @p dvRotVecUnit is (anti)parallel to it.
     DvGuidanceOutput update(const Eigen::Vector3f& dvInrtlCmd,
                             const Eigen::Vector3f& dvRotVecUnit,
                             float dvRotVecMag,


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2280
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
The dvGuidance algorithm as ported from Xmera lacks guards for parallel input dv vectors and zero magnitude command vectors. This PR adds those guards to the algorithm.

## Verification
The fuzz tests a re augmented such that they will exercise the new guards. An additional edge case regression test is added to protect against the guarded cases.

## Documentation
The documentation for the algorithm is updated to account for the added guards.

## Future work
None
