### PR TITLE
Narrow SunlineEphem C shim to plain vector in/out

### DIFF
--- a/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.cpp
+++ b/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.cpp
@@ -11,25 +11,24 @@ void SunlineEphemAlgorithm_destroy(SunlineEphemAlgorithmHandle* self) {
     delete reinterpret_cast<::SunlineEphemAlgorithm*>(self);
 }
 
-NavAttMsgF32Payload SunlineEphemAlgorithm_update(const SunlineEphemAlgorithmHandle* self,
-                                                 const EphemerisMsgF32Payload* sunPos,
-                                                 const NavTransMsgF32Payload* scPos,
-                                                 const NavAttMsgF32Payload* scAtt) {
+void SunlineEphemAlgorithm_update(const SunlineEphemAlgorithmHandle* self,
+                                  const Vector3d_c* sunPos,
+                                  const Vector3d_c* scPos,
+                                  const Vector3f_c* sigmaBN,
+                                  Vector3f_c* result) {
     Eigen::Vector3d r_SN_N;
-    r_SN_N << sunPos->r_BdyZero_N[0], sunPos->r_BdyZero_N[1], sunPos->r_BdyZero_N[2];
+    r_SN_N << sunPos->data[0], sunPos->data[1], sunPos->data[2];
 
     Eigen::Vector3d r_BN_N;
-    r_BN_N << scPos->r_BN_N[0], scPos->r_BN_N[1], scPos->r_BN_N[2];
+    r_BN_N << scPos->data[0], scPos->data[1], scPos->data[2];
 
     Eigen::Vector3f sigma_BN;
-    sigma_BN << scAtt->sigma_BN[0], scAtt->sigma_BN[1], scAtt->sigma_BN[2];
+    sigma_BN << sigmaBN->data[0], sigmaBN->data[1], sigmaBN->data[2];
 
     const Eigen::Vector3f rHat_SB_B =
         reinterpret_cast<const ::SunlineEphemAlgorithm*>(self)->update(r_SN_N, r_BN_N, sigma_BN);
 
-    NavAttMsgF32Payload out{};
-    out.vehSunPntBdy[0] = rHat_SB_B[0];
-    out.vehSunPntBdy[1] = rHat_SB_B[1];
-    out.vehSunPntBdy[2] = rHat_SB_B[2];
-    return out;
+    result->data[0] = rHat_SB_B[0];
+    result->data[1] = rHat_SB_B[1];
+    result->data[2] = rHat_SB_B[2];
 }

--- a/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.h
+++ b/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.h
@@ -1,9 +1,7 @@
 #ifndef F32XMERA_SUNLINEEPHEMALGORITHM_C_H
 #define F32XMERA_SUNLINEEPHEMALGORITHM_C_H
 
-#include "msgPayloadDef/EphemerisMsgF32Payload.h"
-#include "msgPayloadDef/NavAttMsgF32Payload.h"
-#include "msgPayloadDef/NavTransMsgF32Payload.h"
+#include "utilities/fsw/plainCAlgorithmDataTypes.h"
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -14,6 +12,13 @@ extern "C" {
  * @brief Opaque handle to the C++ SunlineEphemAlgorithm instance.
  */
 typedef struct SunlineEphemAlgorithmHandle SunlineEphemAlgorithmHandle;
+
+/**
+ * @brief POD representation of a 3-vector (Eigen::Vector3d).
+ */
+typedef struct {
+    double data[3];
+} Vector3d_c;
 
 /**
  * @brief Construct a new SunlineEphemAlgorithm instance.
@@ -29,16 +34,17 @@ void SunlineEphemAlgorithm_destroy(SunlineEphemAlgorithmHandle* self);
 
 /**
  * @brief Compute ephemeris-based sunline heading in body frame.
- * @param self   Pointer to the instance.
- * @param sunPos Pointer to sun ephemeris message payload.
- * @param scPos  Pointer to spacecraft position message payload.
- * @param scAtt  Pointer to spacecraft attitude message payload.
- * @return NavAttMsgF32Payload  Navigation message containing sunline direction in body frame.
+ * @param self    Pointer to the instance.
+ * @param sunPos  Sun inertial position r_SN_N [m].
+ * @param scPos   Spacecraft inertial position r_BN_N [m].
+ * @param sigmaBN Spacecraft attitude MRP (body relative to inertial).
+ * @param result  Out: sunline direction (unit vector) in body frame.
  */
-NavAttMsgF32Payload SunlineEphemAlgorithm_update(const SunlineEphemAlgorithmHandle* self,
-                                                 const EphemerisMsgF32Payload* sunPos,
-                                                 const NavTransMsgF32Payload* scPos,
-                                                 const NavAttMsgF32Payload* scAtt);
+void SunlineEphemAlgorithm_update(const SunlineEphemAlgorithmHandle* self,
+                                  const Vector3d_c* sunPos,
+                                  const Vector3d_c* scPos,
+                                  const Vector3f_c* sigmaBN,
+                                  Vector3f_c* result);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR narrows the sunlineEphem C shim so that it only takes plain data types rather than Xmera message types. The Xmera message types were a hang over from the early days when we were working out the adapter/shim pattern.

## Verification
This PR needs to build and pass CI here and on sibling repositories (where accompanying PRs are opened).

## Documentation
NA

## Future work
None
