### PR TITLE
Feature/filter core fixes

### DIFF
--- a/algorithms/filteringCore/_tests/test_dynamicsModel.cpp
+++ b/algorithms/filteringCore/_tests/test_dynamicsModel.cpp
@@ -11,6 +11,7 @@
 #include <Eigen/Core>
 
 #include <math.h>
+#include <cmath>
 
 namespace filtering {
 namespace {
@@ -117,6 +118,26 @@ TEST(Propagate, HarmonicOscillatorInvariants) {
         EXPECT_NEAR(sFinal.get<Position<1>>()(0), 0.0, 5e-3) << "quarter-period x";
         EXPECT_NEAR(sFinal.get<Velocity<1>>()(0), -1.0, 5e-3) << "quarter-period v";
     }
+}
+
+// The optional integrationStep is honored: a finer sub-step integrates the harmonic
+// oscillator more accurately
+TEST(Propagate, IntegrationStepIsHonored) {
+    SpringMassState s0;
+    s0.set<Position<1>>(Eigen::Vector<double, 1>(1.0));  // x0 = 1, v0 = 0
+    double const E0 = energy(s0);
+    SpringMassDyn const d;
+
+    // Steps stay under the kMaxNumberOfSteps cap over one period (T/0.1 ~ 63 < 100).
+    double const coarseDrift = std::abs(energy(propagate(d, s0, {0.0, kSHOPeriod}, 1.0)) - E0);
+    double const fineDrift = std::abs(energy(propagate(d, s0, {0.0, kSHOPeriod}, 0.1)) - E0);
+    EXPECT_LT(fineDrift, coarseDrift) << "smaller integration step should integrate more accurately";
+
+    // Passing the default explicitly equals omitting the argument.
+    SpringMassState const withDefault = propagate(d, s0, {0.0, kSHOPeriod}, kIntegrationStep);
+    SpringMassState const omitted = propagate(d, s0, {0.0, kSHOPeriod});
+    EXPECT_TRUE(withDefault.raw().isApprox(omitted.raw(), 1e-15))
+        << "default argument should match explicit kIntegrationStep";
 }
 
 }  // namespace filtering

--- a/algorithms/filteringCore/_tests/test_kalmanFilter.cpp
+++ b/algorithms/filteringCore/_tests/test_kalmanFilter.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: ISC
 // Copyright (c) 2026, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
-// Unit tests for filtering::applySequential(): drains a measurement_queue
-// in chronological order, interleaving timeUpdate / measurementUpdate calls,
-// then a final timeUpdate to callTime.
+// Unit tests for filtering::applySequential() and applySequentialRobust(): both drain a
+// measurement_queue in chronological order, interleaving timeUpdate / measurementUpdate
+// calls then a final timeUpdate to callTime. applySequentialRobust additionally reads each
+// update's bool result and, on a failed update, calls clear() and holds the anchor.
 
 #include <filteringCore/measurementQueue.h>
 #include <filteringCore/kalmanFilter.hpp>
@@ -15,24 +16,42 @@
 namespace filtering {
 namespace {
 
-// Call Log to check when we enter time and measurement updates
+// Call Log to check when we enter time / measurement updates and clear().
 struct CallLog {
-    enum class Kind { TimeUpdate, MeasurementUpdate };
+    enum class Kind { TimeUpdate, MeasurementUpdate, Clear };
     std::vector<std::pair<Kind, double>> entries;
 };
 
-// Filter which records the time/measruement update calls
+// Filter which records the time/measurement update and clear() calls. By default both
+// updates return true (valid) so the schedulers follow their success path; the fail flags
+// force the robust scheduler down its failure path.
 struct RecordingFilter {
     CallLog* log = nullptr;
-    void timeUpdate(double dt) {
+    bool timeUpdatesFail = false;            // when set, every timeUpdate reports invalid
+    bool failOnNegativeMeasurement = false;  // when set, a measurement with value < 0 reports invalid
+    bool timeUpdate(double dt) {
         if (log) log->entries.push_back({CallLog::Kind::TimeUpdate, dt});
+        return !timeUpdatesFail;
     }
-    void measurementUpdate(double const& m) {
+    bool measurementUpdate(double const& m) {
         if (log) log->entries.push_back({CallLog::Kind::MeasurementUpdate, m});
+        return !(failOnNegativeMeasurement && m < 0.0);
+    }
+    void clear() {
+        if (log) log->entries.push_back({CallLog::Kind::Clear, 0.0});
     }
 };
 
 static_assert(SequentialFilter<RecordingFilter, double>);
+
+// Count log entries of a given kind.
+int count(CallLog const& log, CallLog::Kind kind) {
+    int n = 0;
+    for (auto const& [k, v] : log.entries) {
+        if (k == kind) ++n;
+    }
+    return n;
+}
 
 }  // namespace
 
@@ -141,6 +160,72 @@ TEST(ApplySequential, NoFinalTimeUpdateWhenAnchorReachesCallTime) {
         EXPECT_EQ(log.entries[0].first, CallLog::Kind::TimeUpdate);
         EXPECT_EQ(log.entries[1].first, CallLog::Kind::MeasurementUpdate);
     }
+}
+
+// applySequentialRobust tests
+
+// With all-valid updates the robust scheduler behaves like the basic one: the anchor
+// advances to the latest measurement and clear() is never called.
+TEST(ApplySequentialRobust, AllValidUpdatesAdvanceAnchorAndNeverClear) {
+    CallLog log;
+    RecordingFilter filter{&log};
+    measurement_queue<double, 4> q;
+    q.enqueue(5.0, 1.0);
+    q.enqueue(7.0, 2.0);
+
+    applySequentialRobust(q, filter, 10.0);
+
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 7.0);
+    EXPECT_EQ(count(log, CallLog::Kind::MeasurementUpdate), 2);
+    EXPECT_EQ(count(log, CallLog::Kind::Clear), 0);
+}
+
+// A measurement whose update reports invalid triggers clear() and does NOT advance the
+// anchor past it: the anchor stays at the last good measurement and the final propagation
+// continues from there.
+TEST(ApplySequentialRobust, FailedMeasurementClearsAndHoldsAnchor) {
+    CallLog log;
+    RecordingFilter filter{&log};
+    filter.failOnNegativeMeasurement = true;
+    measurement_queue<double, 4> q;
+    q.enqueue(2.0, 0.5);   // good
+    q.enqueue(4.0, -1.0);  // bad: measurementUpdate reports invalid
+
+    applySequentialRobust(q, filter, 10.0);
+
+    // Full sequence: tU(2), meas(0.5), tU(2), meas(-1) [fails], clear, tU(8) from held anchor.
+    ASSERT_EQ(log.entries.size(), 6u);
+    EXPECT_EQ(log.entries[0].first, CallLog::Kind::TimeUpdate);
+    EXPECT_EQ(log.entries[1].first, CallLog::Kind::MeasurementUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[1].second, 0.5);
+    EXPECT_EQ(log.entries[2].first, CallLog::Kind::TimeUpdate);
+    EXPECT_EQ(log.entries[3].first, CallLog::Kind::MeasurementUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[3].second, -1.0);
+    EXPECT_EQ(log.entries[4].first, CallLog::Kind::Clear);
+    EXPECT_EQ(log.entries[5].first, CallLog::Kind::TimeUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[5].second, 8.0);  // callTime(10) - held anchor(2)
+
+    // Anchor held at the last good measurement, not advanced to the failed one.
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 2.0);
+}
+
+// A failed timeUpdate short-circuits the measurement update (|| short-circuit), triggers
+// clear(), and does not advance the anchor.
+TEST(ApplySequentialRobust, FailedTimeUpdateShortCircuitsMeasurementAndClears) {
+    CallLog log;
+    RecordingFilter filter{&log};
+    filter.timeUpdatesFail = true;
+    measurement_queue<double, 4> q;
+    q.enqueue(2.0, 0.5);
+
+    applySequentialRobust(q, filter, 10.0);
+
+    // timeUpdate fails, so measurementUpdate is never reached; each failed timeUpdate
+    // (one for the measurement, one final) is followed by clear(); the anchor never moves.
+    EXPECT_EQ(count(log, CallLog::Kind::MeasurementUpdate), 0);
+    EXPECT_EQ(count(log, CallLog::Kind::TimeUpdate), 2);
+    EXPECT_EQ(count(log, CallLog::Kind::Clear), 2);
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 0.0);
 }
 
 }  // namespace filtering

--- a/algorithms/filteringCore/_tests/test_kalmanFilter_fuzz.cpp
+++ b/algorithms/filteringCore/_tests/test_kalmanFilter_fuzz.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: ISC
 // Copyright (c) 2026, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
-// Property-based fuzz tests for filtering::applySequential.
+// Property-based fuzz tests for filtering::applySequential and applySequentialRobust.
 
 #include <filteringCore/measurementQueue.h>
 #include <filteringCore/kalmanFilter.hpp>
@@ -10,23 +10,33 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <vector>
 
 namespace filtering {
 namespace {
 
 struct CallLog {
-    enum class Kind { TimeUpdate, MeasurementUpdate };
+    enum class Kind { TimeUpdate, MeasurementUpdate, Clear };
     std::vector<std::pair<Kind, double>> entries;
 };
 
+// Records time/measurement update and clear() calls. measurementUpdate logs the measurement
+// value; when failOnNegativeMeasurement is set, a value < 0 reports an invalid update, which
+// lets the sign of a fuzzed value drive the robust scheduler down its failure path.
 struct RecordingFilter {
     CallLog* log = nullptr;
-    void timeUpdate(double dt) {
+    bool failOnNegativeMeasurement = false;
+    bool timeUpdate(double dt) {
         if (log) log->entries.push_back({CallLog::Kind::TimeUpdate, dt});
+        return true;
     }
-    void measurementUpdate(double const&) {
-        if (log) log->entries.push_back({CallLog::Kind::MeasurementUpdate, 0.0});
+    bool measurementUpdate(double const& m) {
+        if (log) log->entries.push_back({CallLog::Kind::MeasurementUpdate, m});
+        return !(failOnNegativeMeasurement && m < 0.0);
+    }
+    void clear() {
+        if (log) log->entries.push_back({CallLog::Kind::Clear, 0.0});
     }
 };
 
@@ -78,5 +88,73 @@ FUZZ_TEST(ApplySequentialFuzz, fuzzApplySequentialInvariants)
                  fuzztest::InRange(-1e4, 1e4),
                  fuzztest::InRange(0.0, 1e4),
                  fuzztest::InRange(0.0, 1e4));
+
+// Robust scheduling under a fuzzed failure pattern: the sign of each measurement value
+// decides whether its update succeeds (>= 0) or fails (< 0). Regardless of the pattern:
+//   * every timeUpdate dt is non-negative (a held anchor never steps backwards),
+//   * clear() fires exactly once per failed measurement, immediately after it, and
+//   * the anchor ends at the last successfully-processed measurement time.
+void fuzzApplySequentialRobustInvariants(double t0,
+                                         double t1,
+                                         double t2,
+                                         double v0,
+                                         double v1,
+                                         double v2,
+                                         double initialAnchor,
+                                         double extraCallTime) {
+    double const callTime = initialAnchor + extraCallTime;
+
+    CallLog log;
+    RecordingFilter filter{&log};
+    filter.failOnNegativeMeasurement = true;
+    measurement_queue<double, 4> q;
+    q.setTimeOfLastMeasurement(initialAnchor);
+    q.enqueue(t0, double{v0});
+    q.enqueue(t1, double{v1});
+    q.enqueue(t2, double{v2});
+
+    applySequentialRobust(q, filter, callTime);
+
+    // (1) non-negative dt everywhere; (2) each clear immediately follows a failed
+    //     (value < 0) measurement update, and clears count equals failed measurements.
+    int clears = 0;
+    int failedMeasurements = 0;
+    for (std::size_t i = 0; i < log.entries.size(); ++i) {
+        auto const& [kind, value] = log.entries[i];
+        if (kind == CallLog::Kind::TimeUpdate) {
+            EXPECT_GE(value, 0.0) << "negative dt";
+        } else if (kind == CallLog::Kind::MeasurementUpdate) {
+            if (value < 0.0) ++failedMeasurements;
+        } else {  // Clear
+            ++clears;
+            ASSERT_GT(i, 0u);
+            EXPECT_EQ(log.entries[i - 1].first, CallLog::Kind::MeasurementUpdate)
+                << "clear must follow a measurement update";
+            EXPECT_LT(log.entries[i - 1].second, 0.0) << "clear must follow a failed (value < 0) measurement";
+        }
+    }
+    EXPECT_EQ(clears, failedMeasurements) << "exactly one clear per failed measurement";
+
+    // (3) reference model: the anchor advances only through successfully-processed
+    //     measurements (timeUpdate always succeeds here; a measurement succeeds iff v >= 0).
+    std::array<std::pair<double, double>, 3> measurements{{{t0, v0}, {t1, v1}, {t2, v2}}};
+    std::sort(measurements.begin(), measurements.end(), [](auto const& a, auto const& b) { return a.first < b.first; });
+    double cursor = initialAnchor;
+    for (auto const& [timeTag, value] : measurements) {
+        if (timeTag < cursor) continue;  // stale: before the running anchor
+        if (value >= 0.0) cursor = timeTag;
+    }
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), cursor)
+        << "anchor must equal the last successfully-processed measurement time";
+}
+FUZZ_TEST(ApplySequentialFuzz, fuzzApplySequentialRobustInvariants)
+    .WithDomains(fuzztest::InRange(-1e4, 1e4),  // t0
+                 fuzztest::InRange(-1e4, 1e4),  // t1
+                 fuzztest::InRange(-1e4, 1e4),  // t2
+                 fuzztest::InRange(-1e4, 1e4),  // v0 (sign selects success/failure)
+                 fuzztest::InRange(-1e4, 1e4),  // v1
+                 fuzztest::InRange(-1e4, 1e4),  // v2
+                 fuzztest::InRange(0.0, 1e4),   // initialAnchor
+                 fuzztest::InRange(0.0, 1e4));  // extraCallTime
 
 }  // namespace filtering

--- a/algorithms/filteringCore/_tests/test_srukf.cpp
+++ b/algorithms/filteringCore/_tests/test_srukf.cpp
@@ -187,6 +187,7 @@ TEST(SrukfApi, ResetCopiesInitialStateAndCovarianceToWorkingState) {
     filter.setProcessNoise(0.1 * Eigen::Matrix3d::Identity());
 
     filter.reset();
+    filter.reConfigure();
 
     // Working state and last-measurement state are both stateInitial.
     EXPECT_TRUE(filter.getState().raw().isApprox(s0.raw(), 1e-12)) << "state";
@@ -206,6 +207,7 @@ TEST(SrukfTimeUpdate, RewindsToLastMeasurementMakingTimeUpdateIdempotent) {
     filter.setInitialCovariance(Eigen::Matrix3d::Identity());
     filter.setProcessNoise(0.1 * Eigen::Matrix3d::Identity());
     filter.reset();
+    filter.reConfigure();
 
     // First timeUpdate from anchor produces stateA / covA.
     filter.timeUpdate(2.0);
@@ -231,6 +233,7 @@ TEST(SrukfTimeUpdate, CovarianceUnderTimeUpdate) {
     filter.setInitialCovariance(P0);
     filter.setProcessNoise(0.1 * Eigen::Matrix3d::Identity());
     filter.reset();
+    filter.reConfigure();
 
     filter.timeUpdate(0.0);
     EXPECT_TRUE(filter.getCovariance().isApprox(P0, 1e-10)) << "dt=0 should leave covariance unchanged";
@@ -253,6 +256,7 @@ TEST(SrukfMeasurementUpdate, InformativeMeasurementUpdatesStateAndShrinksCovaria
     filter.setInitialCovariance(Eigen::Matrix3d::Identity());
     filter.setProcessNoise(Eigen::Matrix3d::Zero());
     filter.reset();
+    filter.reConfigure();
     filter.timeUpdate(0.0);  // populates sigma points around the anchor
 
     PositionMeasurement m;
@@ -287,6 +291,7 @@ TEST(SrukfMeasurementUpdate, HighMeasurementNoiseLeavesStateNearlyUnchanged) {
     filter.setInitialCovariance(Eigen::Matrix3d::Identity());
     filter.setProcessNoise(Eigen::Matrix3d::Zero());
     filter.reset();
+    filter.reConfigure();
     filter.timeUpdate(0.0);
 
     TestState const stateBefore = filter.getState();

--- a/algorithms/filteringCore/_tests/test_srukf.cpp
+++ b/algorithms/filteringCore/_tests/test_srukf.cpp
@@ -19,6 +19,8 @@
 
 #include <Eigen/Core>
 
+#include <limits>
+
 namespace filtering {
 namespace {
 
@@ -263,14 +265,16 @@ TEST(SrukfMeasurementUpdate, InformativeMeasurementUpdatesStateAndShrinksCovaria
     m.observed = Eigen::Vector3d(1.0, 0.0, 0.0);
     m.noiseCov = 0.01 * Eigen::Matrix3d::Identity();
 
+    // A nominal update returns the pre/post-fit residuals.
     auto const result = filter.measurementUpdate(m);
+    ASSERT_TRUE(result.has_value()) << "measurement update should be valid";
 
     // Pre-fit: observation - model(prior anchor at 0) = (1, 0, 0).
-    EXPECT_TRUE(result.preFit.isApprox(Eigen::Vector3d(1.0, 0.0, 0.0), 1e-9))
+    EXPECT_TRUE(result->preFit.isApprox(Eigen::Vector3d(1.0, 0.0, 0.0), 1e-9))
         << "preFit should equal observation when prior state is zero";
 
     // Post-fit less than pre-fit
-    EXPECT_LT(result.postFit.norm(), result.preFit.norm()) << "informative measurement should reduce residual";
+    EXPECT_LT(result->postFit.norm(), result->preFit.norm()) << "informative measurement should reduce residual";
 
     // Covariance shrunk (initial trace was 3.0).
     Eigen::Matrix3d const P = filter.getCovariance();
@@ -301,10 +305,30 @@ TEST(SrukfMeasurementUpdate, HighMeasurementNoiseLeavesStateNearlyUnchanged) {
     m.noiseCov = 1e8 * Eigen::Matrix3d::Identity();  // R ≫ P → Kalman gain ≈ 0
 
     auto const result = filter.measurementUpdate(m);
+    ASSERT_TRUE(result.has_value()) << "measurement update should be valid";
 
     EXPECT_LT((filter.getState().raw() - stateBefore.raw()).norm(), 1e-5)
         << "state should barely move when R much greater than P";
-    EXPECT_TRUE(result.postFit.isApprox(result.preFit, 1e-5)) << "postFit ≈ preFit when R very large";
+    EXPECT_TRUE(result->postFit.isApprox(result->preFit, 1e-5)) << "postFit ≈ preFit when R very large";
+}
+
+// NaNs in the measurement propagate into the state, so measurementUpdate returns no value.
+TEST(SrukfMeasurementUpdate, NaNMeasurementReturnsNoValue) {
+    SRuKFType filter;
+    filter.setAlpha(0.5);
+    filter.setBeta(2.0);
+    filter.setInitialCovariance(Eigen::Matrix3d::Identity());
+    filter.setProcessNoise(Eigen::Matrix3d::Zero());
+    filter.reset();
+    filter.reConfigure();
+    filter.timeUpdate(0.0);
+
+    PositionMeasurement m;
+    m.observed = Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN());
+    m.noiseCov = 0.01 * Eigen::Matrix3d::Identity();
+
+    EXPECT_FALSE(filter.measurementUpdate(m).has_value())
+        << "measurementUpdate should not return a value for a bad (NaN) update";
 }
 
 }  // namespace filtering

--- a/algorithms/filteringCore/_tests/test_srukf.cpp
+++ b/algorithms/filteringCore/_tests/test_srukf.cpp
@@ -12,6 +12,7 @@
 //
 // Time and measurement updates are the heavy ones; left as scaffolding.
 
+#include <utilities/fsw/validPSDCheck.h>
 #include <filteringCore/srukf.hpp>
 #include <filteringCore/state.hpp>
 
@@ -131,46 +132,20 @@ TEST(SrukfApi, SetGetRoundtripsForAlphaAndBeta) {
     EXPECT_DOUBLE_EQ(filter.getBeta(), 2.0);
 }
 
-// Valid inputs
+// Valid inputs. The validators are static: they take the term to check and can be called
+// without an SRuKF instance (e.g. from a filter's config validation in another file).
 TEST(SrukfApi, ValidityChecks) {
-    SRuKFType filter;
+    // (1) alphaIsValid: true iff alpha in (0, 1) (endpoints excluded).
+    EXPECT_TRUE(SRuKFType::alphaIsValid(0.5)) << "alpha=0.5 in range";
+    EXPECT_FALSE(SRuKFType::alphaIsValid(0.0)) << "alpha=0 excluded";
+    EXPECT_FALSE(SRuKFType::alphaIsValid(1.0)) << "alpha=1 excluded";
+    EXPECT_FALSE(SRuKFType::alphaIsValid(-0.1)) << "alpha<0";
+    EXPECT_FALSE(SRuKFType::alphaIsValid(1.5)) << "alpha>1";
 
-    // (1) alphaIsValid: true iff alpha in [0, 1].
-    {
-        filter.setAlpha(0.5);
-        EXPECT_TRUE(filter.alphaIsValid()) << "alpha=0.5 in range";
-        filter.setAlpha(-0.1);
-        EXPECT_FALSE(filter.alphaIsValid()) << "alpha<0";
-        filter.setAlpha(1.5);
-        EXPECT_FALSE(filter.alphaIsValid()) << "alpha>1";
-    }
     // (2) betaIsValid: true iff beta in [0, 2].
-    {
-        filter.setBeta(1.0);
-        EXPECT_TRUE(filter.betaIsValid()) << "beta=1 in range";
-        filter.setBeta(-0.5);
-        EXPECT_FALSE(filter.betaIsValid()) << "beta<0";
-        filter.setBeta(2.5);
-        EXPECT_FALSE(filter.betaIsValid()) << "beta>2";
-    }
-    // (3) initialCovarianceIsValid: true iff PSD.
-    {
-        filter.setInitialCovariance(Eigen::Matrix3d::Identity());
-        EXPECT_TRUE(filter.initialCovarianceIsValid()) << "identity is PSD";
-
-        Eigen::Matrix3d P_neg = -Eigen::Matrix3d::Identity();
-        filter.setInitialCovariance(P_neg);
-        EXPECT_FALSE(filter.initialCovarianceIsValid()) << "negative eigenvalue";
-    }
-    // (4) processNoiseIsValid: true iff PSD.
-    {
-        filter.setProcessNoise(Eigen::Matrix3d::Identity());
-        EXPECT_TRUE(filter.processNoiseIsValid()) << "identity is PSD";
-
-        Eigen::Matrix3d Q_neg = -Eigen::Matrix3d::Identity();
-        filter.setProcessNoise(Q_neg);
-        EXPECT_FALSE(filter.processNoiseIsValid()) << "negative eigenvalue";
-    }
+    EXPECT_TRUE(SRuKFType::betaIsValid(1.0)) << "beta=1 in range";
+    EXPECT_FALSE(SRuKFType::betaIsValid(-0.5)) << "beta<0";
+    EXPECT_FALSE(SRuKFType::betaIsValid(2.5)) << "beta>2";
 }
 
 // Reset

--- a/algorithms/filteringCore/dynamicsModel.hpp
+++ b/algorithms/filteringCore/dynamicsModel.hpp
@@ -28,22 +28,33 @@ constexpr State rk4(D const& dynamics, State const& X0, double t0, double dt) {
     return X0.add(k1.scale(dt / 6.).add(k2.scale(dt / 3.)).add(k3.scale(dt / 3.)).add(k4.scale(dt / 6.)));
 }
 
-/*! Fixed RK4 sub-step used by `propagate`. */
+/*! Fixed RK4 max steps used by `propagate`. */
+inline constexpr double kMaxNumberOfSteps = 100;
+
+/*! Default RK4 sub-step size used by `propagate` when none is supplied. */
 inline constexpr double kIntegrationStep = 0.2;
 
 /*! Propagate state across a time interval in RK4 sub-steps.
  *  @return state at interval[1]
  *  @param dynamics [-]   callable (t, x) -> dx/dt
  *  @param state    [-]   state at interval[0]
- *  @param interval [s,s] {start, end} time pair */
+ *  @param interval [s,s] {start, end} time pair
+ *  @param integrationStep [s] integration time step (optional, defaults to kIntegrationStep) */
 template <LinearlyCombinable State, Dynamics<State> D>
-constexpr State propagate(D const& dynamics, State state, std::array<double, 2> interval) {
+constexpr State propagate(D const& dynamics,
+                          State state,
+                          std::array<double, 2> interval,
+                          double integrationStep = kIntegrationStep) {
     double t = interval[0];
     double const tFinal = interval[1];
 
-    double const N = ceil((tFinal - t) / kIntegrationStep);
+    double N = ceil((tFinal - t) / integrationStep);
+    if (N > kMaxNumberOfSteps) {
+        integrationStep = (tFinal - t) / kMaxNumberOfSteps;
+        N = kMaxNumberOfSteps;
+    }
     for (int i = 0; i < N; ++i) {
-        double const step = std::min(kIntegrationStep, tFinal - t);
+        double const step = std::min(integrationStep, tFinal - t);
         state = rk4(dynamics, state, t, step);
         t += step;
     }

--- a/algorithms/filteringCore/filteringCore.rst
+++ b/algorithms/filteringCore/filteringCore.rst
@@ -438,6 +438,35 @@ A worked, compiling reference (real SRUKF, two observation sizes ``MaxCss``
 and 3) lives in
 ``algorithms/sunlineSRuKF/_tests/test_sunlineSRuKFAlgorithm.cpp``.
 
+Assumptions and Limitations
+---------------------------
+
+Heterogeneous rates share one anchor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``applySequential`` keeps a single last-measurement anchor
+(``queue.getTimeOfLastMeasurement()``) for **all** measurement kinds, and it
+drops any queued measurement whose ``timeTag`` is earlier than that anchor (the
+``if m.timeTag < tLast: continue`` guard). When two kinds are ingested at
+different frequencies, the faster kind repeatedly advances the shared anchor; if
+the filter time step is small enough that a slower kind's sample then lands *in
+the past* relative to the already-advanced anchor, that slower measurement is
+silently skipped and never folded into the state.
+
+To keep every kind observed you must either:
+
+- **size the filter time step so at least one of each of the N measurement kinds
+  falls within a single** ``update`` **call** — then all kinds are enqueued
+  together and applied in time order, so none lands behind the anchor; or
+- **reduce the rate of the faster kind** relative to the time step.
+
+In other words, avoid time steps so small that a window can hold several
+fast-kind samples but no slow-kind sample.
+
+*Future work* (TBD): track a separate previous-measurement time per measurement
+kind, so a slow kind is sequenced against its own last time rather than against a
+global anchor shared with faster kinds.
+
 How to use a filter
 -------------------
 

--- a/algorithms/filteringCore/filteringCore.rst
+++ b/algorithms/filteringCore/filteringCore.rst
@@ -127,10 +127,15 @@ which the parent ``algorithms/`` include path resolves.
      ``srukf::timeUpdate<State, D>``, ``srukf::measurementUpdate<State, M>``;
    - a **stateful facade** — ``SRuKF<State, Dyn>``, which holds a
      ``SrukfStorage`` and a settable ``dynamics`` member and exposes
-     ``reset()`` / ``timeUpdate(dt)`` / ``measurementUpdate<M>(m)`` plus
-     setters/getters and a ``getStateAtLastMeasurement()`` /
-     ``setStateLastMeasurement()`` pair for the rolling last-measurement
-     state.
+     ``reConfigure()`` / ``reset()`` / ``timeUpdate(dt)`` /
+     ``measurementUpdate<M>(m)`` plus setters/getters and a
+     ``getStateAtLastMeasurement()`` / ``setStateLastMeasurement()`` pair for
+     the rolling last-measurement state.
+
+   ``reConfigure()`` re-derives the sigma-point spread (lambda, eta), the sigma
+   weights, and the process-noise Cholesky from alpha, beta, and the process
+   noise, leaving the estimate untouched; ``reset()`` calls ``reConfigure()``
+   and additionally seeds the state and covariance from the initial conditions.
 
    ``timeUpdate(dt)`` always propagates **from the saved last-measurement
    state**, which it leaves untouched, so it is idempotent in ``dt`` — calling
@@ -145,8 +150,9 @@ host adapter
 ``SunlineSRuKF`` is a ``SysModel`` that owns the message ports and holds the
 algorithm behind a ``std::unique_ptr`` (forward-declared, so the SWIG-parsed
 header never sees the concept-heavy core). At ``reset`` it latches the CSS
-geometry (``nHat``, ``CBias``, count) from ``cssConfigInMsg`` into the
-algorithm. Each ``updateState`` it reads the gyro (``navAttInMsg``) and CSS
+geometry (boresights, per-sensor scale factors, count) from ``cssConfigInMsg``,
+builds and validates a ``SunlineSRuKFConfig``, and constructs the algorithm.
+Each ``updateState`` it reads the gyro (``navAttInMsg``) and CSS
 array (``cssDataInMsg``) payloads into ``RateData`` / ``CssData`` (skipping
 stale readings via per-channel timeTag tracking) and drives the filter over the
 window with a single ``update(currentSeconds, cssData, rateData)`` call. The
@@ -156,7 +162,8 @@ call; ``applySequential`` decides per step whether to ``timeUpdate`` (predict)
 or ``measurementUpdate``. The adapter then writes the returned
 ``SunlineSRuKFOutput`` (state + covariance + per-kind residuals) back into the
 ``navAttOutMsg`` / ``filterOutMsg`` / ``filterGyroResOutMsg`` /
-``filterCssResOutMsg`` payloads.
+``filterCssResOutMsg`` payloads. It also exposes ``reInitialize()`` /
+``reInitializeAll()`` pass-throughs for restarting the filter at runtime.
 
 How the pieces compose
 --------------------------------------------
@@ -441,30 +448,21 @@ xmera):
 
    using namespace filtering::sunlineSRuKF;
 
-   SunlineSRuKFAlgorithm algo;          // owns the SRUKF + measurement_queue
-   algo.setAlpha(0.02);
-   algo.setBeta(2.0);
-   algo.setProcessNoise(Q);             // 7x7
-   algo.setInitialCovariance(P0);       // 7x7
-
-   // CSS geometry + noise (the host adapter latches these from CSSConfig at reset)
-   algo.setCssNHat(nHat);               // MaxCss x 3 unit vectors (body)
-   algo.setCssCBias(cBias);             // MaxCss per-sensor calibration biases
-   algo.setNumberOfCss(numCss);         // 0 .. MaxCss
-   algo.setSensorThreshold(0.1);        // min cosValue to count a CSS as active
-   algo.setCssMeasurementNoiseStd(sigmaCss);
-   algo.setGyroMeasurementNoiseStd(sigmaGyro);
-   algo.setBiasLowerBound(0.5);
-   algo.setBiasUpperBound(1.5);
-
    SunlineSRuKFAlgorithm::State x0;
    x0.set<filtering::Position<3>>(sHat0);                       // sun heading (unit)
    x0.set<filtering::Velocity<3>>(omega0);                      // body rate
-   x0.set<filtering::Bias<1>>(Eigen::Vector<double, 1>{1.0});   // CSS bias
-   algo.setInitialState(x0);
+   x0.set<filtering::Bias<1>>(Eigen::Vector<double, 1>{1.0});   // bias state
 
-   algo.reset();                        // pushes config into the SRUKF, installs
-                                        // dynamics, clears the queue
+   // Build a validated configuration (throws on invalid input). CSS geometry
+   // (boresights, per-sensor scale factors, count) is latched from CSSConfig by
+   // the host adapter at reset; here it is supplied directly.
+   SunlineSRuKFConfig cfg = SunlineSRuKFConfig::create(
+       0.02, 2.0, Q, x0, P0,            // alpha, beta, processNoise (7x7), initialState, initialCovariance (7x7)
+       0.5, 1.5,                        // biasLowerBound, biasUpperBound
+       nHat, scaleFactor, numCss,       // MaxCss x 3 boresights, MaxCss scale factors, count (0 .. MaxCss)
+       0.1, sigmaCss, sigmaGyro);       // sensorThreshold, cssMeasurementNoiseStd, gyroMeasurementNoiseStd
+
+   SunlineSRuKFAlgorithm algo(cfg);     // owns the SRUKF + measurement_queue; construction seeds the filter
 
    // Queue-driven path: hand the raw readings to one drive call. update() packs
    // whichever readings are present (timeTag > 0), enqueues them, and runs
@@ -478,6 +476,11 @@ xmera):
    // what applySequential calls under the hood).
    algo.timeUpdate(dt);                            // predict
    algo.measurementUpdate(RateMeasurement{...});   // fold a measurement in directly
+
+   // Runtime resets / reconfiguration:
+   algo.reInitialize();        // clear pending measurements + residuals; keep state and covariance
+   algo.reInitializeAll();     // the above plus re-seed state and covariance from the config
+   algo.setConfig(newCfg);     // swap the config and re-derive the SRUKF parameters in place
 
    FilterStateOutput   state   = out.filterState;   // mean + covariance
    CssResidualsOutput  cssRes  = out.cssResiduals;   // pre/post-fit; valid only if CSS fired
@@ -495,9 +498,10 @@ How to add a new filter
    functor that satisfies ``Dynamics<D, State>``. A multi-kind filter also
    names its ``Measurement`` variant here.
 #. **Write the algorithm class** — the single composition root. Holds a
-   ``SRuKF<State, Dyn>``, the retained configuration with
-   setter/getter implementations, ``reset()``, the ``SequentialFilter``
-   pair (``timeUpdate(dt)`` / ``measurementUpdate(m)``), the readouts
+   ``SRuKF<State, Dyn>`` and an immutable validated ``Config`` (built by a
+   static ``create()`` factory, supplied at construction and swappable via
+   ``setConfig()``), ``reInitialize()`` / ``reInitializeAll()``, the
+   ``SequentialFilter`` pair (``timeUpdate(dt)`` / ``measurementUpdate(m)``), the readouts
    (``getFilterOutput`` / ``getCovariance`` / per-kind residuals), a
    ``measurement_queue<Measurement, CAPACITY>``, plus a single-call
    ``update(...)`` that runs

--- a/algorithms/filteringCore/filteringCore.rst
+++ b/algorithms/filteringCore/filteringCore.rst
@@ -112,12 +112,34 @@ which the parent ``algorithms/`` include path resolves.
    template (see ``kalmanFilter.hpp``).
 
 ``kalmanFilter.hpp``
-   The ``SequentialFilter<F, M>`` concept — the contract a Kalman-style filter
-   satisfies (``timeUpdate(dt)`` + ``measurementUpdate(m)``).
-   It also defines ``applySequential(queue, filter, callTime)`` — the canonical scheduler
-   that interleaves time and measurement updates relative to the queue's
-   last-measurement time. Alternative scheduling styles (batch, iterated, ...)
-   drop in as new ``apply_*`` free templates without touching the queue.
+   The ``SequentialFilter<F, M>`` concept plus the scheduling free functions.
+   The concept is **deliberately non-prescriptive**: it only requires that a
+   filter *has* a ``timeUpdate(dt)`` and a ``measurementUpdate(m)`` — it says
+   nothing about their return types or side effects. What those methods must
+   actually *do* is fixed instead by the **scheduler you choose**, so the
+   scheduler — not the concept — is where the real contract on the filter's
+   methods lives:
+
+   - ``applySequential(queue, filter, callTime)`` — the basic scheduler.
+     It interleaves ``timeUpdate`` / ``measurementUpdate`` relative to the
+     queue's last-measurement time and **ignores their return values**, so the
+     updates may return ``void``. It trusts every update and always advances the
+     anchor.
+   - ``applySequentialRobust(queue, filter, callTime)`` — the robust scheduler.
+     It **reads each update's outcome**, so ``timeUpdate`` and
+     ``measurementUpdate`` must return a bool-convertible validity (``true`` /
+     has-value on success), and the filter must expose a ``clear()`` that rewinds
+     it to its last good state. On a failed update it calls ``clear()`` and
+     leaves the anchor in place, so a bad measurement can neither corrupt the
+     estimate nor advance the timeline.
+
+   The upshot: the concept keeps the core open — any two update methods satisfy
+   it — while the chosen scheduler *drives the design* of those methods. Pick
+   ``applySequentialRobust`` and you are obliged to make your updates report
+   validity and to implement ``clear()``; pick ``applySequential`` and plain
+   ``void`` updates suffice. Other scheduling styles (batch, iterated, ...) drop
+   in as further ``apply_*`` free templates, each imposing its own method
+   contract, without touching the queue.
 
 ``srukf.hpp``
    The square-root uKF (van der Merwe & Wan, ICASSP 2001) in two layers:

--- a/algorithms/filteringCore/filteringCore.rst
+++ b/algorithms/filteringCore/filteringCore.rst
@@ -16,7 +16,7 @@ Background
 This filtering core exists to create and interface in order to compose filters with ease
 and be able to rely on the previously tested math and business logic required by filter families.
 
-For example, the kalmanFilter header file contains the applySequential function which orchestrates the
+For example, the kalmanFilter header file contains the applySequential and applySequentialRobust functions which orchestrate the
 calls of time and measurement updates on a queue of measurements. These functions can call the srukf (other header)
 definitions of those functions to perform those specific updates.
 
@@ -56,21 +56,21 @@ Composable structure
    +-------------------------------------------------------------+
                   depends only on Eigen + the C++ stdlib
 
-The host adapter and the algorithm library live in the **same directory**
+The host adapter and the algorithm library live in the same directory
 (``algorithms/sunlineSRuKF``) and compile into one SWIG module, but they stay
-cleanly separable: ``sunlineSRuKF.{h,cpp}`` is the only xmera-aware translation
+seperate: ``sunlineSRuKF.{h,cpp}`` is the xmera translation
 unit, and ``sunlineSRuKFAlgorithm.{h,cpp}`` / ``sunlineSRuKFSpecs.h`` depend
 only on ``filteringCore``.
 
 filteringCore
 ~~~~~~~~~~~~~~~
 
-Header-only ``INTERFACE`` library (``algorithms/filteringCore``). The headers
+Header-only interface library (``algorithms/filteringCore``). The headers
 sit at the top of that directory and are included as ``<filteringCore/...>``,
 which the parent ``algorithms/`` include path resolves.
 
 ``state.hpp``
-   ``StateVector<Components...>`` is a variadic, type-composed state vector laid
+   ``StateVector<Components...>`` is a type-composed state vector laid
    out contiguously in a single fixed-size ``Eigen::Vector``. Components are
    addressed by their tag type at compile time:
 
@@ -90,7 +90,7 @@ which the parent ``algorithms/`` include path resolves.
 
 ``concepts.hpp``
    The C++20 concepts that define the interfaces, so filters compose by
-   *satisfying an interface* rather than by inheritance:
+   satisfying an interface rather than by inheritance:
 
    - ``LinearlyCombinable<T>`` — has ``scale(k)`` and ``add(other)``.
    - ``FilterState<S>`` — ``LinearlyCombinable`` plus ``S::size`` and ``raw()``.
@@ -100,7 +100,7 @@ which the parent ``algorithms/`` include path resolves.
 
 ``dynamicsModel.hpp``
    ``DynamicsModel<State>`` (a ``std::function`` alias) plus ``rk4()`` and
-   ``propagate()`` — concept-constrained RK4 integration usable on any
+   ``propagate()`` — RK4 integration usable on any
    ``LinearlyCombinable`` state.
 
 ``measurementQueue.h``
@@ -113,28 +113,28 @@ which the parent ``algorithms/`` include path resolves.
 
 ``kalmanFilter.hpp``
    The ``SequentialFilter<F, M>`` concept plus the scheduling free functions.
-   The concept is **deliberately non-prescriptive**: it only requires that a
-   filter *has* a ``timeUpdate(dt)`` and a ``measurementUpdate(m)`` — it says
-   nothing about their return types or side effects. What those methods must
-   actually *do* is fixed instead by the **scheduler you choose**, so the
-   scheduler — not the concept — is where the real contract on the filter's
+   The concept is deliberately non-prescriptive: it only requires that a
+   filter has a ``timeUpdate(dt)`` and a ``measurementUpdate(m)``. It does not
+   constrain their return types. What those methods must
+   actually return is fixed instead by the **scheduler you choose**, so the
+   scheduler — not the concept — is where the final contract on the filter's
    methods lives:
 
    - ``applySequential(queue, filter, callTime)`` — the basic scheduler.
      It interleaves ``timeUpdate`` / ``measurementUpdate`` relative to the
-     queue's last-measurement time and **ignores their return values**, so the
-     updates may return ``void``. It trusts every update and always advances the
+     queue's last-measurement time, so the
+     updates should return ``void``. It trusts every update and always advances the
      anchor.
    - ``applySequentialRobust(queue, filter, callTime)`` — the robust scheduler.
-     It **reads each update's outcome**, so ``timeUpdate`` and
-     ``measurementUpdate`` must return a bool-convertible validity (``true`` /
+     It reads each update's outcome, so ``timeUpdate`` and
+     ``measurementUpdate`` must return a bool validity (``true`` /
      has-value on success), and the filter must expose a ``clear()`` that rewinds
      it to its last good state. On a failed update it calls ``clear()`` and
      leaves the anchor in place, so a bad measurement can neither corrupt the
      estimate nor advance the timeline.
 
    The upshot: the concept keeps the core open — any two update methods satisfy
-   it — while the chosen scheduler *drives the design* of those methods. Pick
+   it — while the chosen scheduler drives the design of those methods. Pick
    ``applySequentialRobust`` and you are obliged to make your updates report
    validity and to implement ``clear()``; pick ``applySequential`` and plain
    ``void`` updates suffice. Other scheduling styles (batch, iterated, ...) drop
@@ -144,10 +144,10 @@ which the parent ``algorithms/`` include path resolves.
 ``srukf.hpp``
    The square-root uKF (van der Merwe & Wan, ICASSP 2001) in two layers:
 
-   - a **functional core** — ``SrukfStorage<State>`` (plain data, all
+   - a functional core — ``SrukfStorage<State>`` (plain data, all
      fixed-size) and free functions ``srukf::reset``,
      ``srukf::timeUpdate<State, D>``, ``srukf::measurementUpdate<State, M>``;
-   - a **stateful facade** — ``SRuKF<State, Dyn>``, which holds a
+   - a state container — ``SRuKF<State, Dyn>``, which holds a
      ``SrukfStorage`` and a settable ``dynamics`` member and exposes
      ``reConfigure()`` / ``reset()`` / ``timeUpdate(dt)`` /
      ``measurementUpdate<M>(m)`` plus setters/getters and a
@@ -168,24 +168,11 @@ which the parent ``algorithms/`` include path resolves.
 host adapter
 ~~~~~~~~~~~~
 
-``algorithms/sunlineSRuKF/sunlineSRuKF.{h,cpp}`` is the only xmera-aware layer.
+``algorithms/sunlineSRuKF/sunlineSRuKF.{h,cpp}`` is the only xmera layer.
 ``SunlineSRuKF`` is a ``SysModel`` that owns the message ports and holds the
 algorithm behind a ``std::unique_ptr`` (forward-declared, so the SWIG-parsed
-header never sees the concept-heavy core). At ``reset`` it latches the CSS
-geometry (boresights, per-sensor scale factors, count) from ``cssConfigInMsg``,
-builds and validates a ``SunlineSRuKFConfig``, and constructs the algorithm.
-Each ``updateState`` it reads the gyro (``navAttInMsg``) and CSS
-array (``cssDataInMsg``) payloads into ``RateData`` / ``CssData`` (skipping
-stale readings via per-channel timeTag tracking) and drives the filter over the
-window with a single ``update(currentSeconds, cssData, rateData)`` call. The
-algorithm owns the ``measurement_queue`` and runs
-``applySequential(measurements, *this, currentSeconds)`` inside that ``update``
-call; ``applySequential`` decides per step whether to ``timeUpdate`` (predict)
-or ``measurementUpdate``. The adapter then writes the returned
-``SunlineSRuKFOutput`` (state + covariance + per-kind residuals) back into the
-``navAttOutMsg`` / ``filterOutMsg`` / ``filterGyroResOutMsg`` /
-``filterCssResOutMsg`` payloads. It also exposes ``reInitialize()`` /
-``reInitializeAll()`` pass-throughs for restarting the filter at runtime.
+header never sees the concept-heavy core). See filter implementation examples
+for more details.
 
 How the pieces compose
 --------------------------------------------
@@ -196,40 +183,6 @@ measurement scheduler, and the C++20 concepts that define the interfaces; a conc
 filter supplies only what is genuinely filter-specific: what is estimated, how
 it evolves, and how it is observed.
 
-Roles, interfaces, and what sunline provides
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-   :widths: 24 28 24 24
-
-   * - Role
-     - Contract (concept)
-     - Core consumer
-     - SunlineSRuKF supplies
-   * - What is estimated
-     - ``FilterState<S>``
-     - ``SRuKF<State, Dyn>``, ``propagate``
-     - ``StateVector<Position<3>, Velocity<3>, Bias<1>>``
-   * - How the state evolves
-     - ``Dynamics<D, State>``
-     - ``rk4`` / ``propagate`` (in ``srukf::timeUpdate``)
-     - ``SunlineDynamics`` (``ds/dt = s × ω``)
-   * - How the state is observed
-     - ``Measurement<M, State>``
-     - ``srukf::measurementUpdate``
-     - ``CssMeasurementModel`` and ``RateMeasurementModel``
-   * - The drivable filter
-     - ``SequentialFilter<F, M>`` (``timeUpdate`` + ``measurementUpdate``)
-     - ``applySequential`` (free template)
-     - ``SunlineSRuKFAlgorithm``
-   * - When to time-update vs. measurement-update
-     - — (concrete, not a concept)
-     - ``measurement_queue`` (container) + ``applySequential`` (free function)
-     - ``SunlineSRuKFAlgorithm`` owns one ``measurement_queue<Measurement, BatchSize>`` and runs ``applySequential(measurements, *this, currentSeconds)`` from its ``update``
-
-The first three rows are the interfaces a new filter must implement; everything
-in the "Core consumer" column is reused unchanged.
 
 Static view: concepts as interfaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -263,74 +216,6 @@ the estimate physically meaningful, it post-processes after the queue drains —
 sunline's ``regularize()`` renormalizes the heading to a unit vector and clamps
 the CSS bias to its configured bounds; the SRUKF itself stays agnostic to that.
 
-Runtime view: one update window
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A single ``update(currentSeconds, cssData, rateData)`` call does three things:
-it enqueues the fresh readings, drains the queue through the filter in time
-order, and returns the post-update snapshot. The four schematics below break
-that down — first the top-level flow across the layers, then what
-``applySequential`` drives, then the two update call chains it drives into.
-
-**1. Top-level flow — one call across the layers**
-
-::
-
-   Xmera adapter                         SunlineSRuKFAlgorithm
-   ------------                          ---------------------
-   read NavAtt + CSS msgs
-   build RateData / CssData
-   algo.update(t, css, rate) ─────────►  enqueue fresh readings
-                                         applySequential(queue, *this, t)
-                                         (drives the two updates below)
-   write output msgs         ◄─────────  return SunlineSRuKFOutput
-                                         (state + covariance + residuals)
-
-**2. What ``applySequential`` drives, per queued step**
-
-It walks the queue earliest-first and is the only thing that decides whether the
-next action is a prediction or a correction:
-
-::
-
-   for each queued measurement m (earliest first):
-       filter.timeUpdate(m.timeTag - tLast)   // advance to m's time
-       filter.measurementUpdate(m)            // fold m in
-       tLast = m.timeTag
-   filter.timeUpdate(t - tLast)               // advance to the output time
-
-**3. A time update — the prediction call chain**
-
-::
-
-   algo.timeUpdate(dt)
-     └─ srukf.timeUpdate(dt)
-          └─ srukf::timeUpdate
-               └─ propagate ─► rk4 ─► dynamics(t, x):  ṡ = s × ω
-
-**4. A measurement update — the correction call chain**
-
-The measurement is a ``std::variant``; ``std::visit`` dispatches to the overload
-for the kind that arrived, which builds that kind's model and hands it to the
-estimator:
-
-::
-
-   algo.measurementUpdate(m)         // m : variant<CssMeasurement, RateMeasurement>
-     └─ std::visit ─► applyMeasurement(kind)
-          └─ srukf.measurementUpdate(model)
-               └─ srukf::measurementUpdate
-                    └─ model.model(x) / model.noise() / model.subtract(a, b)
-
-The queue is just a container, and the algorithm doesn't sequence anything
-itself — it only exposes the ``SequentialFilter`` pair that ``applySequential``
-calls. A filter family that wants different scheduling (batch, iterated,
-particle resample, ...) gets a different ``apply_*`` free template (constrained
-on whatever concept that family needs) and reuses the same container.
-The estimator behind the algorithm is likewise an internal detail: it only has
-to make ``timeUpdate`` / ``measurementUpdate`` do the right thing, and the
-queue, the scheduling function, the integrator, and the concepts don't depend
-on which estimator is inside.
 
 Time bookkeeping: queue ↔ SRUKF
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -345,7 +230,7 @@ that stay in lockstep:
   ``srukf::measurementUpdate``.
 
 This anchor is the last estimate the filter fully trusts, and it is never
-compromised by a prediction. ``timeUpdate(dt)`` propagates a *working copy* of
+compromised by a prediction. ``timeUpdate(dt)`` propagates a working copy of
 the anchor forward by ``dt`` to produce the current output; the anchor itself is
 left intact. Only ``measurementUpdate`` advances it — once a new measurement is
 folded in, that posterior becomes the new anchor. So ``dt`` is always measured
@@ -377,12 +262,12 @@ After the loop above runs against m1 then m2:
 - inside the SRUKF: ``stateLastMeasurement`` (the anchor) = post-update state at t=4;
 - on the queue: ``getTimeOfLastMeasurement() == 4``;
 - the final ``filter.timeUpdate(callTime - 4) == timeUpdate(3)`` advances a
-  working copy to t=7 **without** moving the anchor. The output messages read
+  working copy to t=7 without moving the anchor. The output messages read
   this propagated value.
 
 On the next call, if a new measurement arrives at t=10, the scheduler issues
 ``filter.timeUpdate(10 - 4) == timeUpdate(6)`` — the SRUKF propagates 6 s
-forward from its preserved t=4 anchor, **not** 3 s past the previously-output
+forward from its preserved t=4 anchor, not 3 s past the previously-output
 t=7 value. Because the anchor was never compromised, no drift accumulates from
 the output-only propagation.
 
@@ -417,10 +302,10 @@ Why the pattern is generic
 Heterogeneous measurements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A multi-sensor filter consumes more than one *kind* of measurement on one
-timeline. ``sunlineSRuKF`` is exactly this case — it folds CSS array readings
+A multi-sensor filter consumes more than one kind of measurement on one
+timeline. ``sunlineSRuKF`` is an example — it folds CSS array readings
 and gyro rates into the same state on a shared timeline. No core change is
-needed for this; the core is kind-agnostic:
+needed for this; the core is agnostic of the measurement type:
 
 - ``measurement_queue``, ``applySequential``, and ``SequentialFilter`` all
   operate over an arbitrary ``Measurement`` type.
@@ -430,10 +315,8 @@ needed for this; the core is kind-agnostic:
   is size 3, both driven through the same path).
 
 ``std::variant`` is freestanding on the target toolchain (GCC 14+ / C++26
-P2407, ``__cpp_lib_freestanding_variant``), so it is an appropriate closed-set
-mechanism here. The filter that knows its kinds names the set as a
-``std::variant`` and dispatches with ``std::visit`` — fixed-size, no heap, no
-virtual:
+P2407, ``__cpp_lib_freestanding_variant``). The filter that knows its kinds names the set as a
+``std::variant`` and dispatches with ``std::visit``
 
 .. code-block:: cpp
 
@@ -448,17 +331,13 @@ virtual:
    void applyMeasurement(RateMeasurement const&);
 
 Because every kind shares the one queue timeline, ``applySequential``
-interleaves them in time order. The variant is over the **input structs**; each
-``applyMeasurement`` overload builds that kind's **model** (the
+interleaves them in time order. The variant is over the input structs; each
+``applyMeasurement`` overload builds that kind's model (the
 ``Measurement<M, State>`` object) and calls ``srukf.measurementUpdate`` — the
 same input-struct-vs-model split a single-kind filter would use. Each overload also
 records its own residuals (``lastCssResiduals`` / ``lastRateResiduals``), so the
 bundled ``SunlineSRuKFOutput`` reports only the kinds that actually fired this
 cycle.
-
-A worked, compiling reference (real SRUKF, two observation sizes ``MaxCss``
-and 3) lives in
-``algorithms/sunlineSRuKF/_tests/test_sunlineSRuKFAlgorithm.cpp``.
 
 Assumptions and Limitations
 ---------------------------
@@ -467,7 +346,7 @@ Heterogeneous rates share one anchor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``applySequential`` keeps a single last-measurement anchor
-(``queue.getTimeOfLastMeasurement()``) for **all** measurement kinds, and it
+(``queue.getTimeOfLastMeasurement()``) for all measurement kinds, and it
 drops any queued measurement whose ``timeTag`` is earlier than that anchor (the
 ``if m.timeTag < tLast: continue`` guard). When two kinds are ingested at
 different frequencies, the faster kind repeatedly advances the shared anchor; if
@@ -477,17 +356,13 @@ silently skipped and never folded into the state.
 
 To keep every kind observed you must either:
 
-- **size the filter time step so at least one of each of the N measurement kinds
-  falls within a single** ``update`` **call** — then all kinds are enqueued
+- **size the filter time step** so at least one of each of the N measurement kinds
+  falls within a single ``update`` **call** — then all kinds are enqueued
   together and applied in time order, so none lands behind the anchor; or
 - **reduce the rate of the faster kind** relative to the time step.
 
 In other words, avoid time steps so small that a window can hold several
 fast-kind samples but no slow-kind sample.
-
-*Future work* (TBD): track a separate previous-measurement time per measurement
-kind, so a slow kind is sequenced against its own last time rather than against a
-global anchor shared with faster kinds.
 
 How to use a filter
 -------------------
@@ -573,13 +448,3 @@ How to add a new filter
    ``algorithms/sunlineSRuKF/_tests``.
 #. **Write the host adapter** under ``algorithms/<filter>`` that marshals
    messages to and from the plain-data I/O types and links the algorithm library.
-
-.. note::
-
-   **Variable-size measurements** (e.g. a varying number of active coarse sun
-   sensors) are handled with a fixed-capacity ``Eigen::Vector<double, MAX>`` and
-   a runtime count, sliced with ``.head()`` / ``.topRows()`` — not a dynamically
-   sized Eigen type. ``sunlineSRuKF`` exercises this directly: its
-   ``CssMeasurement`` carries an ``Eigen::Vector<double, MaxCss>`` plus a
-   ``numberOfActiveCss`` count, and ``packCssMeasurement`` fills only the active
-   leading rows (those above ``sensorUseThresh``).

--- a/algorithms/filteringCore/kalmanFilter.hpp
+++ b/algorithms/filteringCore/kalmanFilter.hpp
@@ -8,17 +8,23 @@
 
 namespace filtering {
 
-/*! A sequential filter exposes the time-update and measurement-update functions. */
+/*! A sequential filter exposes the time-update and measurement-update functions.
+ * At the concept level, they are not constrained to return anything specific. That is only driven by
+ * the choice of applySquential. So when implementing a filter, the developer must ensure that their
+ * implementations if time and measurement updates match the signature required by the applySequential logic.
+ */
 template <class Filter, class Measurement>
 concept SequentialFilter = requires(Filter f, Measurement& m, double dt) {
     { f.timeUpdate(dt) };
     { f.measurementUpdate(m) };
 };
 
-/*! Sequential filter scheduling: empty the measurement queue in chronological order, calling
+/*! Basic sequential filter scheduling: empty the measurement queue in chronological order, calling
  *  timeUpdate from the last measurement-updated state to the measurement timeTag then measurementUpdate
  *  for each measurement; Call timeUpdate to `callTime` from there so the filter's `state`
  *  reflects the call time on return.
+ *  If this function is called, the timeUpdate and measurementUpdates of the specific filter obeying the concept
+ *  defined above must both return voids
  *  @param queue    [-] measurement queue (drained on return)
  *  @param filter   [-] filter satisfying SequentialFilter
  *  @param callTime [s] sim time the filter is advancing to */
@@ -30,15 +36,48 @@ void applySequential(measurement_queue<Measurement, Capacity>& queue, Filter& fi
     for (auto entry = queue.popEarliest(); entry.has_value(); entry = queue.popEarliest()) {
         auto& [timeTag, measurement] = entry.value();
         if (timeTag < timeOfLastMeasurement) continue;
-
         filter.timeUpdate(timeTag - timeOfLastMeasurement);
         filter.measurementUpdate(measurement);
-
         timeOfLastMeasurement = timeTag;
     }
 
     if (timeOfLastMeasurement < callTime) {
         filter.timeUpdate(callTime - timeOfLastMeasurement);
+    }
+
+    queue.setTimeOfLastMeasurement(timeOfLastMeasurement);
+}
+
+/*! Robust sequential filter scheduling: empty the measurement queue in chronological order, calling
+ *  timeUpdate from the last measurement-updated state to the measurement timeTag then measurementUpdate
+ *  for each measurement; Call timeUpdate to `callTime` from there so the filter's `state`
+ *  reflects the call time on return.
+ *  Because the timeUpdate and measurementUpdates now detect bad updates, they must now both return a bool.
+ *  If the update was successful they should return true, and false otherwise. The filter must also have a
+ *  clear method so that internal state can be sanitized after a bad update.
+ *  @param queue    [-] measurement queue (drained on return)
+ *  @param filter   [-] filter satisfying SequentialFilter
+ *  @param callTime [s] sim time the filter is advancing to */
+template <class Filter, class Measurement, std::size_t Capacity>
+    requires SequentialFilter<Filter, Measurement>
+void applySequentialRobust(measurement_queue<Measurement, Capacity>& queue, Filter& filter, double callTime) {
+    double timeOfLastMeasurement = queue.getTimeOfLastMeasurement();
+
+    for (auto entry = queue.popEarliest(); entry.has_value(); entry = queue.popEarliest()) {
+        auto& [timeTag, measurement] = entry.value();
+        if (timeTag < timeOfLastMeasurement) continue;
+
+        if (!filter.timeUpdate(timeTag - timeOfLastMeasurement) || !filter.measurementUpdate(measurement)) {
+            filter.clear();
+        } else {
+            timeOfLastMeasurement = timeTag;
+        }
+    }
+
+    if (timeOfLastMeasurement < callTime) {
+        if (!filter.timeUpdate(callTime - timeOfLastMeasurement)) {
+            filter.clear();
+        }
     }
 
     queue.setTimeOfLastMeasurement(timeOfLastMeasurement);

--- a/algorithms/filteringCore/measurementQueue.h
+++ b/algorithms/filteringCore/measurementQueue.h
@@ -30,13 +30,10 @@ class measurement_queue final {
     bool enqueue(double timeTag, Measurement&& measurement) {
         if (this->isFull()) return false;
 
-        std::size_t insertionIndex = this->size;
-        while (insertionIndex > 0) {
+        std::size_t insertionIndex = 0;
+        for (insertionIndex = this->size; insertionIndex > 0; --insertionIndex) {
             if (timeTag <= this->measurements[insertionIndex - 1].value().first) break;
-
             this->measurements[insertionIndex] = std::move(this->measurements[insertionIndex - 1]);
-
-            insertionIndex -= 1;
         }
 
         this->measurements[insertionIndex] = {timeTag, std::move(measurement)};

--- a/algorithms/filteringCore/srukf.hpp
+++ b/algorithms/filteringCore/srukf.hpp
@@ -4,6 +4,7 @@
 #ifndef FILTERING_CORE_SRUKF_HPP
 #define FILTERING_CORE_SRUKF_HPP
 
+#include <utilities/fsw/safeMath.h>
 #include <utilities/fsw/validPSDCheck.h>
 #include <filteringCore/concepts.hpp>
 #include <filteringCore/dynamicsModel.hpp>
@@ -158,7 +159,7 @@ class SRuKF {
         this->cholProcessNoise = choleskyDecomposition<N>(this->processNoise);
 
         this->lambda = Ndouble * (this->alpha * this->alpha - 1.0);
-        this->eta = sqrt(Ndouble + this->lambda);
+        this->eta = safeSqrt(Ndouble + this->lambda);
 
         this->wM(0) = this->lambda / (Ndouble + this->lambda);
         this->wC(0) = this->lambda / (Ndouble + this->lambda) + (1.0 - this->alpha * this->alpha + this->beta);

--- a/algorithms/filteringCore/srukf.hpp
+++ b/algorithms/filteringCore/srukf.hpp
@@ -147,20 +147,13 @@ class SRuKF {
     /*! @return true iff the configured process noise is symmetric PSD */
     bool processNoiseIsValid() const { return isPositiveSemiDefinite(this->processNoise); }
 
-    /*! Initialize from initial conditions; seeds the rolling
-     *  last-measurement state and derives lambda, eta, sigma weights. */
-    void reset() {
+    /*! Derive the sigma-point spread (lambda, eta), the sigma weights, and the
+     *  process-noise Cholesky from alpha, beta, and the process noise. The estimate
+     *  (state and covariance) is left untouched. */
+    void reConfigure() {
         constexpr int N = State::size;
         constexpr int numSigmaPoints = 2 * N + 1;
         constexpr auto Ndouble = static_cast<double>(N);
-
-        this->state = this->stateInitial;
-        this->covariance = this->covarianceInitial;
-        this->sqrtCovar = choleskyDecomposition<N>(this->covarianceInitial);
-
-        this->stateLastMeasurement = this->state;
-        this->covarianceLastMeasurement = this->covariance;
-        this->sqrtCovarLastMeasurement = this->sqrtCovar;
 
         this->cholProcessNoise = choleskyDecomposition<N>(this->processNoise);
 
@@ -173,6 +166,20 @@ class SRuKF {
             this->wM(i) = 1.0 / (2.0 * (Ndouble + this->lambda));
             this->wC(i) = this->wM(i);
         }
+    }
+
+    /*! Seed the estimate from initial conditions and re-derive the filter parameters
+     *  (reConfigure() plus a state/covariance reset). */
+    void reset() {
+        constexpr int N = State::size;
+        
+        this->state = this->stateInitial;
+        this->covariance = this->covarianceInitial;
+        this->sqrtCovar = choleskyDecomposition<N>(this->covarianceInitial);
+
+        this->stateLastMeasurement = this->state;
+        this->covarianceLastMeasurement = this->covariance;
+        this->sqrtCovarLastMeasurement = this->sqrtCovar;
     }
 
     /*! Rewind to the last-measurement state and propagate by dt. If dt = 0

--- a/algorithms/filteringCore/srukf.hpp
+++ b/algorithms/filteringCore/srukf.hpp
@@ -198,7 +198,7 @@ class SRuKF {
      *  the sigma points are populated around the last-measurement state for the
      *  next measurementUpdate but the timeUpdate math isn't done
      *  @param dt [s] elapsed time since the last measurement */
-    void timeUpdate(const double dt) {
+    bool timeUpdate(const double dt) {
         constexpr int N = State::size;
         constexpr int numSigmaPoints = 2 * N + 1;
 
@@ -251,7 +251,12 @@ class SRuKF {
             this->sqrtCovar = choleskyUpDownDate<N>(sBar, xError, this->wC(0));
             this->covariance = this->sqrtCovar * this->sqrtCovar.transpose();
             this->state = this->sigmaPoints[0];
+
+            if (!this->state.allFinite() || !this->sqrtCovar.allFinite()) {
+                return false;
+            }
         }
+        return true;
     }
 
     /*! Process a measurement. Update the last-measurement state and the time-state

--- a/algorithms/filteringCore/srukf.hpp
+++ b/algorithms/filteringCore/srukf.hpp
@@ -183,6 +183,17 @@ class SRuKF {
         this->sqrtCovarLastMeasurement = this->sqrtCovar;
     }
 
+    /*! Return the filter state to the previous measurement in the case of a bad update.
+     * Re-configure in case a value became corrupted.
+     */
+    void clear() {
+        this->state = this->stateLastMeasurement;
+        this->covariance = this->covarianceLastMeasurement;
+        this->sqrtCovar = this->sqrtCovarLastMeasurement;
+
+        this->reConfigure();
+    }
+
     /*! Rewind to the last-measurement state and propagate by dt. If dt = 0
      *  the sigma points are populated around the last-measurement state for the
      *  next measurementUpdate but the timeUpdate math isn't done

--- a/algorithms/filteringCore/srukf.hpp
+++ b/algorithms/filteringCore/srukf.hpp
@@ -5,7 +5,6 @@
 #define FILTERING_CORE_SRUKF_HPP
 
 #include <utilities/fsw/safeMath.h>
-#include <utilities/fsw/validPSDCheck.h>
 #include <filteringCore/concepts.hpp>
 #include <filteringCore/dynamicsModel.hpp>
 
@@ -136,17 +135,11 @@ class SRuKF {
 
     // ---- Validity checks ----------------------------------------------------
 
-    /*! @return true iff alpha is in [0, 1] */
-    bool alphaIsValid() const { return this->alpha >= 0.0 && this->alpha <= 1.0; }
+    /*! @return true iff alpha is in (0, 1) */
+    static bool alphaIsValid(double alpha) { return alpha > 0.0 && alpha < 1.0; }
 
     /*! @return true iff beta is in [0, 2] */
-    bool betaIsValid() const { return this->beta >= 0.0 && this->beta <= 2.0; }
-
-    /*! @return true iff the configured initial covariance is symmetric PSD */
-    bool initialCovarianceIsValid() const { return isPositiveSemiDefinite(this->covarianceInitial); }
-
-    /*! @return true iff the configured process noise is symmetric PSD */
-    bool processNoiseIsValid() const { return isPositiveSemiDefinite(this->processNoise); }
+    static bool betaIsValid(double beta) { return beta >= 0.0 && beta <= 2.0; }
 
     /*! Derive the sigma-point spread (lambda, eta), the sigma weights, and the
      *  process-noise Cholesky from alpha, beta, and the process noise. The estimate

--- a/algorithms/filteringCore/srukf.hpp
+++ b/algorithms/filteringCore/srukf.hpp
@@ -173,7 +173,7 @@ class SRuKF {
      *  (reConfigure() plus a state/covariance reset). */
     void reset() {
         constexpr int N = State::size;
-        
+
         this->state = this->stateInitial;
         this->covariance = this->covarianceInitial;
         this->sqrtCovar = choleskyDecomposition<N>(this->covarianceInitial);
@@ -263,80 +263,92 @@ class SRuKF {
      *  @return pre- and post-fit residuals
      *  @param measurement [-] satisfies Measurement<M, State> */
     template <Measurement<State> M>
-    UpdateResult<M> measurementUpdate(M const& measurement) {
+    std::optional<UpdateResult<M>> measurementUpdate(M const& measurement) {
         constexpr int N = State::size;
         constexpr int numSigma = 2 * N + 1;
         constexpr int MSize = M::size;
 
+        std::optional<UpdateResult<M>> residuals = {};
+
         //! > Read the observation
         auto const observation = measurement.observation();
 
-        //! > Using the measurement model, get the Y matrix (expected measurement) of each sigma point (eq 22)
-        Eigen::Matrix<double, MSize, numSigma> yMeasPre;
-        for (int j = 0; j < numSigma; ++j) {
-            yMeasPre.col(j) = measurement.model(this->sigmaPoints[j]);
+        //! > Skip the update on non-finite inputs so a bad measurement cannot propagate NaNs/Infs into the state.
+        bool const inputsFinite = observation.allFinite() and measurement.noise().allFinite() and
+                                  this->state.allFinite() and this->sqrtCovar.allFinite();
+
+        if (inputsFinite) {
+            //! > Using the measurement model, get the Y matrix (expected measurement) of each sigma point (eq 22)
+            Eigen::Matrix<double, MSize, numSigma> yMeasPre;
+            for (int j = 0; j < numSigma; ++j) {
+                yMeasPre.col(j) = measurement.model(this->sigmaPoints[j]);
+            }
+            //! > Like eq 19, the measurement expected is the weighted sum of the Sigma points transformed (eq 23)
+            Eigen::Vector<double, MSize> yBarPre = Eigen::Vector<double, MSize>::Zero();
+            for (int i = 0; i < numSigma; ++i) {
+                yBarPre += this->wM(i) * yMeasPre.col(i);
+            }
+
+            //! > Before moving to the update, computed the prefits
+            Eigen::Vector<double, MSize> const preFit = measurement.subtract(observation, yBarPre);
+
+            //! > Sqrt the measurement noise, this could theoretically be different at every time step
+            Eigen::Matrix<double, MSize, MSize> const cholMeasNoise = choleskyDecomposition<MSize>(measurement.noise());
+
+            //! > Symmetrically to the time update, populate the A matrix for a qr decomposition (eq 24)
+            Eigen::Matrix<double, MSize, 2 * N + MSize> A;
+            for (int i = 1; i < numSigma; ++i) {
+                A.col(i - 1) = sqrt(this->wC(1)) * (yMeasPre.col(i) - yBarPre);
+            }
+            A.template block<MSize, MSize>(0, numSigma - 1) = cholMeasNoise;
+
+            //! > Qr decomposition of A (eq 24)
+            Eigen::Matrix<double, MSize, MSize> sy = qrDecompositionJustR<MSize, 2 * N + MSize>(A);
+
+            //! > Cholesky-downDate the covariance and the measurement error
+            Eigen::Vector<double, MSize> const yError0 = yMeasPre.col(0) - yBarPre;
+            sy = choleskyUpDownDate<MSize>(sy, yError0, this->wC(0));
+
+            //! > Covariance of prior prediction computation eq 26
+            Eigen::Matrix<double, N, MSize> pXY = Eigen::Matrix<double, N, MSize>::Zero();
+            for (int i = 0; i < numSigma; ++i) {
+                Eigen::Vector<double, N> const xError = this->sigmaPoints[i].raw() - this->xBar.raw();
+                Eigen::Vector<double, MSize> const yError = yMeasPre.col(i) - yBarPre;
+                pXY += this->wC(i) * xError * yError.transpose();
+            }
+
+            //! > Calculate Kalman gain eq 27
+            Eigen::Matrix<double, MSize, N> const pXYT = pXY.transpose();
+            Eigen::Matrix<double, MSize, N> const stKt = forwardSubstitution<MSize, N>(sy, pXYT);
+            Eigen::Matrix<double, MSize, MSize> const syT = sy.transpose();
+            Eigen::Matrix<double, N, MSize> const kMat = backSubstitution<MSize, N>(syT, stKt).transpose();
+
+            //! > Calculate surprise factor and update state
+            Eigen::Vector<double, MSize> const innovation = measurement.subtract(observation, yBarPre);
+            this->state = State(this->xBar.raw() + kMat * innovation);
+
+            //! > Cholesky downDate to get the update covariance (eq 29)
+            Eigen::Matrix<double, N, MSize> const Umat = kMat * sy;
+            for (int i = 0; i < MSize; ++i) {
+                Eigen::Vector<double, N> const col = Umat.col(i);
+                this->sqrtCovar = choleskyUpDownDate<N>(this->sqrtCovar, col, -1.0);
+            }
+            this->covariance = this->sqrtCovar * this->sqrtCovar.transpose();
+
+            if (this->state.allFinite() and this->sqrtCovar.allFinite()) {
+                //! > Move the state and covariance of last measuremnts up
+                this->stateLastMeasurement = this->state;
+                this->covarianceLastMeasurement = this->covariance;
+                this->sqrtCovarLastMeasurement = this->sqrtCovar;
+
+                //! > Now that update is done compute post fit residuals
+                Eigen::Vector<double, MSize> const postFit =
+                    measurement.subtract(observation, measurement.model(this->state));
+
+                residuals = {.preFit = preFit, .postFit = postFit};
+            }
         }
-        //! > Like eq 19, the measurement expected is the weighted sum of the Sigma points transformed (eq 23)
-        Eigen::Vector<double, MSize> yBarPre = Eigen::Vector<double, MSize>::Zero();
-        for (int i = 0; i < numSigma; ++i) {
-            yBarPre += this->wM(i) * yMeasPre.col(i);
-        }
-
-        //! > Before moving to the update, computed the prefits
-        Eigen::Vector<double, MSize> const preFit = measurement.subtract(observation, yBarPre);
-
-        //! > Sqrt the measurement noise, this could theoretically be different at every time step
-        Eigen::Matrix<double, MSize, MSize> const cholMeasNoise = choleskyDecomposition<MSize>(measurement.noise());
-
-        //! > Symmetrically to the time update, populate the A matrix for a qr decomposition (eq 24)
-        Eigen::Matrix<double, MSize, 2 * N + MSize> A;
-        for (int i = 1; i < numSigma; ++i) {
-            A.col(i - 1) = sqrt(this->wC(1)) * (yMeasPre.col(i) - yBarPre);
-        }
-        A.template block<MSize, MSize>(0, numSigma - 1) = cholMeasNoise;
-
-        //! > Qr decomposition of A (eq 24)
-        Eigen::Matrix<double, MSize, MSize> sy = qrDecompositionJustR<MSize, 2 * N + MSize>(A);
-
-        //! > Cholesky-downDate the covariance and the measurement error
-        Eigen::Vector<double, MSize> const yError0 = yMeasPre.col(0) - yBarPre;
-        sy = choleskyUpDownDate<MSize>(sy, yError0, this->wC(0));
-
-        //! > Covariance of prior prediction computation eq 26
-        Eigen::Matrix<double, N, MSize> pXY = Eigen::Matrix<double, N, MSize>::Zero();
-        for (int i = 0; i < numSigma; ++i) {
-            Eigen::Vector<double, N> const xError = this->sigmaPoints[i].raw() - this->xBar.raw();
-            Eigen::Vector<double, MSize> const yError = yMeasPre.col(i) - yBarPre;
-            pXY += this->wC(i) * xError * yError.transpose();
-        }
-
-        //! > Calculate Kalman gain eq 27
-        Eigen::Matrix<double, MSize, N> const pXYT = pXY.transpose();
-        Eigen::Matrix<double, MSize, N> const stKt = forwardSubstitution<MSize, N>(sy, pXYT);
-        Eigen::Matrix<double, MSize, MSize> const syT = sy.transpose();
-        Eigen::Matrix<double, N, MSize> const kMat = backSubstitution<MSize, N>(syT, stKt).transpose();
-
-        //! > Calculate surprise factor and update state
-        Eigen::Vector<double, MSize> const innovation = measurement.subtract(observation, yBarPre);
-        this->state = State(this->xBar.raw() + kMat * innovation);
-
-        //! > Cholesky downDate to get the update covariance (eq 29)
-        Eigen::Matrix<double, N, MSize> const Umat = kMat * sy;
-        for (int i = 0; i < MSize; ++i) {
-            Eigen::Vector<double, N> const col = Umat.col(i);
-            this->sqrtCovar = choleskyUpDownDate<N>(this->sqrtCovar, col, -1.0);
-        }
-        this->covariance = this->sqrtCovar * this->sqrtCovar.transpose();
-
-        //! > Move the state and covariance of last measuremnts up
-        this->stateLastMeasurement = this->state;
-        this->covarianceLastMeasurement = this->covariance;
-        this->sqrtCovarLastMeasurement = this->sqrtCovar;
-
-        //! > Now that update is done compute post fit residuals
-        Eigen::Vector<double, MSize> const postFit = measurement.subtract(observation, measurement.model(this->state));
-
-        return {.preFit = preFit, .postFit = postFit};
+        return residuals;
     }
 
     /*! @return current filter state */

--- a/algorithms/filteringCore/state.hpp
+++ b/algorithms/filteringCore/state.hpp
@@ -92,6 +92,9 @@ class StateVector {
     /*! @return const reference to the underlying flat Eigen vector */
     Storage const& raw() const { return this->data; }
 
+    /*! @return true iff every element of the underlying vector is finite */
+    bool allFinite() const { return this->data.allFinite(); }
+
     StateVector add(StateVector const& other) const { return StateVector(this->data + other.data); }
     StateVector scale(double scalar) const { return StateVector(this->data * scalar); }
 


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2306
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
Made updates to the filtering core algorithms, tests, and documentation in accordance to a first wave of V&V.
The main change is the addition of applySequentialRobust which allows the filter to clear itself in the presence of a bad update.

## Verification
Tests added and improved

## Documentation
Improved

## Future work
More V&V
