### PR TITLE
Update mrpSwitch to have a default switch threshold of 1.0

### DIFF
--- a/algorithms/mrpRotation/_tests/mrpRotationTestHelpers.hpp
+++ b/algorithms/mrpRotation/_tests/mrpRotationTestHelpers.hpp
@@ -35,7 +35,7 @@ inline MrpRotationReferenceOutput referenceUpdate(MrpRotationReferenceState& sta
     const Eigen::Matrix3f B = bmatMrp(state.sigma_RR0);
     const Eigen::Vector3f sigmaDot_RR0 = 0.25F * B * state.omega_RR0_R;
     const Eigen::Vector3f mrpSetNew = state.sigma_RR0 + sigmaDot_RR0 * dt;
-    state.sigma_RR0 = mrpSwitch(mrpSetNew, 1.0F);
+    state.sigma_RR0 = mrpSwitch(mrpSetNew);
 
     const Eigen::Matrix3f dcm_RR0 = mrpToDcm(state.sigma_RR0);
     const Eigen::Matrix3f dcm_R0N = mrpToDcm(sigma_R0N);
@@ -68,7 +68,7 @@ inline void regressionTestMrpRotation(const Eigen::Vector3f& initialSigmaRR0,
 
     // The algorithm bounds the seed MRP via mrpSwitch in MrpRotationConfig::create, so the
     // reference must start from the same bounded representative to stay in lock-step.
-    MrpRotationReferenceState refState{mrpSwitch(initialSigmaRR0, 1.0F), omegaRR0R};
+    MrpRotationReferenceState refState{mrpSwitch(initialSigmaRR0), omegaRR0R};
 
     const MrpRotationAttRefInputs attRef{sigma_R0N, omega_R0N_N, domega_R0N_N};
 
@@ -149,7 +149,7 @@ inline void propertySigmaRNEqualsSigmaRR0WhenInputRefIsIdentity(const Eigen::Vec
     };
     // The algorithm bounds the seed MRP via mrpSwitch in MrpRotationConfig::create, so the
     // reference must start from the same bounded representative to stay in lock-step.
-    MrpRotationReferenceState refState{mrpSwitch(initialSigmaRR0, 1.0F), omegaRR0R};
+    MrpRotationReferenceState refState{mrpSwitch(initialSigmaRR0), omegaRR0R};
 
     constexpr float tol = 1e-5F;
     for (int k = 0; k < kNumSteps; ++k) {

--- a/algorithms/mrpRotation/_tests/test_mrpRotation.cpp
+++ b/algorithms/mrpRotation/_tests/test_mrpRotation.cpp
@@ -227,7 +227,7 @@ TEST(MrpRotationTest, SetConfigReseedsRuntimeState) {
     // Independent reference: setConfig re-seeded runtime state to cfgB's initial sigma / omega
     // (discarding the post-firstStep state), so the step integrates from there using cfgB's period.
     // create() bounds the seed MRP via mrpSwitch, so mirror that here.
-    MrpRotationReferenceState refState{mrpSwitch(initialSigmaRR0_B, 1.0F), omegaRR0R_B};
+    MrpRotationReferenceState refState{mrpSwitch(initialSigmaRR0_B), omegaRR0R_B};
     const auto refOut =
         referenceUpdate(refState, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), kPeriodB);
 

--- a/algorithms/mrpRotation/mrpRotationAlgorithm.cpp
+++ b/algorithms/mrpRotation/mrpRotationAlgorithm.cpp
@@ -31,14 +31,13 @@ void MrpRotationAlgorithm::setConfig(const MrpRotationConfig& config) {
  */
 MrpRotationOutput MrpRotationAlgorithm::update(const MrpRotationAttRefInputs& attRef) {
     constexpr float kMrpKinematicGain = 0.25F;
-    constexpr float kMrpShadowSwitchNorm = 1.0F;
 
     /*! - Advance sigma_RR0 one forward-Euler step using the MRP kinematic differential equation,
      *    then shadow-switch to keep the representation bounded. */
     const Eigen::Matrix3f B = bmatMrp(this->sigma_RR0);
     const Eigen::Vector3f sigmaDot_RR0 = kMrpKinematicGain * B * this->omega_RR0_R;
     const Eigen::Vector3f mrpSetNew = this->sigma_RR0 + (sigmaDot_RR0 * this->cfg.getControlPeriod());
-    this->sigma_RR0 = mrpSwitch(mrpSetNew, kMrpShadowSwitchNorm);
+    this->sigma_RR0 = mrpSwitch(mrpSetNew);
 
     /*! - Compose with the input reference frame to produce the output R/N attitude and rates. */
     const Eigen::Matrix3f dcm_RR0 = mrpToDcm(this->sigma_RR0);

--- a/algorithms/mrpRotation/mrpRotationAlgorithm.h
+++ b/algorithms/mrpRotation/mrpRotationAlgorithm.h
@@ -41,7 +41,7 @@ class MrpRotationConfig final {
         }
         // Bound the seed MRP to the principal set (norm <= 1) by switching to the shadow set if
         // needed, so the stored initial attitude is always a well-conditioned MRP representation.
-        return {mrpSwitch(initialSigmaRR0, 1.0F), omegaRR0R, controlPeriod};
+        return {mrpSwitch(initialSigmaRR0), omegaRR0R, controlPeriod};
     }
 
     static bool isValidInitialSigmaRR0(const Eigen::Vector3f& sigma) { return sigma.allFinite(); }

--- a/algorithms/sunSafePoint/_tests/sunSafePointTestHelpers.hpp
+++ b/algorithms/sunSafePoint/_tests/sunSafePointTestHelpers.hpp
@@ -35,7 +35,7 @@ inline SunSafePointOutput referenceUpdate(const Eigen::Vector3f& vehSunPntBdy,
         }
         Eigen::Vector3f sunMnvrVec = e_hat.stableNormalized();
         Eigen::Vector3f sigma_BR = std::tan(sunAngleErr * 0.25f) * sunMnvrVec;
-        sigma_BR = mrpSwitch(sigma_BR, 1.0f);
+        sigma_BR = mrpSwitch(sigma_BR);
 
         output.sigma_BR = sigma_BR;
         output.omega_RN_B = sunAxisSpinRate * rHat_SB_B;

--- a/algorithms/sunSafePoint/sunSafePointAlgorithm.cpp
+++ b/algorithms/sunSafePoint/sunSafePointAlgorithm.cpp
@@ -37,7 +37,7 @@ SunSafePointOutput SunSafePointAlgorithm::update(const Eigen::Vector3f& vehSunPn
         }
         Eigen::Vector3f const e_hat = e_axis.stableNormalized();
         Eigen::Vector3f sigma_BR = safeTanf(sunAngleErr * 0.25F) * e_hat;
-        sigma_BR = mrpSwitch(sigma_BR, 1.0F);
+        sigma_BR = mrpSwitch(sigma_BR);
 
         output.sigma_BR = sigma_BR;
         // Rate tracking error is the body rate to bring spacecraft to rest

--- a/algorithms/utilities/fsw/rigidBodyKinematics.hpp
+++ b/algorithms/utilities/fsw/rigidBodyKinematics.hpp
@@ -28,7 +28,7 @@ Eigen::Vector3<ScalarT> mrpShadow(const Eigen::Vector3<ScalarT>& mrp) {
  * @return Eigen::Vector3d
  */
 template <typename ScalarT>
-Eigen::Vector3<ScalarT> mrpSwitch(const Eigen::Vector3<ScalarT>& mrp, const ScalarT s) {
+Eigen::Vector3<ScalarT> mrpSwitch(const Eigen::Vector3<ScalarT>& mrp, const ScalarT s = 1.0) {
     if (mrp.squaredNorm() > s * s) {
         return mrpShadow(mrp);
     }

--- a/algorithms/utilities/fsw/rigidBodyKinematics.hpp
+++ b/algorithms/utilities/fsw/rigidBodyKinematics.hpp
@@ -821,7 +821,7 @@ Eigen::Vector3<ScalarT> addMrp(const Eigen::Vector3<ScalarT>& mrp1, const Eigen:
     Eigen::Vector3<ScalarT> mrp = numerator / denominator;
 
     // Map MRP to the inner set
-    mrp = mrpSwitch<ScalarT>(mrp, 1.0);
+    mrp = mrpSwitch<ScalarT>(mrp);
 
     return mrp;
 }
@@ -864,7 +864,7 @@ Eigen::Vector3<ScalarT> subMrp(const Eigen::Vector3<ScalarT>& mrp1, const Eigen:
                 ScalarT(2) * mrp1Shadow.cross(mrp2);
     Eigen::Vector3<ScalarT> mrp = numerator / denominator;
     /* map mrp to inner set */
-    mrp = mrpSwitch(mrp, ScalarT(1));
+    mrp = mrpSwitch(mrp);
 
     return mrp;
 }


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2226
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR changes adds a default argument of `1.0` to the switch threshold parameter of `mrpSwitch` in `rigidBodyKinematics.hpp`. In all usages of this function the passed argument is `1.0`, so we decided to simply make it a default.

## Verification
All tests and CI pass unchanged. This should amount to a no-op in terms of testing and correctness.

## Documentation
None invalidated or added.

## Future work
NA
