### PR TITLE
Hotfix: fix include error in test_cssComm.cpp

### DIFF
--- a/algorithms/cssComm/_tests/test_cssComm.cpp
+++ b/algorithms/cssComm/_tests/test_cssComm.cpp
@@ -1,5 +1,6 @@
 #include "cssCommTestHelpers.hpp"
 #include "utilities/fsw/freestandingInvalidArgument.h"
+#include <algorithm>
 
 TEST(CssCommTest, RegressionTest) {
     uint32_t numSensors = 4;


### PR DESCRIPTION
* **Tickets addressed:** hot fix
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)  

## Description
Hotfix: include missing <algorithm> to test_cssComm.cpp

## Verification
passed test_cssComm.cpp tests

## Documentation
N/A

## Future work
N/A
