### PR TITLE
Feature/2267 add accel to mimu majority vote

### DIFF
--- a/.github/clang-tidy-exclude.txt
+++ b/.github/clang-tidy-exclude.txt
@@ -51,6 +51,8 @@ algorithms/inertial3D/inertial3DAlgorithm_c.h
 algorithms/inertial3D/inertial3DAlgorithm_c.cpp
 algorithms/mimuMajorityVote/mimuMajorityVote.h
 algorithms/mimuMajorityVote/mimuMajorityVote.cpp
+algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.h
+algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
 algorithms/mrpFeedback/mrpFeedback.h
 algorithms/mrpFeedback/mrpFeedback.cpp
 algorithms/mrpPD/mrpPD.h

--- a/.github/workflows/downstream-build.yml
+++ b/.github/workflows/downstream-build.yml
@@ -27,7 +27,7 @@ jobs:
       # Uncomment/set to pin adamant-xmera-components for THIS branch's CI
       # runs. The workflow_dispatch input still wins over a PIN; revert (or
       # comment back) before merging.
-      # ADAMANT_XMERA_COMPONENTS_REF_PIN: 'your-branch-here'
+      ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/EMAGNCFSW-1117-add-acceleration-to-mimu-majority-vote-component'
     container:
       image: ghcr.io/lasp/adamant:0.2
       options: --user root

--- a/.github/workflows/downstream-build.yml
+++ b/.github/workflows/downstream-build.yml
@@ -3,6 +3,12 @@ name: "Downstream Build (adamant-xmera-components)"
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      adamant_xmera_components_ref:
+        description: "adamant-xmera-components ref (default: repo default branch)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -15,7 +21,13 @@ jobs:
   downstream-test:
     name: adamant-xmera-components test_all
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    env:
+      # === Per-CI-run pin ===
+      # Uncomment/set to pin adamant-xmera-components for THIS branch's CI
+      # runs. The workflow_dispatch input still wins over a PIN; revert (or
+      # comment back) before merging.
+      # ADAMANT_XMERA_COMPONENTS_REF_PIN: 'your-branch-here'
     container:
       image: ghcr.io/lasp/adamant:0.2
       options: --user root
@@ -25,6 +37,7 @@ jobs:
         with:
           set-safe-directory: true
           repository: lasp/adamant-xmera-components
+          ref: ${{ inputs.adamant_xmera_components_ref || env.ADAMANT_XMERA_COMPONENTS_REF_PIN || '' }}
           path: adamant-xmera-components
           persist-credentials: false
 
@@ -32,7 +45,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           set-safe-directory: true
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           path: fp32-fsw-xmera
           persist-credentials: false
 

--- a/.github/workflows/trigger_jenkins_renode.yml
+++ b/.github/workflows/trigger_jenkins_renode.yml
@@ -60,10 +60,10 @@ jobs:
       # branch's CI runs (e.g. one-off DROP / integration testing without
       # touching Jenkins UI). workflow_dispatch inputs still win over a
       # PIN; revert (or comment back) before merging.
-      # ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/your-branch-here'
+      ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/EMAGNCFSW-1117-add-acceleration-to-mimu-majority-vote-component'
       # ADAMANT_REF_PIN: 'feature/your-branch-here'
       # ADAMANT_EXAMPLE_REF_PIN: 'feature/your-branch-here'
-      # PROJECT_REF_PIN: 'feature/your-branch-here'
+      PROJECT_REF_PIN: 'feature/EMAGNCFSW-1117-mimu-accel-vote-integration'
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
       - name: Resolve commit SHA

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -87,11 +87,11 @@
   ],
 
   "buildPresets": [
-    { "name": "linux-gcc-debug",     "configurePreset": "linux-gcc-debug",     "verbose": true },
-    { "name": "linux-gcc-release",   "configurePreset": "linux-gcc-release",   "verbose": true },
-    { "name": "macos-gcc-debug",     "configurePreset": "macos-gcc-debug",     "verbose": true },
-    { "name": "macos-gcc-release",   "configurePreset": "macos-gcc-release",   "verbose": true },
-    { "name": "riscv32-gcc-debug",   "configurePreset": "riscv32-gcc-debug",   "verbose": true },
-    { "name": "riscv32-gcc-release", "configurePreset": "riscv32-gcc-release", "verbose": true }
+    { "name": "linux-gcc-debug",     "configurePreset": "linux-gcc-debug",     "verbose": true , "jobs": 4},
+    { "name": "linux-gcc-release",   "configurePreset": "linux-gcc-release",   "verbose": true , "jobs": 4},
+    { "name": "macos-gcc-debug",     "configurePreset": "macos-gcc-debug",     "verbose": true , "jobs": 4},
+    { "name": "macos-gcc-release",   "configurePreset": "macos-gcc-release",   "verbose": true , "jobs": 4},
+    { "name": "riscv32-gcc-debug",   "configurePreset": "riscv32-gcc-debug",   "verbose": true , "jobs": 4},
+    { "name": "riscv32-gcc-release", "configurePreset": "riscv32-gcc-release", "verbose": true , "jobs": 4}
   ]
 }

--- a/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
+++ b/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
@@ -8,37 +8,46 @@
 #include <Eigen/Core>
 #include <vector>
 
-// Reference computation for update — must mirror the production logic exactly
-MimuMajorityVoteOutput referenceUpdate(float omegaThreshold,
-                                       uint32_t persistenceLimit,
-                                       const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B,
-                                       std::array<uint32_t, kMimuCount>& persistenceCount) {
-    // Stage 1: Compute average and find differences
-    Eigen::Vector3f omegaAverage = Eigen::Vector3f::Zero();
-    for (size_t i = 0U; i < kMimuCount; ++i) {
-        omegaAverage += imuOmegas_BN_B.at(i);
-    }
-    omegaAverage /= static_cast<float>(kMimuCount);
+/*! @brief Reference result of one majority vote over a single quantity (mirrors the production
+ majorityVote helper). */
+struct ReferenceVote {
+    Eigen::Vector3f average{};
+    bool faultDetected{};
+    std::array<float, kMimuCount> imuDifferenceMag{};
+    std::array<bool, kMimuCount> imuValid{};
+};
 
-    MimuMajorityVoteOutput out{};
+// Reference computation for a single quantity's vote — must mirror the production logic exactly.
+inline ReferenceVote referenceUpdate(float threshold,
+                                     uint32_t persistenceLimit,
+                                     const std::array<Eigen::Vector3f, kMimuCount>& measurements,
+                                     std::array<uint32_t, kMimuCount>& persistenceCount) {
+    // Stage 1: Compute average and find differences
+    Eigen::Vector3f average = Eigen::Vector3f::Zero();
+    for (size_t i = 0U; i < kMimuCount; ++i) {
+        average += measurements.at(i);
+    }
+    average /= static_cast<float>(kMimuCount);
+
+    ReferenceVote out{};
     size_t maxDiffIndex = 0U;
     for (size_t i = 0U; i < kMimuCount; ++i) {
-        out.omegaDifferencesMag.at(i) = (imuOmegas_BN_B.at(i) - omegaAverage).norm();
-        if (out.omegaDifferencesMag.at(i) > out.omegaDifferencesMag.at(maxDiffIndex)) {
+        out.imuDifferenceMag.at(i) = (measurements.at(i) - average).norm();
+        if (out.imuDifferenceMag.at(i) > out.imuDifferenceMag.at(maxDiffIndex)) {
             maxDiffIndex = i;
         }
-        out.validImus.at(i) = true;
+        out.imuValid.at(i) = true;
     }
 
     // Update persistence counter for the worst outlier
     bool faultDetected = false;
-    if (out.omegaDifferencesMag.at(maxDiffIndex) >= omegaThreshold) {
+    if (out.imuDifferenceMag.at(maxDiffIndex) >= threshold) {
         ++persistenceCount.at(maxDiffIndex);
 
         // Determine if the outlier has persisted long enough to be faulted
         if (persistenceCount.at(maxDiffIndex) >= persistenceLimit) {
             faultDetected = true;
-            out.validImus.at(maxDiffIndex) = false;
+            out.imuValid.at(maxDiffIndex) = false;
         }
     } else {
         persistenceCount.at(maxDiffIndex) = 0U;
@@ -52,56 +61,69 @@ MimuMajorityVoteOutput referenceUpdate(float omegaThreshold,
     }
 
     if (!faultDetected) {
-        out.avgOmega_BN_B = omegaAverage;
+        out.average = average;
         return out;
     }
 
     // Exclude outlier and average the remaining IMUs
     out.faultDetected = true;
-    out.avgOmega_BN_B = (omegaAverage * static_cast<float>(kMimuCount) - imuOmegas_BN_B.at(maxDiffIndex)) /
-                        static_cast<float>(kMimuCount - 1U);
+    out.average = (average * static_cast<float>(kMimuCount) - measurements.at(maxDiffIndex)) /
+                  static_cast<float>(kMimuCount - 1U);
     return out;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 inline void regressionTestMimuMajorityVote(float omegaThreshold,
-                                           uint32_t persistenceLimit,
+                                           uint32_t gyroFaultPersistenceLimit,
+                                           float accelThreshold,
+                                           uint32_t accelFaultPersistenceLimit,
                                            uint32_t algCallCount,
                                            const Eigen::Vector3f& angVel1,
                                            const Eigen::Vector3f& angVel2,
-                                           const Eigen::Vector3f& angVel3) {
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, persistenceLimit)};
+                                           const Eigen::Vector3f& angVel3,
+                                           const Eigen::Vector3f& accel1,
+                                           const Eigen::Vector3f& accel2,
+                                           const Eigen::Vector3f& accel3) {
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(
+        omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit)};
 
-    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
-    imuOmegas_BN_B.at(0) = angVel1;
-    imuOmegas_BN_B.at(1) = angVel2;
-    imuOmegas_BN_B.at(2) = angVel3;
+    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{angVel1, angVel2, angVel3};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{accel1, accel2, accel3};
 
-    std::array<uint32_t, kMimuCount> persistenceCount{};
+    std::array<uint32_t, kMimuCount> gyroCount{};
+    std::array<uint32_t, kMimuCount> accelCount{};
     MimuMajorityVoteOutput out{};
-    MimuMajorityVoteOutput ref{};
+    ReferenceVote gyroRef{};
+    ReferenceVote accelRef{};
 
     for (uint32_t call = 0U; call < algCallCount; ++call) {
-        EXPECT_NO_THROW(out = alg.update(imuOmegas_BN_B));
-        EXPECT_NO_THROW(ref = referenceUpdate(omegaThreshold, persistenceLimit, imuOmegas_BN_B, persistenceCount));
+        EXPECT_NO_THROW(out = alg.update(imuOmegas_BN_B, imuAccels_B));
+        EXPECT_NO_THROW(gyroRef =
+                            referenceUpdate(omegaThreshold, gyroFaultPersistenceLimit, imuOmegas_BN_B, gyroCount));
+        EXPECT_NO_THROW(accelRef =
+                            referenceUpdate(accelThreshold, accelFaultPersistenceLimit, imuAccels_B, accelCount));
     }
 
-    // Compare averaged angular velocity
+    // Gyro vote
+    EXPECT_EQ(out.gyro.faultDetected, gyroRef.faultDetected);
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], ref.avgOmega_BN_B[i], 1e-6);
-        EXPECT_TRUE(std::isfinite(out.avgOmega_BN_B[i]));
+        EXPECT_NEAR(out.gyro.average[i], gyroRef.average[i], 1e-6);
+        EXPECT_TRUE(std::isfinite(out.gyro.average[i]));
+    }
+    for (size_t i = 0U; i < kMimuCount; ++i) {
+        EXPECT_EQ(out.gyro.imuValid.at(i), gyroRef.imuValid.at(i));
+        EXPECT_NEAR(out.gyro.imuDifferenceMag.at(i), gyroRef.imuDifferenceMag.at(i), 1e-6);
     }
 
-    // Compare fault detection
-    EXPECT_EQ(out.faultDetected, ref.faultDetected);
-
-    // Compare validImus
-    for (size_t i = 0U; i < kMimuCount; ++i) {
-        EXPECT_EQ(out.validImus.at(i), ref.validImus.at(i));
+    // Accel vote (independent)
+    EXPECT_EQ(out.accel.faultDetected, accelRef.faultDetected);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.accel.average[i], accelRef.average[i], 1e-6);
+        EXPECT_TRUE(std::isfinite(out.accel.average[i]));
     }
-
-    // Compare omegaDifferencesMag
     for (size_t i = 0U; i < kMimuCount; ++i) {
-        EXPECT_NEAR(out.omegaDifferencesMag.at(i), ref.omegaDifferencesMag.at(i), 1e-6);
+        EXPECT_EQ(out.accel.imuValid.at(i), accelRef.imuValid.at(i));
+        EXPECT_NEAR(out.accel.imuDifferenceMag.at(i), accelRef.imuDifferenceMag.at(i), 1e-6);
     }
 }
 

--- a/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
+++ b/algorithms/mimuMajorityVote/_tests/mimuMajorityVoteTestHelpers.hpp
@@ -69,9 +69,7 @@ inline void regressionTestMimuMajorityVote(float omegaThreshold,
                                            const Eigen::Vector3f& angVel1,
                                            const Eigen::Vector3f& angVel2,
                                            const Eigen::Vector3f& angVel3) {
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(omegaThreshold);
-    alg.setFaultPersistenceLimit(persistenceLimit);
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, persistenceLimit)};
 
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
     imuOmegas_BN_B.at(0) = angVel1;

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
@@ -21,9 +21,8 @@ TEST(MimuMajorityVoteTest, RegressionTestOffNominal) {
 
 TEST(MimuMajorityVoteTest, PropertyTestNominal) {
     // When all IMUs agree within threshold, output should be simple average with no fault
-    MimuMajorityVoteAlgorithm alg{};
-    float threshold = 1.0F;
-    alg.setOmegaThreshold(threshold);
+    const float threshold = 1.0F;
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(threshold, 1U)};
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
 
@@ -47,9 +46,8 @@ TEST(MimuMajorityVoteTest, PropertyTestNominal) {
 
 TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
     // When one IMU is far off, it should be detected as faulted and excluded from average
-    MimuMajorityVoteAlgorithm alg{};
-    float threshold = 0.05F;
-    alg.setOmegaThreshold(threshold);
+    const float threshold = 0.05F;
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(threshold, 1U)};
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
     Eigen::Vector3f outlierRate = baseRate + Eigen::Vector3f(2.0F, 2.0F, 2.0F);
@@ -74,9 +72,7 @@ TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
 }
 
 TEST(MimuMajorityVoteTest, PersistenceFaultAndRecovery) {
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(0.05F);
-    alg.setFaultPersistenceLimit(3U);
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 3U)};
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
     Eigen::Vector3f outlierRate = baseRate + Eigen::Vector3f(2.0F, 2.0F, 2.0F);
@@ -152,10 +148,8 @@ TEST(MimuMajorityVoteTest, PersistenceFaultAndRecovery) {
     }
 }
 
-TEST(MimuMajorityVoteTest, ResetClearsPersistence) {
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(0.05F);
-    alg.setFaultPersistenceLimit(3U);
+TEST(MimuMajorityVoteTest, ReInitializeClearsPersistence) {
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 3U)};
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
     Eigen::Vector3f outlierRate = baseRate + Eigen::Vector3f(2.0F, 2.0F, 2.0F);
@@ -180,8 +174,8 @@ TEST(MimuMajorityVoteTest, ResetClearsPersistence) {
         }
     }
 
-    // Reset clears persistence counters
-    alg.reset();
+    // reInitialize clears persistence counters
+    alg.reInitialize();
 
     // Same outlier inputs — counter starts from zero again, no fault
     for (uint32_t call = 0U; call < 2U; ++call) {
@@ -207,16 +201,14 @@ TEST(MimuMajorityVoteTest, ResetClearsPersistence) {
 }
 
 TEST(MimuMajorityVoteTest, SetupTest) {
-    MimuMajorityVoteAlgorithm alg{};
+    // Config validation rejects a zero/negative omegaThreshold and a zero faultPersistenceLimit.
+    EXPECT_THROW((void)MimuMajorityVoteConfig::create(0.0F, 1U), fsw::invalid_argument);
+    EXPECT_THROW((void)MimuMajorityVoteConfig::create(-0.1F, 1U), fsw::invalid_argument);
+    EXPECT_THROW((void)MimuMajorityVoteConfig::create(0.5F, 0U), fsw::invalid_argument);
 
-    // --- Test expected exceptions for omegaThreshold ---
-
-    // Zero or negative omegaThreshold
-    EXPECT_THROW(alg.setOmegaThreshold(0.0F), fsw::invalid_argument);
-    EXPECT_THROW(alg.setOmegaThreshold(-0.1F), fsw::invalid_argument);
-
-    // Valid threshold
-    float threshold = 0.5F;
-    EXPECT_NO_THROW(alg.setOmegaThreshold(threshold));
-    EXPECT_NEAR(alg.getOmegaThreshold(), threshold, 1e-6);
+    // A valid config exposes exactly the supplied parameters.
+    const float threshold = 0.5F;
+    const MimuMajorityVoteConfig cfg = MimuMajorityVoteConfig::create(threshold, 2U);
+    EXPECT_NEAR(cfg.getOmegaThreshold(), threshold, 1e-6);
+    EXPECT_EQ(cfg.getFaultPersistenceLimit(), 2U);
 }

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
@@ -86,6 +86,77 @@ TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
     EXPECT_TRUE(out.gyro.imuValid.at(2));
 }
 
+TEST(MimuMajorityVoteTest, IndependentVotesAccelFaultOnly) {
+    // The gyro and accel votes are independent: IMU 1 is a clean gyro but an accelerometer outlier,
+    // so it must be reported gyro-valid yet accel-faulted (and excluded only from the accel average).
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 1U, 0.05F, 1U)};
+
+    const Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
+    const Eigen::Vector3f baseAccel(0.0F, 0.0F, 9.8F);
+
+    // All three IMUs agree on angular velocity (no gyro fault).
+    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{baseRate, baseRate, baseRate};
+
+    // IMU 1 is a large acceleration outlier; IMUs 0 and 2 agree.
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{
+        baseAccel, baseAccel + Eigen::Vector3f(2.0F, 2.0F, 2.0F), baseAccel};
+
+    auto out = alg.update(imuOmegas_BN_B, imuAccels_B);
+
+    // Gyro vote: no fault, all IMUs valid, full average.
+    EXPECT_FALSE(out.gyro.faultDetected);
+    for (size_t i = 0U; i < kMimuCount; ++i) {
+        EXPECT_TRUE(out.gyro.imuValid.at(i));
+    }
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.gyro.average[i], baseRate[i], 1e-6);
+    }
+
+    // Accel vote: IMU 1 faulted/excluded, IMUs 0 and 2 valid; accel average excludes IMU 1.
+    EXPECT_TRUE(out.accel.faultDetected);
+    EXPECT_TRUE(out.accel.imuValid.at(0));
+    EXPECT_FALSE(out.accel.imuValid.at(1));
+    EXPECT_TRUE(out.accel.imuValid.at(2));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.accel.average[i], baseAccel[i], 1e-6);
+    }
+}
+
+TEST(MimuMajorityVoteTest, IndependentVotesBothFault) {
+    // Both votes fault in a single update on different IMUs: IMU 1 is a gyro outlier and IMU 2 is an
+    // accel outlier. Each vote excludes only its own outlier, and the gyro-faulted IMU stays
+    // accel-valid while the accel-faulted IMU stays gyro-valid.
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 1U, 0.05F, 1U)};
+
+    const Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
+    const Eigen::Vector3f baseAccel(0.0F, 0.0F, 9.8F);
+    const Eigen::Vector3f offset(2.0F, 2.0F, 2.0F);
+
+    // IMU 1 is a gyro outlier; IMU 2 is an accel outlier (different IMUs).
+    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{baseRate, baseRate + offset, baseRate};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{baseAccel, baseAccel, baseAccel + offset};
+
+    auto out = alg.update(imuOmegas_BN_B, imuAccels_B);
+
+    // Gyro vote: IMU 1 faulted/excluded; IMUs 0 and 2 valid (accel-faulted IMU 2 stays gyro-valid).
+    EXPECT_TRUE(out.gyro.faultDetected);
+    EXPECT_TRUE(out.gyro.imuValid.at(0));
+    EXPECT_FALSE(out.gyro.imuValid.at(1));
+    EXPECT_TRUE(out.gyro.imuValid.at(2));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.gyro.average[i], baseRate[i], 1e-6);
+    }
+
+    // Accel vote: IMU 2 faulted/excluded; IMUs 0 and 1 valid (gyro-faulted IMU 1 stays accel-valid).
+    EXPECT_TRUE(out.accel.faultDetected);
+    EXPECT_TRUE(out.accel.imuValid.at(0));
+    EXPECT_TRUE(out.accel.imuValid.at(1));
+    EXPECT_FALSE(out.accel.imuValid.at(2));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_NEAR(out.accel.average[i], baseAccel[i], 1e-6);
+    }
+}
+
 TEST(MimuMajorityVoteTest, PersistenceFaultAndRecovery) {
     MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 3U, 1.0F, 1U)};
 

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
@@ -2,27 +2,40 @@
 #include <gtest/gtest.h>
 
 TEST(MimuMajorityVoteTest, RegressionTest) {
-    regressionTestMimuMajorityVote(1.0F,
-                                   1U,
-                                   1U,
-                                   Eigen::Vector3f{-0.1F, 0.25F, 0.3F},
-                                   Eigen::Vector3f{-0.09F, 0.24F, 0.305F},
-                                   Eigen::Vector3f{-0.105F, 0.26F, 0.295F});
+    // Nominal: gyro and accel inputs both agree within their thresholds — no fault on either vote.
+    regressionTestMimuMajorityVote(/* omegaThreshold */ 1.0F,
+                                   /* gyroFaultPersistenceLimit */ 1U,
+                                   /* accelThreshold */ 1.0F,
+                                   /* accelFaultPersistenceLimit */ 1U,
+                                   /* algCallCount */ 1U,
+                                   /* angVel1 */ Eigen::Vector3f{-0.1F, 0.25F, 0.3F},
+                                   /* angVel2 */ Eigen::Vector3f{-0.09F, 0.24F, 0.305F},
+                                   /* angVel3 */ Eigen::Vector3f{-0.105F, 0.26F, 0.295F},
+                                   /* accel1 */ Eigen::Vector3f{0.0F, 0.0F, 9.8F},
+                                   /* accel2 */ Eigen::Vector3f{0.01F, -0.02F, 9.81F},
+                                   /* accel3 */ Eigen::Vector3f{-0.01F, 0.02F, 9.79F});
 }
 
 TEST(MimuMajorityVoteTest, RegressionTestOffNominal) {
-    regressionTestMimuMajorityVote(0.05F,
-                                   1U,
-                                   1U,
-                                   Eigen::Vector3f{-0.1F, 0.25F, 0.3F},
-                                   Eigen::Vector3f{1.9F, 2.25F, 2.3F},
-                                   Eigen::Vector3f{-0.1F, 0.25F, 0.3F});
+    // Off-nominal oracle cross-check: gyro IMU 1 and accel IMU 2 are outliers on different IMUs, so
+    // both votes fault independently — the regression helper verifies each vote against the reference.
+    regressionTestMimuMajorityVote(/* omegaThreshold */ 0.05F,
+                                   /* gyroFaultPersistenceLimit */ 1U,
+                                   /* accelThreshold */ 0.05F,
+                                   /* accelFaultPersistenceLimit */ 1U,
+                                   /* algCallCount */ 1U,
+                                   /* angVel1 */ Eigen::Vector3f{-0.1F, 0.25F, 0.3F},
+                                   /* angVel2 */ Eigen::Vector3f{1.9F, 2.25F, 2.3F},
+                                   /* angVel3 */ Eigen::Vector3f{-0.1F, 0.25F, 0.3F},
+                                   /* accel1 */ Eigen::Vector3f{0.0F, 0.0F, 9.8F},
+                                   /* accel2 */ Eigen::Vector3f{0.0F, 0.0F, 9.8F},
+                                   /* accel3 */ Eigen::Vector3f{2.0F, 2.0F, 11.8F});
 }
 
 TEST(MimuMajorityVoteTest, PropertyTestNominal) {
     // When all IMUs agree within threshold, output should be simple average with no fault
     const float threshold = 1.0F;
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(threshold, 1U)};
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(threshold, 1U, threshold, 1U)};
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
 
@@ -30,24 +43,25 @@ TEST(MimuMajorityVoteTest, PropertyTestNominal) {
     imuOmegas_BN_B.at(0) = baseRate;
     imuOmegas_BN_B.at(1) = baseRate + Eigen::Vector3f(0.01F, -0.01F, 0.005F);
     imuOmegas_BN_B.at(2) = baseRate + Eigen::Vector3f(-0.005F, 0.01F, -0.01F);
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{};  // all zero: no accel fault
 
     Eigen::Vector3f expectedAvg = (imuOmegas_BN_B.at(0) + imuOmegas_BN_B.at(1) + imuOmegas_BN_B.at(2)) / 3.0F;
 
-    auto out = alg.update(imuOmegas_BN_B);
+    auto out = alg.update(imuOmegas_BN_B, imuAccels_B);
 
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], expectedAvg[i], 1e-6);
+        EXPECT_NEAR(out.gyro.average[i], expectedAvg[i], 1e-6);
     }
-    EXPECT_FALSE(out.faultDetected);
+    EXPECT_FALSE(out.gyro.faultDetected);
     for (size_t i = 0U; i < 3U; ++i) {
-        EXPECT_TRUE(out.validImus.at(i));
+        EXPECT_TRUE(out.gyro.imuValid.at(i));
     }
 }
 
 TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
     // When one IMU is far off, it should be detected as faulted and excluded from average
     const float threshold = 0.05F;
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(threshold, 1U)};
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(threshold, 1U, threshold, 1U)};
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
     Eigen::Vector3f outlierRate = baseRate + Eigen::Vector3f(2.0F, 2.0F, 2.0F);
@@ -56,23 +70,24 @@ TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
     imuOmegas_BN_B.at(0) = baseRate;
     imuOmegas_BN_B.at(1) = outlierRate;  // The outlier
     imuOmegas_BN_B.at(2) = baseRate;
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{};  // all zero: no accel fault
 
     // Expected: outlier excluded, average of remaining two
     Eigen::Vector3f expectedAvg = (imuOmegas_BN_B.at(0) + imuOmegas_BN_B.at(2)) / 2.0F;
 
-    auto out = alg.update(imuOmegas_BN_B);
+    auto out = alg.update(imuOmegas_BN_B, imuAccels_B);
 
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], expectedAvg[i], 1e-6);
+        EXPECT_NEAR(out.gyro.average[i], expectedAvg[i], 1e-6);
     }
-    EXPECT_TRUE(out.faultDetected);
-    EXPECT_TRUE(out.validImus.at(0));
-    EXPECT_FALSE(out.validImus.at(1));
-    EXPECT_TRUE(out.validImus.at(2));
+    EXPECT_TRUE(out.gyro.faultDetected);
+    EXPECT_TRUE(out.gyro.imuValid.at(0));
+    EXPECT_FALSE(out.gyro.imuValid.at(1));
+    EXPECT_TRUE(out.gyro.imuValid.at(2));
 }
 
 TEST(MimuMajorityVoteTest, PersistenceFaultAndRecovery) {
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 3U)};
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 3U, 1.0F, 1U)};
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
     Eigen::Vector3f outlierRate = baseRate + Eigen::Vector3f(2.0F, 2.0F, 2.0F);
@@ -82,30 +97,31 @@ TEST(MimuMajorityVoteTest, PersistenceFaultAndRecovery) {
     imuOmegas_BN_B.at(0) = baseRate;
     imuOmegas_BN_B.at(1) = outlierRate;
     imuOmegas_BN_B.at(2) = baseRate;
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{};  // all zero: no accel fault
 
     Eigen::Vector3f fullAvg = (imuOmegas_BN_B.at(0) + imuOmegas_BN_B.at(1) + imuOmegas_BN_B.at(2)) / 3.0F;
     Eigen::Vector3f faultedAvg = (imuOmegas_BN_B.at(0) + imuOmegas_BN_B.at(2)) / 2.0F;
 
     // Calls 1 and 2: counter building, no fault — full average returned
     for (uint32_t call = 0U; call < 2U; ++call) {
-        auto out = alg.update(imuOmegas_BN_B);
-        EXPECT_FALSE(out.faultDetected);
+        auto out = alg.update(imuOmegas_BN_B, imuAccels_B);
+        EXPECT_FALSE(out.gyro.faultDetected);
         for (size_t i = 0U; i < kMimuCount; ++i) {
-            EXPECT_TRUE(out.validImus.at(i));
+            EXPECT_TRUE(out.gyro.imuValid.at(i));
         }
         for (int i = 0; i < 3; ++i) {
-            EXPECT_NEAR(out.avgOmega_BN_B[i], fullAvg[i], 1e-6);
+            EXPECT_NEAR(out.gyro.average[i], fullAvg[i], 1e-6);
         }
     }
 
     // Call 3: persistence limit reached, fault triggers — outlier excluded
-    auto out = alg.update(imuOmegas_BN_B);
-    EXPECT_TRUE(out.faultDetected);
-    EXPECT_TRUE(out.validImus.at(0));
-    EXPECT_FALSE(out.validImus.at(1));
-    EXPECT_TRUE(out.validImus.at(2));
+    auto out = alg.update(imuOmegas_BN_B, imuAccels_B);
+    EXPECT_TRUE(out.gyro.faultDetected);
+    EXPECT_TRUE(out.gyro.imuValid.at(0));
+    EXPECT_FALSE(out.gyro.imuValid.at(1));
+    EXPECT_TRUE(out.gyro.imuValid.at(2));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], faultedAvg[i], 1e-6);
+        EXPECT_NEAR(out.gyro.average[i], faultedAvg[i], 1e-6);
     }
 
     // Call 4: IMU 2 recovers to baseRate, IMU 3 becomes mild outlier —
@@ -116,40 +132,40 @@ TEST(MimuMajorityVoteTest, PersistenceFaultAndRecovery) {
 
     Eigen::Vector3f call4Avg = (imuOmegas_BN_B.at(0) + imuOmegas_BN_B.at(1) + imuOmegas_BN_B.at(2)) / 3.0F;
 
-    out = alg.update(imuOmegas_BN_B);
-    EXPECT_FALSE(out.faultDetected);
+    out = alg.update(imuOmegas_BN_B, imuAccels_B);
+    EXPECT_FALSE(out.gyro.faultDetected);
     for (size_t i = 0U; i < kMimuCount; ++i) {
-        EXPECT_TRUE(out.validImus.at(i));
+        EXPECT_TRUE(out.gyro.imuValid.at(i));
     }
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], call4Avg[i], 1e-6);
+        EXPECT_NEAR(out.gyro.average[i], call4Avg[i], 1e-6);
     }
 
     // Call 5: IMU 3 still the outlier, persistence count increments but no fault yet
-    out = alg.update(imuOmegas_BN_B);
-    EXPECT_FALSE(out.faultDetected);
+    out = alg.update(imuOmegas_BN_B, imuAccels_B);
+    EXPECT_FALSE(out.gyro.faultDetected);
     for (size_t i = 0U; i < kMimuCount; ++i) {
-        EXPECT_TRUE(out.validImus.at(i));
+        EXPECT_TRUE(out.gyro.imuValid.at(i));
     }
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], call4Avg[i], 1e-6);
+        EXPECT_NEAR(out.gyro.average[i], call4Avg[i], 1e-6);
     }
 
     // Call 6: IMU 3 persistence limit reached, fault triggers — IMU 3 excluded
     Eigen::Vector3f call6FaultedAvg = (imuOmegas_BN_B.at(0) + imuOmegas_BN_B.at(1)) / 2.0F;
 
-    out = alg.update(imuOmegas_BN_B);
-    EXPECT_TRUE(out.faultDetected);
-    EXPECT_TRUE(out.validImus.at(0));
-    EXPECT_TRUE(out.validImus.at(1));
-    EXPECT_FALSE(out.validImus.at(2));
+    out = alg.update(imuOmegas_BN_B, imuAccels_B);
+    EXPECT_TRUE(out.gyro.faultDetected);
+    EXPECT_TRUE(out.gyro.imuValid.at(0));
+    EXPECT_TRUE(out.gyro.imuValid.at(1));
+    EXPECT_FALSE(out.gyro.imuValid.at(2));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], call6FaultedAvg[i], 1e-6);
+        EXPECT_NEAR(out.gyro.average[i], call6FaultedAvg[i], 1e-6);
     }
 }
 
 TEST(MimuMajorityVoteTest, ReInitializeClearsPersistence) {
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 3U)};
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 3U, 1.0F, 1U)};
 
     Eigen::Vector3f baseRate(-0.1F, 0.25F, 0.3F);
     Eigen::Vector3f outlierRate = baseRate + Eigen::Vector3f(2.0F, 2.0F, 2.0F);
@@ -158,19 +174,20 @@ TEST(MimuMajorityVoteTest, ReInitializeClearsPersistence) {
     imuOmegas_BN_B.at(0) = baseRate;
     imuOmegas_BN_B.at(1) = outlierRate;
     imuOmegas_BN_B.at(2) = baseRate;
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{};  // all zero: no accel fault
 
     Eigen::Vector3f fullAvg = (imuOmegas_BN_B.at(0) + imuOmegas_BN_B.at(1) + imuOmegas_BN_B.at(2)) / 3.0F;
     Eigen::Vector3f faultedAvg = (imuOmegas_BN_B.at(0) + imuOmegas_BN_B.at(2)) / 2.0F;
 
     // Call twice to build up persistence (limit is 3, so no fault yet)
     for (uint32_t call = 0U; call < 2U; ++call) {
-        auto out = alg.update(imuOmegas_BN_B);
-        EXPECT_FALSE(out.faultDetected);
+        auto out = alg.update(imuOmegas_BN_B, imuAccels_B);
+        EXPECT_FALSE(out.gyro.faultDetected);
         for (size_t i = 0U; i < kMimuCount; ++i) {
-            EXPECT_TRUE(out.validImus.at(i));
+            EXPECT_TRUE(out.gyro.imuValid.at(i));
         }
         for (int i = 0; i < 3; ++i) {
-            EXPECT_NEAR(out.avgOmega_BN_B[i], fullAvg[i], 1e-6);
+            EXPECT_NEAR(out.gyro.average[i], fullAvg[i], 1e-6);
         }
     }
 
@@ -179,36 +196,43 @@ TEST(MimuMajorityVoteTest, ReInitializeClearsPersistence) {
 
     // Same outlier inputs — counter starts from zero again, no fault
     for (uint32_t call = 0U; call < 2U; ++call) {
-        auto out = alg.update(imuOmegas_BN_B);
-        EXPECT_FALSE(out.faultDetected);
+        auto out = alg.update(imuOmegas_BN_B, imuAccels_B);
+        EXPECT_FALSE(out.gyro.faultDetected);
         for (size_t i = 0U; i < kMimuCount; ++i) {
-            EXPECT_TRUE(out.validImus.at(i));
+            EXPECT_TRUE(out.gyro.imuValid.at(i));
         }
         for (int i = 0; i < 3; ++i) {
-            EXPECT_NEAR(out.avgOmega_BN_B[i], fullAvg[i], 1e-6);
+            EXPECT_NEAR(out.gyro.average[i], fullAvg[i], 1e-6);
         }
     }
 
-    // Third call after reset — now fault triggers
-    auto out = alg.update(imuOmegas_BN_B);
-    EXPECT_TRUE(out.faultDetected);
-    EXPECT_TRUE(out.validImus.at(0));
-    EXPECT_FALSE(out.validImus.at(1));
-    EXPECT_TRUE(out.validImus.at(2));
+    // Third call after reInitialize — now fault triggers
+    auto out = alg.update(imuOmegas_BN_B, imuAccels_B);
+    EXPECT_TRUE(out.gyro.faultDetected);
+    EXPECT_TRUE(out.gyro.imuValid.at(0));
+    EXPECT_FALSE(out.gyro.imuValid.at(1));
+    EXPECT_TRUE(out.gyro.imuValid.at(2));
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], faultedAvg[i], 1e-6);
+        EXPECT_NEAR(out.gyro.average[i], faultedAvg[i], 1e-6);
     }
 }
 
 TEST(MimuMajorityVoteTest, SetupTest) {
-    // Config validation rejects a zero/negative omegaThreshold and a zero gyroFaultPersistenceLimit.
-    EXPECT_THROW((void)MimuMajorityVoteConfig::create(0.0F, 1U), fsw::invalid_argument);
-    EXPECT_THROW((void)MimuMajorityVoteConfig::create(-0.1F, 1U), fsw::invalid_argument);
-    EXPECT_THROW((void)MimuMajorityVoteConfig::create(0.5F, 0U), fsw::invalid_argument);
+    // Config validation rejects a zero/negative threshold and a zero persistence limit, for both
+    // the gyro and accel parameters.
+    EXPECT_THROW((void)MimuMajorityVoteConfig::create(0.0F, 1U, 1.0F, 1U), fsw::invalid_argument);
+    EXPECT_THROW((void)MimuMajorityVoteConfig::create(-0.1F, 1U, 1.0F, 1U), fsw::invalid_argument);
+    EXPECT_THROW((void)MimuMajorityVoteConfig::create(1.0F, 0U, 1.0F, 1U), fsw::invalid_argument);
+    EXPECT_THROW((void)MimuMajorityVoteConfig::create(1.0F, 1U, 0.0F, 1U), fsw::invalid_argument);
+    EXPECT_THROW((void)MimuMajorityVoteConfig::create(1.0F, 1U, -0.1F, 1U), fsw::invalid_argument);
+    EXPECT_THROW((void)MimuMajorityVoteConfig::create(1.0F, 1U, 1.0F, 0U), fsw::invalid_argument);
 
     // A valid config exposes exactly the supplied parameters.
-    const float threshold = 0.5F;
-    const MimuMajorityVoteConfig cfg = MimuMajorityVoteConfig::create(threshold, 2U);
-    EXPECT_NEAR(cfg.getOmegaThreshold(), threshold, 1e-6);
+    const float omegaThreshold = 0.5F;
+    const float accelThreshold = 0.25F;
+    const MimuMajorityVoteConfig cfg = MimuMajorityVoteConfig::create(omegaThreshold, 2U, accelThreshold, 3U);
+    EXPECT_NEAR(cfg.getOmegaThreshold(), omegaThreshold, 1e-6);
     EXPECT_EQ(cfg.getGyroFaultPersistenceLimit(), 2U);
+    EXPECT_NEAR(cfg.getAccelThreshold(), accelThreshold, 1e-6);
+    EXPECT_EQ(cfg.getAccelFaultPersistenceLimit(), 3U);
 }

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
@@ -201,7 +201,7 @@ TEST(MimuMajorityVoteTest, ReInitializeClearsPersistence) {
 }
 
 TEST(MimuMajorityVoteTest, SetupTest) {
-    // Config validation rejects a zero/negative omegaThreshold and a zero faultPersistenceLimit.
+    // Config validation rejects a zero/negative omegaThreshold and a zero gyroFaultPersistenceLimit.
     EXPECT_THROW((void)MimuMajorityVoteConfig::create(0.0F, 1U), fsw::invalid_argument);
     EXPECT_THROW((void)MimuMajorityVoteConfig::create(-0.1F, 1U), fsw::invalid_argument);
     EXPECT_THROW((void)MimuMajorityVoteConfig::create(0.5F, 0U), fsw::invalid_argument);
@@ -210,5 +210,5 @@ TEST(MimuMajorityVoteTest, SetupTest) {
     const float threshold = 0.5F;
     const MimuMajorityVoteConfig cfg = MimuMajorityVoteConfig::create(threshold, 2U);
     EXPECT_NEAR(cfg.getOmegaThreshold(), threshold, 1e-6);
-    EXPECT_EQ(cfg.getFaultPersistenceLimit(), 2U);
+    EXPECT_EQ(cfg.getGyroFaultPersistenceLimit(), 2U);
 }

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote.cpp
@@ -1,7 +1,7 @@
 #include "mimuMajorityVoteTestHelpers.hpp"
 #include <gtest/gtest.h>
 
-TEST(MimuMajorityVoteTest, RegressionTest) {
+TEST(MimuMajorityVoteTest, RegressionTestNominal) {
     // Nominal: gyro and accel inputs both agree within their thresholds — no fault on either vote.
     regressionTestMimuMajorityVote(/* omegaThreshold */ 1.0F,
                                    /* gyroFaultPersistenceLimit */ 1U,
@@ -32,7 +32,7 @@ TEST(MimuMajorityVoteTest, RegressionTestOffNominal) {
                                    /* accel3 */ Eigen::Vector3f{2.0F, 2.0F, 11.8F});
 }
 
-TEST(MimuMajorityVoteTest, PropertyTestNominal) {
+TEST(MimuMajorityVoteTest, NoFaultAveragesAllImus) {
     // When all IMUs agree within threshold, output should be simple average with no fault
     const float threshold = 1.0F;
     MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(threshold, 1U, threshold, 1U)};
@@ -58,7 +58,7 @@ TEST(MimuMajorityVoteTest, PropertyTestNominal) {
     }
 }
 
-TEST(MimuMajorityVoteTest, PropertyTestOffNominal) {
+TEST(MimuMajorityVoteTest, OutlierFaultedAndExcluded) {
     // When one IMU is far off, it should be detected as faulted and excluded from average
     const float threshold = 0.05F;
     MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(threshold, 1U, threshold, 1U)};
@@ -288,7 +288,7 @@ TEST(MimuMajorityVoteTest, ReInitializeClearsPersistence) {
     }
 }
 
-TEST(MimuMajorityVoteTest, SetupTest) {
+TEST(MimuMajorityVoteTest, ConfigValidation) {
     // Config validation rejects a zero/negative threshold and a zero persistence limit, for both
     // the gyro and accel parameters.
     EXPECT_THROW((void)MimuMajorityVoteConfig::create(0.0F, 1U, 1.0F, 1U), fsw::invalid_argument);

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVoteF32.py
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVoteF32.py
@@ -78,6 +78,15 @@ def test_mimu_majority_vote_off_nominal():
     expected_output_fault = True
     expected_valid_imus = [True, False, True]
 
+    # Independent accel vote: make IMU 3 the accel outlier (offset past the 1.0 m/s^2 accelThreshold).
+    # Only IMU 3 exceeds the threshold, so it alone is faulted -- a different IMU than the gyro vote
+    # (IMU 2), demonstrating that the gyro and accel votes are independent.
+    base_acceleration = np.array([0.0, 0.0, 9.8])
+    acceleration_3 = base_acceleration + np.array([0.0, 0.0, 2.0])
+    expected_acceleration = base_acceleration  # IMU 3 excluded -> IMU 1 & 2 average back to base
+    expected_accel_fault = True
+    expected_accel_valid_imus = [True, True, False]
+
     run_test(
         angular_velocity_1,
         angular_velocity_2,
@@ -87,6 +96,10 @@ def test_mimu_majority_vote_off_nominal():
         expected_angular_velocity,
         expected_output_fault,
         expected_valid_imus,
+        acceleration_3=acceleration_3,
+        expected_acceleration=expected_acceleration,
+        expected_accel_fault=expected_accel_fault,
+        expected_accel_valid_imus=expected_accel_valid_imus,
     )
 
 
@@ -99,6 +112,12 @@ def run_test(
     expected_angular_velocity,
     expected_output_fault,
     expected_valid_imus,
+    acceleration_1=None,
+    acceleration_2=None,
+    acceleration_3=None,
+    expected_acceleration=None,
+    expected_accel_fault=False,
+    expected_accel_valid_imus=None,
 ):
 
     unit_task_name = "unitTask"
@@ -116,11 +135,23 @@ def run_test(
 
     module.omegaThreshold = omega_threshold_rad_per_sec
     module.gyroFaultPersistenceLimit = fault_persistence_limit
+    module.accelThreshold = 1.0  # m/s^2
+    module.accelFaultPersistenceLimit = 1
+
+    # Accel inputs default to a common value (no accel fault) unless a test overrides them.
+    base_acceleration = np.array([0.0, 0.0, 9.8])
+    acceleration_1 = base_acceleration if acceleration_1 is None else np.asarray(acceleration_1)
+    acceleration_2 = base_acceleration if acceleration_2 is None else np.asarray(acceleration_2)
+    acceleration_3 = base_acceleration if acceleration_3 is None else np.asarray(acceleration_3)
+    expected_acceleration = base_acceleration if expected_acceleration is None else np.asarray(expected_acceleration)
+    if expected_accel_valid_imus is None:
+        expected_accel_valid_imus = [True, True, True]
 
     unit_test_sim.AddModelToTask(unit_task_name, module)
 
     input_message_data_1 = messaging.IMUSensorBodyMsgF32Payload()
     input_message_data_1.AngVelBody = angular_velocity_1.tolist()
+    input_message_data_1.AccelBody = acceleration_1.tolist()
     in_msg_1 = messaging.IMUSensorBodyMsgF32().write(input_message_data_1)
 
     imu_message_1 = mimuMajorityVoteF32.ImuMessage()
@@ -129,6 +160,7 @@ def run_test(
 
     input_message_data_2 = messaging.IMUSensorBodyMsgF32Payload()
     input_message_data_2.AngVelBody = angular_velocity_2.tolist()
+    input_message_data_2.AccelBody = acceleration_2.tolist()
     in_msg_2 = messaging.IMUSensorBodyMsgF32().write(input_message_data_2)
 
     imu_message_2 = mimuMajorityVoteF32.ImuMessage()
@@ -137,6 +169,7 @@ def run_test(
 
     input_message_data_3 = messaging.IMUSensorBodyMsgF32Payload()
     input_message_data_3.AngVelBody = angular_velocity_3.tolist()
+    input_message_data_3.AccelBody = acceleration_3.tolist()
     in_msg_3 = messaging.IMUSensorBodyMsgF32().write(input_message_data_3)
 
     imu_message_3 = mimuMajorityVoteF32.ImuMessage()
@@ -165,6 +198,16 @@ def run_test(
     np.testing.assert_array_equal(module_output_valid_imus[-1], expected_valid_imus)
     np.testing.assert_allclose(module.omegaThreshold, omega_threshold_rad_per_sec, rtol=0, atol=1e-7, verbose=True)
     np.testing.assert_array_equal(module.gyroFaultPersistenceLimit, fault_persistence_limit)
+
+    # Independent accel vote.
+    module_output_acceleration = rate_data_log.AccelBody
+    module_output_accel_fault = fault_data_log.accelFaultDetected
+    module_output_accel_valid_imus = fault_data_log.accelImuValid
+
+    # atol is looser than the gyro check: float32 round-trip of a ~9.8 m/s^2 value carries ~1e-6 error.
+    np.testing.assert_allclose(module_output_acceleration[-1], expected_acceleration, rtol=0, atol=1e-5, verbose=True)
+    np.testing.assert_allclose(module_output_accel_fault[-1], expected_accel_fault, verbose=True)
+    np.testing.assert_array_equal(module_output_accel_valid_imus[-1], expected_accel_valid_imus)
 
 
 if __name__ == "__main__":

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVoteF32.py
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVoteF32.py
@@ -115,7 +115,7 @@ def run_test(
     module.modelTag = "mimuMajorityVote"
 
     module.omegaThreshold = omega_threshold_rad_per_sec
-    module.faultPersistenceLimit = fault_persistence_limit
+    module.gyroFaultPersistenceLimit = fault_persistence_limit
 
     unit_test_sim.AddModelToTask(unit_task_name, module)
 
@@ -155,8 +155,8 @@ def run_test(
     unit_test_sim.ExecuteSimulation()
 
     module_output_angular_velocity = rate_data_log.AngVelBody
-    module_output_fault = fault_data_log.faultDetected
-    module_output_valid_imus = fault_data_log.validImus
+    module_output_fault = fault_data_log.gyroFaultDetected
+    module_output_valid_imus = fault_data_log.gyroImuValid
 
     np.testing.assert_allclose(
         module_output_angular_velocity[-1], expected_angular_velocity, rtol=0, atol=1e-7, verbose=True
@@ -164,7 +164,7 @@ def run_test(
     np.testing.assert_allclose(module_output_fault[-1], expected_output_fault, verbose=True)
     np.testing.assert_array_equal(module_output_valid_imus[-1], expected_valid_imus)
     np.testing.assert_allclose(module.omegaThreshold, omega_threshold_rad_per_sec, rtol=0, atol=1e-7, verbose=True)
-    np.testing.assert_array_equal(module.faultPersistenceLimit, fault_persistence_limit)
+    np.testing.assert_array_equal(module.gyroFaultPersistenceLimit, fault_persistence_limit)
 
 
 if __name__ == "__main__":

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote_fuzz.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote_fuzz.cpp
@@ -13,8 +13,7 @@ void propertyOutputAlwaysFinite(const Eigen::Vector3f& angVel1,
                                 const Eigen::Vector3f& angVel2,
                                 const Eigen::Vector3f& angVel3,
                                 float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(omegaThreshold);
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
 
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
     imuOmegas_BN_B.at(0) = angVel1;
@@ -36,8 +35,7 @@ void propertyFaultAndValidConsistency(const Eigen::Vector3f& angVel1,
                                       const Eigen::Vector3f& angVel2,
                                       const Eigen::Vector3f& angVel3,
                                       float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(omegaThreshold);
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
 
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
     imuOmegas_BN_B.at(0) = angVel1;
@@ -102,8 +100,7 @@ void propertyAverageIsCorrect(const Eigen::Vector3f& angVel1,
                               const Eigen::Vector3f& angVel2,
                               const Eigen::Vector3f& angVel3,
                               float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(omegaThreshold);
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
 
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
     imuOmegas_BN_B.at(0) = angVel1;
@@ -128,8 +125,7 @@ void propertyAverageIsCorrect(const Eigen::Vector3f& angVel1,
 }
 
 void propertyIdenticalIMUsNoFault(const Eigen::Vector3f& angVel, float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(omegaThreshold);
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
 
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
     for (size_t i = 0U; i < kMimuCount; ++i) {
@@ -151,8 +147,7 @@ void propertyIdenticalIMUsNoFault(const Eigen::Vector3f& angVel, float omegaThre
 void propertyClearSingleOutlier(const Eigen::Vector3f& baseAngVel, size_t outlierIndex, float omegaThreshold) {
     constexpr float kOutlierFactor = 10.0F;
 
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(omegaThreshold);
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
 
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
     for (size_t i = 0U; i < kMimuCount; ++i) {
@@ -176,8 +171,7 @@ void propertyCyclicPermutationInvariant(const Eigen::Vector3f& angVel1,
                                         const Eigen::Vector3f& angVel2,
                                         const Eigen::Vector3f& angVel3,
                                         float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(omegaThreshold);
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
 
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
     imuOmegas_BN_B.at(0) = angVel1;

--- a/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote_fuzz.cpp
+++ b/algorithms/mimuMajorityVote/_tests/test_mimuMajorityVote_fuzz.cpp
@@ -5,77 +5,66 @@
 namespace {
 
 constexpr float kMaxAngVel = 1e3F;
+constexpr float kMaxAccel = 1e3F;
 constexpr float kMinThreshold = 1e-2F;
 constexpr float kMaxThreshold = 1e3F;
 constexpr float kCompTol = 1e-3F;
 
-void propertyOutputAlwaysFinite(const Eigen::Vector3f& angVel1,
-                                const Eigen::Vector3f& angVel2,
-                                const Eigen::Vector3f& angVel3,
-                                float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
+// The property functions below exercise both the gyro and accelerometer votes: each drives a single
+// update() with independent fuzzed gyro and accel inputs (and independent thresholds) and asserts
+// the same property on both out.gyro and out.accel. The regressionTestMimuMajorityVote fuzz target
+// additionally checks both votes against a reference implementation.
 
-    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
-    imuOmegas_BN_B.at(0) = angVel1;
-    imuOmegas_BN_B.at(1) = angVel2;
-    imuOmegas_BN_B.at(2) = angVel3;
+// ----- Shared per-vote property checks (applied identically to the gyro and accel results) -----
 
-    auto const out = alg.update(imuOmegas_BN_B);
-
-    for (int i = 0; i < 3; ++i) {
-        ASSERT_TRUE(std::isfinite(out.avgOmega_BN_B[i]));
-    }
+size_t invalidCount(const MimuVoteResult& vote) {
+    size_t count = 0U;
     for (size_t i = 0U; i < kMimuCount; ++i) {
-        ASSERT_GE(out.omegaDifferencesMag.at(i), 0.0F);
-        ASSERT_TRUE(std::isfinite(out.omegaDifferencesMag.at(i)));
-    }
-}
-
-void propertyFaultAndValidConsistency(const Eigen::Vector3f& angVel1,
-                                      const Eigen::Vector3f& angVel2,
-                                      const Eigen::Vector3f& angVel3,
-                                      float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
-
-    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
-    imuOmegas_BN_B.at(0) = angVel1;
-    imuOmegas_BN_B.at(1) = angVel2;
-    imuOmegas_BN_B.at(2) = angVel3;
-
-    auto const out = alg.update(imuOmegas_BN_B);
-
-    size_t invalidCount = 0U;
-    for (size_t i = 0U; i < kMimuCount; ++i) {
-        if (!out.validImus.at(i)) {
-            ++invalidCount;
+        if (!vote.imuValid.at(i)) {
+            ++count;
         }
     }
-
-    // Invalid count must be 0 (no fault) or 1 (single outlier)
-    ASSERT_TRUE(invalidCount == 0U || invalidCount == 1U);
-    // faultDetected must be consistent with validImus
-    ASSERT_EQ(out.faultDetected, invalidCount > 0U);
+    return count;
 }
 
-void expectNoFaultAverage(const MimuMajorityVoteOutput& out,
-                          const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B,
+void assertResultFinite(const MimuVoteResult& vote) {
+    for (int i = 0; i < 3; ++i) {
+        ASSERT_TRUE(std::isfinite(vote.average[i]));
+    }
+    for (size_t i = 0U; i < kMimuCount; ++i) {
+        ASSERT_GE(vote.imuDifferenceMag.at(i), 0.0F);
+        ASSERT_TRUE(std::isfinite(vote.imuDifferenceMag.at(i)));
+    }
+}
+
+void assertFaultValidConsistency(const MimuVoteResult& vote) {
+    // Invalid count must be 0 (no fault) or 1 (single outlier)
+    size_t const invalid = invalidCount(vote);
+    ASSERT_TRUE(invalid == 0U || invalid == 1U);
+    // faultDetected must be consistent with imuValid
+    ASSERT_EQ(vote.faultDetected, invalid > 0U);
+}
+
+void expectNoFaultAverage(const Eigen::Vector3f& average,
+                          const std::array<Eigen::Vector3f, kMimuCount>& measurements,
                           size_t numImus) {
     Eigen::Vector3f expectedAvg = Eigen::Vector3f::Zero();
     for (size_t i = 0U; i < numImus; ++i) {
-        expectedAvg += imuOmegas_BN_B.at(i);
+        expectedAvg += measurements.at(i);
     }
     expectedAvg /= static_cast<float>(numImus);
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], expectedAvg[i], kCompTol);
+        EXPECT_NEAR(average[i], expectedAvg[i], kCompTol);
     }
 }
 
-void expectSingleFaultAverage(const MimuMajorityVoteOutput& out,
-                              const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B,
+void expectSingleFaultAverage(const Eigen::Vector3f& average,
+                              const std::array<bool, kMimuCount>& imuValid,
+                              const std::array<Eigen::Vector3f, kMimuCount>& measurements,
                               size_t numImus) {
     size_t faultedIndex = numImus;  // sentinel
     for (size_t i = 0U; i < numImus; ++i) {
-        if (!out.validImus.at(i)) {
+        if (!imuValid.at(i)) {
             faultedIndex = i;
             break;
         }
@@ -86,162 +75,251 @@ void expectSingleFaultAverage(const MimuMajorityVoteOutput& out,
     size_t count = 0U;
     for (size_t i = 0U; i < numImus; ++i) {
         if (i != faultedIndex) {
-            expectedAvg += imuOmegas_BN_B.at(i);
+            expectedAvg += measurements.at(i);
             ++count;
         }
     }
     expectedAvg /= static_cast<float>(count);
     for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(out.avgOmega_BN_B[i], expectedAvg[i], kCompTol);
+        EXPECT_NEAR(average[i], expectedAvg[i], kCompTol);
     }
+}
+
+void assertAverageCorrect(const MimuVoteResult& vote, const std::array<Eigen::Vector3f, kMimuCount>& measurements) {
+    if (invalidCount(vote) == 0U) {
+        expectNoFaultAverage(vote.average, measurements, kMimuCount);
+    } else {
+        // Single outlier excluded: average of the remaining sensors
+        expectSingleFaultAverage(vote.average, vote.imuValid, measurements, kMimuCount);
+    }
+}
+
+void assertIdenticalNoFault(const MimuVoteResult& vote, const Eigen::Vector3f& value) {
+    ASSERT_FALSE(vote.faultDetected);
+    for (size_t i = 0U; i < kMimuCount; ++i) {
+        ASSERT_TRUE(vote.imuValid.at(i));
+        ASSERT_NEAR(vote.imuDifferenceMag.at(i), 0.0F, kCompTol);
+    }
+    for (int i = 0; i < 3; ++i) {
+        ASSERT_NEAR(vote.average[i], value[i], kCompTol);
+    }
+}
+
+void assertClearSingleOutlier(const MimuVoteResult& vote, size_t outlierIndex) {
+    ASSERT_TRUE(vote.faultDetected);
+    ASSERT_FALSE(vote.imuValid.at(outlierIndex));
+    for (size_t i = 0U; i < kMimuCount; ++i) {
+        if (i != outlierIndex) {
+            ASSERT_TRUE(vote.imuValid.at(i));
+        }
+    }
+}
+
+void assertVoteInvariantUnderPermutation(const MimuVoteResult& voteA, const MimuVoteResult& voteB) {
+    ASSERT_EQ(voteA.faultDetected, voteB.faultDetected);
+    ASSERT_EQ(invalidCount(voteA), invalidCount(voteB));
+}
+
+// ----- Property functions: each drives both votes and asserts the property on each -----
+
+void propertyOutputAlwaysFinite(const Eigen::Vector3f& angVel1,
+                                const Eigen::Vector3f& angVel2,
+                                const Eigen::Vector3f& angVel3,
+                                float omegaThreshold,
+                                const Eigen::Vector3f& accel1,
+                                const Eigen::Vector3f& accel2,
+                                const Eigen::Vector3f& accel3,
+                                float accelThreshold) {
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U, accelThreshold, 1U)};
+
+    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{angVel1, angVel2, angVel3};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{accel1, accel2, accel3};
+
+    auto const out = alg.update(imuOmegas_BN_B, imuAccels_B);
+
+    assertResultFinite(out.gyro);
+    assertResultFinite(out.accel);
+}
+
+void propertyFaultAndValidConsistency(const Eigen::Vector3f& angVel1,
+                                      const Eigen::Vector3f& angVel2,
+                                      const Eigen::Vector3f& angVel3,
+                                      float omegaThreshold,
+                                      const Eigen::Vector3f& accel1,
+                                      const Eigen::Vector3f& accel2,
+                                      const Eigen::Vector3f& accel3,
+                                      float accelThreshold) {
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U, accelThreshold, 1U)};
+
+    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{angVel1, angVel2, angVel3};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{accel1, accel2, accel3};
+
+    auto const out = alg.update(imuOmegas_BN_B, imuAccels_B);
+
+    assertFaultValidConsistency(out.gyro);
+    assertFaultValidConsistency(out.accel);
 }
 
 void propertyAverageIsCorrect(const Eigen::Vector3f& angVel1,
                               const Eigen::Vector3f& angVel2,
                               const Eigen::Vector3f& angVel3,
-                              float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
+                              float omegaThreshold,
+                              const Eigen::Vector3f& accel1,
+                              const Eigen::Vector3f& accel2,
+                              const Eigen::Vector3f& accel3,
+                              float accelThreshold) {
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U, accelThreshold, 1U)};
 
-    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
-    imuOmegas_BN_B.at(0) = angVel1;
-    imuOmegas_BN_B.at(1) = angVel2;
-    imuOmegas_BN_B.at(2) = angVel3;
+    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{angVel1, angVel2, angVel3};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{accel1, accel2, accel3};
 
-    auto const out = alg.update(imuOmegas_BN_B);
+    auto const out = alg.update(imuOmegas_BN_B, imuAccels_B);
 
-    size_t invalidCount = 0U;
-    for (size_t i = 0U; i < kMimuCount; ++i) {
-        if (!out.validImus.at(i)) {
-            ++invalidCount;
-        }
-    }
-
-    if (invalidCount == 0U) {
-        expectNoFaultAverage(out, imuOmegas_BN_B, kMimuCount);
-    } else if (invalidCount == 1U) {
-        // Single outlier excluded: average of the remaining sensors
-        expectSingleFaultAverage(out, imuOmegas_BN_B, kMimuCount);
-    }
+    assertAverageCorrect(out.gyro, imuOmegas_BN_B);
+    assertAverageCorrect(out.accel, imuAccels_B);
 }
 
-void propertyIdenticalIMUsNoFault(const Eigen::Vector3f& angVel, float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
+void propertyIdenticalIMUsNoFault(const Eigen::Vector3f& angVel,
+                                  float omegaThreshold,
+                                  const Eigen::Vector3f& accel,
+                                  float accelThreshold) {
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U, accelThreshold, 1U)};
 
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{};
     for (size_t i = 0U; i < kMimuCount; ++i) {
         imuOmegas_BN_B.at(i) = angVel;
+        imuAccels_B.at(i) = accel;
     }
 
-    auto const out = alg.update(imuOmegas_BN_B);
+    auto const out = alg.update(imuOmegas_BN_B, imuAccels_B);
 
-    ASSERT_FALSE(out.faultDetected);
-    for (size_t i = 0U; i < kMimuCount; ++i) {
-        ASSERT_TRUE(out.validImus.at(i));
-        ASSERT_NEAR(out.omegaDifferencesMag.at(i), 0.0F, kCompTol);
-    }
-    for (int i = 0; i < 3; ++i) {
-        ASSERT_NEAR(out.avgOmega_BN_B[i], angVel[i], kCompTol);
-    }
+    assertIdenticalNoFault(out.gyro, angVel);
+    assertIdenticalNoFault(out.accel, accel);
 }
 
-void propertyClearSingleOutlier(const Eigen::Vector3f& baseAngVel, size_t outlierIndex, float omegaThreshold) {
+void propertyClearSingleOutlier(const Eigen::Vector3f& baseAngVel,
+                                size_t gyroOutlierIndex,
+                                float omegaThreshold,
+                                const Eigen::Vector3f& baseAccel,
+                                size_t accelOutlierIndex,
+                                float accelThreshold) {
     constexpr float kOutlierFactor = 10.0F;
 
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U, accelThreshold, 1U)};
 
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{};
     for (size_t i = 0U; i < kMimuCount; ++i) {
         imuOmegas_BN_B.at(i) = baseAngVel;
+        imuAccels_B.at(i) = baseAccel;
     }
-    // Make outlier clearly separable: kOutlierFactor × threshold beyond the base pair
-    imuOmegas_BN_B.at(outlierIndex) = baseAngVel + kOutlierFactor * omegaThreshold * Eigen::Vector3f::Ones();
+    // Make each outlier clearly separable: kOutlierFactor × threshold beyond the base pair
+    imuOmegas_BN_B.at(gyroOutlierIndex) = baseAngVel + kOutlierFactor * omegaThreshold * Eigen::Vector3f::Ones();
+    imuAccels_B.at(accelOutlierIndex) = baseAccel + kOutlierFactor * accelThreshold * Eigen::Vector3f::Ones();
 
-    auto const out = alg.update(imuOmegas_BN_B);
+    auto const out = alg.update(imuOmegas_BN_B, imuAccels_B);
 
-    ASSERT_TRUE(out.faultDetected);
-    ASSERT_FALSE(out.validImus.at(outlierIndex));
-    for (size_t i = 0U; i < kMimuCount; ++i) {
-        if (i != outlierIndex) {
-            ASSERT_TRUE(out.validImus.at(i));
-        }
-    }
+    assertClearSingleOutlier(out.gyro, gyroOutlierIndex);
+    assertClearSingleOutlier(out.accel, accelOutlierIndex);
 }
 
 void propertyCyclicPermutationInvariant(const Eigen::Vector3f& angVel1,
                                         const Eigen::Vector3f& angVel2,
                                         const Eigen::Vector3f& angVel3,
-                                        float omegaThreshold) {
-    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U)};
+                                        float omegaThreshold,
+                                        const Eigen::Vector3f& accel1,
+                                        const Eigen::Vector3f& accel2,
+                                        const Eigen::Vector3f& accel3,
+                                        float accelThreshold) {
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(omegaThreshold, 1U, accelThreshold, 1U)};
 
-    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
-    imuOmegas_BN_B.at(0) = angVel1;
-    imuOmegas_BN_B.at(1) = angVel2;
-    imuOmegas_BN_B.at(2) = angVel3;
+    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{angVel1, angVel2, angVel3};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{accel1, accel2, accel3};
 
-    auto const out0 = alg.update(imuOmegas_BN_B);
+    auto const out0 = alg.update(imuOmegas_BN_B, imuAccels_B);
 
-    // Cyclic permutation: [v2, v3, v1]
+    // Cyclic permutation: [v2, v3, v1] applied to both votes
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B1{};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B1{};
     imuOmegas_BN_B1.at(0) = imuOmegas_BN_B.at(1);
     imuOmegas_BN_B1.at(1) = imuOmegas_BN_B.at(2);
     imuOmegas_BN_B1.at(2) = imuOmegas_BN_B.at(0);
+    imuAccels_B1.at(0) = imuAccels_B.at(1);
+    imuAccels_B1.at(1) = imuAccels_B.at(2);
+    imuAccels_B1.at(2) = imuAccels_B.at(0);
 
-    auto const out1 = alg.update(imuOmegas_BN_B1);
+    auto const out1 = alg.update(imuOmegas_BN_B1, imuAccels_B1);
 
-    ASSERT_EQ(out0.faultDetected, out1.faultDetected);
-
-    size_t invalidCount0 = 0U;
-    size_t invalidCount1 = 0U;
-    for (size_t i = 0U; i < kMimuCount; ++i) {
-        if (!out0.validImus.at(i)) {
-            ++invalidCount0;
-        }
-        if (!out1.validImus.at(i)) {
-            ++invalidCount1;
-        }
-    }
-    ASSERT_EQ(invalidCount0, invalidCount1);
+    assertVoteInvariantUnderPermutation(out0.gyro, out1.gyro);
+    assertVoteInvariantUnderPermutation(out0.accel, out1.accel);
 }
 
 }  // namespace
 
 FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, regressionTestMimuMajorityVote)
     .WithDomains(fuzztest::InRange(1e-6F, 1e3F),              // omegaThreshold
-                 fuzztest::InRange<uint32_t>(1U, 200U),       // persistenceLimit
+                 fuzztest::InRange<uint32_t>(1U, 200U),       // gyroFaultPersistenceLimit
+                 fuzztest::InRange(1e-6F, 1e3F),              // accelThreshold
+                 fuzztest::InRange<uint32_t>(1U, 200U),       // accelFaultPersistenceLimit
                  fuzztest::InRange<uint32_t>(1U, 100U),       // algCallCount
                  xmera::fuzz::Vector3fInRange(-1e3F, 1e3F),   // angVel1
                  xmera::fuzz::Vector3fInRange(-1e3F, 1e3F),   // angVel2
-                 xmera::fuzz::Vector3fInRange(-1e3F, 1e3F));  // angVel3
+                 xmera::fuzz::Vector3fInRange(-1e3F, 1e3F),   // angVel3
+                 xmera::fuzz::Vector3fInRange(-1e3F, 1e3F),   // accel1
+                 xmera::fuzz::Vector3fInRange(-1e3F, 1e3F),   // accel2
+                 xmera::fuzz::Vector3fInRange(-1e3F, 1e3F));  // accel3
 
 FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyOutputAlwaysFinite)
     .WithDomains(xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel1
                  xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel2
                  xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel3
-                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // omegaThreshold
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold),        // omegaThreshold
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel1
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel2
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel3
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // accelThreshold
 
 FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyFaultAndValidConsistency)
     .WithDomains(xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel1
                  xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel2
                  xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel3
-                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // omegaThreshold
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold),        // omegaThreshold
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel1
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel2
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel3
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // accelThreshold
 
 FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyAverageIsCorrect)
     .WithDomains(xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel1
                  xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel2
                  xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel3
-                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // omegaThreshold
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold),        // omegaThreshold
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel1
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel2
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel3
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // accelThreshold
 
 FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyIdenticalIMUsNoFault)
     .WithDomains(xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel
-                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // omegaThreshold
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold),        // omegaThreshold
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // accelThreshold
 
 FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyClearSingleOutlier)
     .WithDomains(xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // baseAngVel
-                 fuzztest::InRange<size_t>(0, 2),                        // outlierIndex
-                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // omegaThreshold
+                 fuzztest::InRange<size_t>(0, 2),                        // gyroOutlierIndex
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold),        // omegaThreshold
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // baseAccel
+                 fuzztest::InRange<size_t>(0, 2),                        // accelOutlierIndex
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // accelThreshold
 
 FUZZ_TEST(MimuMajorityVoteAlgorithmFuzz, propertyCyclicPermutationInvariant)
     .WithDomains(xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel1
                  xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel2
                  xmera::fuzz::Vector3fInRange(-kMaxAngVel, kMaxAngVel),  // angVel3
-                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // omegaThreshold
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold),        // omegaThreshold
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel1
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel2
+                 xmera::fuzz::Vector3fInRange(-kMaxAccel, kMaxAccel),    // accel3
+                 fuzztest::InRange(kMinThreshold, kMaxThreshold));       // accelThreshold

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
@@ -1,16 +1,28 @@
 #include "mimuMajorityVote.h"
 
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/xmera/xmeraLifecycleException.h"
+
+#include <stdexcept>
 
 void MimuMajorityVote::reset(uint64_t const callTime) {
     if (this->actualNumberOfImus != kMimuCount) {
         throw std::invalid_argument(
             "Number of connected IMU messages must equal kMimuCount (3); call addImuInput() exactly 3 times.");
     }
-    this->algorithm.reset();
+    this->algorithm = std::make_unique<MimuMajorityVoteAlgorithm>(this->toConfig());
+}
+
+/*! Build a validated algorithm configuration from the current module parameters. */
+MimuMajorityVoteConfig MimuMajorityVote::toConfig() const {
+    return MimuMajorityVoteConfig::create(this->omegaThreshold, this->faultPersistenceLimit);
 }
 
 void MimuMajorityVote::updateState(uint64_t const callTime) {
+    if (!this->algorithm) {
+        throw XmeraLifecycleException("MimuMajorityVote reset() has not been called.");
+    }
+
     // Convert message payloads to algorithm input type
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B = {};
     for (size_t index = 0U; index < kMimuCount; ++index) {
@@ -18,7 +30,7 @@ void MimuMajorityVote::updateState(uint64_t const callTime) {
         imuOmegas_BN_B.at(index) = cArrayToEigenVector(payload.AngVelBody);
     }
 
-    MimuMajorityVoteOutput output = this->algorithm.update(imuOmegas_BN_B);
+    MimuMajorityVoteOutput output = this->algorithm->update(imuOmegas_BN_B);
 
     // Convert algorithm output to message payloads
     IMUSensorBodyMsgF32Payload imuOutPayload{};
@@ -35,6 +47,24 @@ void MimuMajorityVote::updateState(uint64_t const callTime) {
     this->mimuFaultMsg.write(faultPayload, this->moduleID, callTime);
 }
 
+/*! Re-validate the current module parameters and push them onto the live algorithm without resetting
+ its persistence counters. Rebuilds the validated config from the public members via setConfig(). */
+void MimuMajorityVote::reconfigure() {
+    if (!this->algorithm) {
+        throw XmeraLifecycleException("MimuMajorityVote reconfigure() before reset().");
+    }
+    this->algorithm->setConfig(this->toConfig());
+}
+
+/*! Reset the algorithm's fault persistence counters without rebuilding the config; a simple
+ pass-through to the algorithm's reInitialize(). */
+void MimuMajorityVote::reInitialize() {
+    if (!this->algorithm) {
+        throw XmeraLifecycleException("MimuMajorityVote reInitialize() before reset().");
+    }
+    this->algorithm->reInitialize();
+}
+
 // Add imu to the majority vote module
 void MimuMajorityVote::addImuInput(const ImuMessage& imu) {
     if (this->actualNumberOfImus >= kMimuCount) {
@@ -43,15 +73,3 @@ void MimuMajorityVote::addImuInput(const ImuMessage& imu) {
     this->imuMessages.at(this->actualNumberOfImus) = imu;
     this->actualNumberOfImus++;
 }
-
-void MimuMajorityVote::setOmegaThreshold(float const omegaThreshold) {
-    this->algorithm.setOmegaThreshold(omegaThreshold);
-}
-
-float MimuMajorityVote::getOmegaThreshold() const { return this->algorithm.getOmegaThreshold(); }
-
-void MimuMajorityVote::setFaultPersistenceLimit(uint32_t const faultPersistenceLimit) {
-    this->algorithm.setFaultPersistenceLimit(faultPersistenceLimit);
-}
-
-uint32_t MimuMajorityVote::getFaultPersistenceLimit() const { return this->algorithm.getFaultPersistenceLimit(); }

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
@@ -15,7 +15,8 @@ void MimuMajorityVote::reset(uint64_t const callTime) {
 
 /*! Build a validated algorithm configuration from the current module parameters. */
 MimuMajorityVoteConfig MimuMajorityVote::toConfig() const {
-    return MimuMajorityVoteConfig::create(this->omegaThreshold, this->gyroFaultPersistenceLimit);
+    return MimuMajorityVoteConfig::create(
+        this->omegaThreshold, this->gyroFaultPersistenceLimit, this->accelThreshold, this->accelFaultPersistenceLimit);
 }
 
 void MimuMajorityVote::updateState(uint64_t const callTime) {
@@ -23,24 +24,30 @@ void MimuMajorityVote::updateState(uint64_t const callTime) {
         throw XmeraLifecycleException("MimuMajorityVote reset() has not been called.");
     }
 
-    // Convert message payloads to algorithm input type
+    // Convert message payloads to algorithm input types (angular velocity and acceleration)
     std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B = {};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B = {};
     for (size_t index = 0U; index < kMimuCount; ++index) {
         auto payload = this->imuMessages.at(index).imuSensorBodyInMsg();
         imuOmegas_BN_B.at(index) = cArrayToEigenVector(payload.AngVelBody);
+        imuAccels_B.at(index) = cArrayToEigenVector(payload.AccelBody);
     }
 
-    MimuMajorityVoteOutput output = this->algorithm->update(imuOmegas_BN_B);
+    MimuMajorityVoteOutput output = this->algorithm->update(imuOmegas_BN_B, imuAccels_B);
 
     // Convert algorithm output to message payloads
     IMUSensorBodyMsgF32Payload imuOutPayload{};
-    eigenVectorToCArray(output.avgOmega_BN_B, imuOutPayload.AngVelBody);
+    eigenVectorToCArray(output.gyro.average, imuOutPayload.AngVelBody);
+    eigenVectorToCArray(output.accel.average, imuOutPayload.AccelBody);
 
     MimuFaultMsgPayload faultPayload{};
-    faultPayload.gyroFaultDetected = output.faultDetected;
+    faultPayload.gyroFaultDetected = output.gyro.faultDetected;
+    faultPayload.accelFaultDetected = output.accel.faultDetected;
     for (size_t i = 0U; i < kMimuCount; ++i) {
-        faultPayload.gyroImuValid[i] = output.validImus.at(i);
-        faultPayload.gyroImuDifferenceMag[i] = output.omegaDifferencesMag.at(i);
+        faultPayload.gyroImuValid[i] = output.gyro.imuValid.at(i);
+        faultPayload.gyroImuDifferenceMag[i] = output.gyro.imuDifferenceMag.at(i);
+        faultPayload.accelImuValid[i] = output.accel.imuValid.at(i);
+        faultPayload.accelImuDifferenceMag[i] = output.accel.imuDifferenceMag.at(i);
     }
 
     this->imuSensorBodyOutMsg.write(imuOutPayload, this->moduleID, callTime);

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
@@ -15,7 +15,7 @@ void MimuMajorityVote::reset(uint64_t const callTime) {
 
 /*! Build a validated algorithm configuration from the current module parameters. */
 MimuMajorityVoteConfig MimuMajorityVote::toConfig() const {
-    return MimuMajorityVoteConfig::create(this->omegaThreshold, this->faultPersistenceLimit);
+    return MimuMajorityVoteConfig::create(this->omegaThreshold, this->gyroFaultPersistenceLimit);
 }
 
 void MimuMajorityVote::updateState(uint64_t const callTime) {
@@ -37,10 +37,10 @@ void MimuMajorityVote::updateState(uint64_t const callTime) {
     eigenVectorToCArray(output.avgOmega_BN_B, imuOutPayload.AngVelBody);
 
     MimuFaultMsgPayload faultPayload{};
-    faultPayload.faultDetected = output.faultDetected;
+    faultPayload.gyroFaultDetected = output.faultDetected;
     for (size_t i = 0U; i < kMimuCount; ++i) {
-        faultPayload.validImus[i] = output.validImus.at(i);
-        faultPayload.omegaDifferencesMag[i] = output.omegaDifferencesMag.at(i);
+        faultPayload.gyroImuValid[i] = output.validImus.at(i);
+        faultPayload.gyroImuDifferenceMag[i] = output.omegaDifferencesMag.at(i);
     }
 
     this->imuSensorBodyOutMsg.write(imuOutPayload, this->moduleID, callTime);

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.h
@@ -1,12 +1,15 @@
 #ifndef MIMU_MAJORITY_VOTE
 #define MIMU_MAJORITY_VOTE
 
-#include <Eigen/Core>
-
 #include "architecture/messaging/messaging.h"
 #include "mimuMajorityVoteAlgorithm.h"
 #include "msgPayloadDef/IMUSensorBodyMsgF32Payload.h"
 #include "msgPayloadDef/MimuFaultMsgPayload.h"
+
+#include <Eigen/Core>
+#include <array>
+#include <cstdint>
+#include <memory>
 
 /*! @brief Inertial Measurement Unit (IMU) sensor container class */
 class ImuMessage {
@@ -15,22 +18,28 @@ class ImuMessage {
 };
 
 /*!@brief Adapter class to kick off the computation of majority voted imu data. */
-class MimuMajorityVote : public SysModel {
+class MimuMajorityVote final : public SysModel {
    public:
-    void reset(uint64_t callTime) final;
-    void updateState(uint64_t callTime) final;
-    void addImuInput(const ImuMessage& imu);                        //!< Method to add imus to the computation
-    void setOmegaThreshold(float omegaThreshold);                   //!< Setter method for omegaThreshold
-    float getOmegaThreshold() const;                                //!< Getter method for omegaThreshold
-    void setFaultPersistenceLimit(uint32_t faultPersistenceLimit);  //!< Setter method for faultPersistenceLimit
-    uint32_t getFaultPersistenceLimit() const;                      //!< Getter method for faultPersistenceLimit
+    MimuMajorityVote() = default;
+    ~MimuMajorityVote() override = default;
+
+    void reset(uint64_t callTime) override;
+    void updateState(uint64_t callTime) override;
+    void reconfigure();                       //!< Re-validate the public parameters onto the live algorithm
+    void reInitialize();                      //!< Reset the algorithm's fault persistence counters
+    void addImuInput(const ImuMessage& imu);  //!< Method to add imus to the computation
+
+    float omegaThreshold{};              //!< [rad/s] threshold to determine if a MIMU is faulted (must be > 0)
+    uint32_t faultPersistenceLimit{};    //!< [-] consecutive faults needed to trigger faultDetected (> 0)
 
     Message<IMUSensorBodyMsgF32Payload> imuSensorBodyOutMsg;
     Message<MimuFaultMsgPayload> mimuFaultMsg;
 
    private:
+    MimuMajorityVoteConfig toConfig() const;  //!< Build a validated config from the public parameters
+
     size_t actualNumberOfImus = 0U;
-    MimuMajorityVoteAlgorithm algorithm{};
+    std::unique_ptr<MimuMajorityVoteAlgorithm> algorithm = nullptr;
     std::array<ImuMessage, kMimuCount> imuMessages;
 };
 

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.h
@@ -29,8 +29,8 @@ class MimuMajorityVote final : public SysModel {
     void reInitialize();                      //!< Reset the algorithm's fault persistence counters
     void addImuInput(const ImuMessage& imu);  //!< Method to add imus to the computation
 
-    float omegaThreshold{};              //!< [rad/s] threshold to determine if a MIMU is faulted (must be > 0)
-    uint32_t faultPersistenceLimit{};    //!< [-] consecutive faults needed to trigger faultDetected (> 0)
+    float omegaThreshold{};                //!< [rad/s] threshold to determine if a MIMU is faulted (must be > 0)
+    uint32_t gyroFaultPersistenceLimit{};  //!< [-] consecutive faults needed to trigger faultDetected (> 0)
 
     Message<IMUSensorBodyMsgF32Payload> imuSensorBodyOutMsg;
     Message<MimuFaultMsgPayload> mimuFaultMsg;

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.h
@@ -29,8 +29,10 @@ class MimuMajorityVote final : public SysModel {
     void reInitialize();                      //!< Reset the algorithm's fault persistence counters
     void addImuInput(const ImuMessage& imu);  //!< Method to add imus to the computation
 
-    float omegaThreshold{};                //!< [rad/s] threshold to determine if a MIMU is faulted (must be > 0)
-    uint32_t gyroFaultPersistenceLimit{};  //!< [-] consecutive faults needed to trigger faultDetected (> 0)
+    float omegaThreshold{};                 //!< [rad/s] gyro threshold to determine if a MIMU is faulted (must be > 0)
+    uint32_t gyroFaultPersistenceLimit{};   //!< [-] consecutive gyro faults needed to trigger gyroFaultDetected (> 0)
+    float accelThreshold{};                 //!< [m/s^2] accel threshold to determine if a MIMU is faulted (must be > 0)
+    uint32_t accelFaultPersistenceLimit{};  //!< [-] consecutive accel faults needed to trigger accelFaultDetected (> 0)
 
     Message<IMUSensorBodyMsgF32Payload> imuSensorBodyOutMsg;
     Message<MimuFaultMsgPayload> mimuFaultMsg;

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.rst
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.rst
@@ -6,14 +6,16 @@ MIMU Majority Vote
 Executive Summary
 -----------------
 
-The MIMU Majority Vote module combines the angular velocity measurements from exactly three
-Inertial Measurement Units (IMUs) into a single best-estimate body-frame angular velocity.
-It uses an outlier rejection algorithm: a single faulty sensor is identified by comparing
-each measurement against the full-sensor average, and the remaining two sensors are averaged
-to form the best estimate.
-The module outputs the best-estimate average, a per-IMU validity array, and the angular
-velocity difference magnitudes for every sensor — providing downstream fault management with
-the information needed to take further action.
+The MIMU Majority Vote module combines the measurements from exactly three Inertial Measurement
+Units (IMUs) into single best-estimate body-frame quantities. It runs two **independent** majority
+votes — one on the angular velocity (gyro) and one on the apparent acceleration (accelerometer) —
+each with its own threshold and fault persistence limit. In each vote a single faulty sensor is
+identified by comparing each measurement against the full-sensor average, and the remaining two
+sensors are averaged to form the best estimate. Because the votes are independent, an IMU may be
+valid on one quantity but rejected on the other.
+The module outputs the best-estimate averages, per-IMU validity arrays, and the per-sensor
+difference magnitudes for both quantities — providing downstream fault management with the
+information needed to take further action.
 
 -------------------------------
 Module Input/Output Messages
@@ -34,22 +36,28 @@ The following table lists the Xmera message connections for the ``MimuMajorityVo
         per sensor and added via ``addImuInput()``.
     * - ``imuSensorBodyOutMsg``
       - :ref:`IMUSensorBodyMsgF32Payload`
-      - Output message containing the majority-voted angular velocity estimate in the
-        spacecraft body frame (``AngVelBody``).
+      - Output message containing the majority-voted angular velocity (``AngVelBody``) and
+        apparent acceleration (``AccelBody``) estimates in the spacecraft body frame.
     * - ``mimuFaultMsg``
       - :ref:`MimuFaultMsgPayload`
-      - Output message containing fault status, per-IMU validity flags
-        (``validImus[3]``), and per-IMU difference magnitudes
-        (``omegaDifferencesMag[3]``).
+      - Output message containing the gyro and accel fault status (``gyroFaultDetected`` /
+        ``accelFaultDetected``), per-IMU validity flags (``gyroImuValid[3]`` /
+        ``accelImuValid[3]``), and per-IMU difference magnitudes (``gyroImuDifferenceMag[3]`` /
+        ``accelImuDifferenceMag[3]``).
 
 ----------------------------
 Algorithm Description
 ----------------------------
 
-The voting algorithm operates on :math:`n = 3` IMU measurements
-:math:`\boldsymbol{\omega}_i \in \mathbb{R}^3` (body-frame angular velocity, rad/s),
-a scalar threshold :math:`T > 0` (rad/s), and a persistence limit :math:`P \geq 1`
-(number of consecutive detections required to trigger a fault).
+The same majority vote runs **independently** on two quantities: the angular velocity
+(``omegaThreshold`` / ``gyroFaultPersistenceLimit``) and the apparent acceleration
+(``accelThreshold`` / ``accelFaultPersistenceLimit``). Each vote keeps its own persistence counters,
+so the two faults are decided separately. The description below is written for a generic measurement
+:math:`\boldsymbol{m}_i \in \mathbb{R}^3` and applies to each quantity in turn.
+
+The vote operates on :math:`n = 3` IMU measurements :math:`\boldsymbol{m}_i`, a scalar threshold
+:math:`T > 0`, and a persistence limit :math:`P \geq 1` (number of consecutive detections required
+to trigger a fault).
 
 **Outlier detection and averaging**
 
@@ -57,13 +65,13 @@ Compute the average of all :math:`n` measurements:
 
 .. math::
 
-   \bar{\boldsymbol{\omega}} = \frac{1}{n} \sum_{i=0}^{n-1} \boldsymbol{\omega}_i
+   \bar{\boldsymbol{m}} = \frac{1}{n} \sum_{i=0}^{n-1} \boldsymbol{m}_i
 
 Compute the Euclidean distance of each measurement from the full average:
 
 .. math::
 
-   \delta_i = \lVert \boldsymbol{\omega}_i - \bar{\boldsymbol{\omega}} \rVert_2, \quad i = 0, \ldots, n-1
+   \delta_i = \lVert \boldsymbol{m}_i - \bar{\boldsymbol{m}} \rVert_2, \quad i = 0, \ldots, n-1
 
 Identify the worst offender:
 
@@ -78,19 +86,19 @@ Each IMU maintains an independent consecutive-detection counter :math:`c_i`. Eac
 - If :math:`\delta_k \geq T`, increment :math:`c_k`; reset all other :math:`c_i` to zero.
 - If :math:`\delta_k < T`, reset all :math:`c_i` to zero.
 
-IMU :math:`i` is marked invalid when :math:`c_i \geq P`. Once marked invalid, it is
+IMU :math:`i` is marked invalid when :math:`c_i \geq P`. While it is marked invalid it is
 excluded from the output average:
 
 .. math::
 
-   \bar{\boldsymbol{\omega}}_2 = \frac{1}{n-1} \sum_{i \,:\, c_i < P} \boldsymbol{\omega}_i
+   \bar{\boldsymbol{m}}_2 = \frac{1}{n-1} \sum_{i \,:\, c_i < P} \boldsymbol{m}_i
 
-If no IMU is invalid, :math:`\bar{\boldsymbol{\omega}}` is returned directly.
+If no IMU is invalid, :math:`\bar{\boldsymbol{m}}` is returned directly.
 
 **Difference magnitudes in the output**
 
-The ``omegaDifferencesMag`` array is always populated with the values
-:math:`\delta_i` for all sensors.
+Each vote's difference array (``gyro.imuDifferenceMag`` for the gyro, ``accel.imuDifferenceMag`` for
+the accel) is always populated with the values :math:`\delta_i` for all sensors.
 
 **Valid-count invariant**
 
@@ -113,8 +121,10 @@ Standalone Algorithm (C++ API)
       - Description
     * - ``imuOmegas_BN_B``
       - ``std::array<Eigen::Vector3f, kMimuCount>``
-      - Array of exactly 3 IMU angular velocity measurements
-        (:math:`\boldsymbol{\omega}_i`, rad/s).
+      - Array of exactly 3 IMU angular velocity measurements (rad/s).
+    * - ``imuAccels_B``
+      - ``std::array<Eigen::Vector3f, kMimuCount>``
+      - Array of exactly 3 IMU apparent acceleration measurements (m/s²).
 
 **Output** ``MimuMajorityVoteOutput``
 
@@ -125,46 +135,50 @@ Standalone Algorithm (C++ API)
     * - Field
       - Type
       - Description
-    * - ``avgOmega_BN_B``
+    * - ``gyro`` / ``accel``
+      - ``MimuVoteResult``
+      - Independent vote result for the angular velocity / apparent acceleration. Each bundles the
+        four fields below.
+    * - ``gyro.average`` / ``accel.average``
       - ``Eigen::Vector3f``
-      - Best-estimate body-frame angular velocity (rad/s). Equals
-        :math:`\bar{\boldsymbol{\omega}}` when all agree, or
-        :math:`\bar{\boldsymbol{\omega}}_2` when one is invalid.
-    * - ``faultDetected``
+      - Best-estimate body-frame angular velocity (rad/s) / apparent acceleration (m/s²). Equals the
+        full average when all agree, or the 2-sensor average when one is invalid.
+    * - ``gyro.faultDetected`` / ``accel.faultDetected``
       - ``bool``
-      - ``true`` if any IMU has been marked invalid.
-    * - ``omegaDifferencesMag``
+      - ``true`` if any IMU has been marked invalid for that quantity's vote.
+    * - ``gyro.imuDifferenceMag`` / ``accel.imuDifferenceMag``
       - ``std::array<float, kMimuCount>``
-      - Per-IMU difference magnitude (rad/s) as described above. Always populated.
-    * - ``validImus``
+      - Per-IMU difference magnitude (rad/s / m/s²) as described above. Always populated.
+    * - ``gyro.imuValid`` / ``accel.imuValid``
       - ``std::array<bool, kMimuCount>``
-      - Per-IMU validity flag. ``true`` means the sensor is trusted.
+      - Per-IMU validity flag for that quantity's vote. ``true`` means the sensor is trusted.
 
 **Configuration**
 
-The detection threshold is set via ``setOmegaThreshold()`` / ``getOmegaThreshold()``.
-The threshold must be strictly positive; a zero or negative value throws ``fsw::invalid_argument``.
+Configuration is supplied as an immutable ``MimuMajorityVoteConfig``, built via the validating
+factory ``MimuMajorityVoteConfig::create(omegaThreshold, gyroFaultPersistenceLimit, accelThreshold,
+accelFaultPersistenceLimit)``:
 
-The fault persistence limit is set via ``setFaultPersistenceLimit()`` / ``getFaultPersistenceLimit()``.
-It must be at least 1 (default); zero throws ``fsw::invalid_argument``. A value of 1
-triggers the fault immediately on first detection.
+- ``omegaThreshold`` (rad/s) and ``accelThreshold`` (m/s²) must be finite and strictly positive.
+- ``gyroFaultPersistenceLimit`` and ``accelFaultPersistenceLimit`` must be strictly positive; a value
+  of 1 triggers that vote's fault immediately on first detection.
+
+``create()`` throws ``fsw::invalid_argument`` on any invalid parameter. Constructing the algorithm
+from a config validates and arms it; ``reInitialize()`` clears both votes' persistence counters.
 
 .. code-block:: cpp
 
-    MimuMajorityVoteAlgorithm alg{};
-    alg.setOmegaThreshold(0.05F);        // rad/s
-    alg.setFaultPersistenceLimit(3U);    // require 3 consecutive detections
+    // omega threshold 0.05 rad/s (3 detections), accel threshold 0.5 m/s² (1 detection)
+    MimuMajorityVoteAlgorithm alg{MimuMajorityVoteConfig::create(0.05F, 3U, 0.5F, 1U)};
 
-    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{};
-    imuOmegas_BN_B.at(0) = omega0;
-    imuOmegas_BN_B.at(1) = omega1;
-    imuOmegas_BN_B.at(2) = omega2;
+    std::array<Eigen::Vector3f, kMimuCount> imuOmegas_BN_B{omega0, omega1, omega2};
+    std::array<Eigen::Vector3f, kMimuCount> imuAccels_B{accel0, accel1, accel2};
 
-    MimuMajorityVoteOutput out = alg.update(imuOmegas_BN_B);
-    // out.avgOmega_BN_B  — best-estimate rate
-    // out.faultDetected  — true if any IMU was rejected
-    // out.validImus      — per-sensor validity flags
-    // out.omegaDifferencesMag — per-sensor residuals
+    MimuMajorityVoteOutput out = alg.update(imuOmegas_BN_B, imuAccels_B);
+    // out.gyro.average / out.accel.average             — best-estimate rate / acceleration
+    // out.gyro.faultDetected / out.accel.faultDetected — true if an IMU was rejected for that vote
+    // out.gyro.imuValid / out.accel.imuValid           — per-sensor validity flags per vote
+    // out.gyro.imuDifferenceMag / out.accel.imuDifferenceMag — per-sensor residuals per vote
 
 -----------------------------------
 Module Assumptions and Limitations
@@ -172,7 +186,7 @@ Module Assumptions and Limitations
 
 - Exactly ``kMimuCount`` (3) ``addImuInput()`` calls must be made before ``reset()``;
   any other count throws ``std::invalid_argument``. Attempting to add more than
-  ``kMimuCount`` IMUs throws ``fsw::invalid_argument``.
+  ``kMimuCount`` IMUs throws ``std::invalid_argument``.
 - The threshold :math:`T` must be chosen to be meaningfully larger than the float32
   rounding error in the average computation (~3 × :math:`\varepsilon_\text{mach}` ×
   :math:`|\boldsymbol{\omega}|`). For angular rates up to 1000 rad/s this is
@@ -181,9 +195,12 @@ Module Assumptions and Limitations
   algorithm rejects the one with the lower array index. The returned average therefore
   depends on sensor ordering when ties occur; however, the fault detection outcome and
   invalid count are index-order independent.
-- The module does not perform sensor health monitoring over time or persist fault
-  history between update cycles. Each call to ``update()`` is stateless with respect
-  to fault detection.
+- Fault detection is **not** stateless: each vote carries a per-IMU consecutive-detection
+  counter across ``update()`` calls. The counters are cleared by ``reInitialize()`` and by
+  nothing else, so a caller that changes the configuration must decide whether the counts
+  accumulated under the old thresholds should carry over.
+- A fault does not latch. The counters are re-evaluated every cycle, so an IMU whose
+  difference falls back below the threshold for a single update is immediately revalidated.
 
 ----------
 User Guide
@@ -194,8 +211,11 @@ The Xmera module is instantiated and configured from Python as follows::
     module = mimuMajorityVoteF32.MimuMajorityVote()
     module.modelTag = "mimuMajorityVote"
 
-    # Set the detection threshold (rad/s)
-    module.omegaThreshold = omegaThresholdRadPerSec
+    # Set the detection parameters (validated when the module is reset)
+    module.omegaThreshold = omegaThresholdRadPerSec   # rad/s, must be > 0
+    module.gyroFaultPersistenceLimit = 3              # must be >= 1
+    module.accelThreshold = accelThresholdMPerSec2    # m/s^2, must be > 0
+    module.accelFaultPersistenceLimit = 1             # must be >= 1
 
     # Connect exactly 3 ImuMessage objects
     for imu_msg in imu_input_messages:  # must have exactly 3 entries
@@ -205,10 +225,17 @@ The Xmera module is instantiated and configured from Python as follows::
 
     scSim.AddModelToTask(taskName, module)
 
-The voted angular velocity is available on ``module.imuSensorBodyOutMsg`` and the
-fault status on ``module.mimuFaultMsg``. The ``mimuFaultMsg`` payload fields are:
+``reset()`` builds the validated configuration from the public parameters (raising
+``fsw::invalid_argument`` if a parameter is invalid) and constructs the algorithm. ``reconfigure()``
+re-applies the current public parameters to the running algorithm, and ``reInitialize()`` clears both
+votes' persistence counters.
 
-- ``faultDetected`` — ``bool``, mirrors ``MimuMajorityVoteOutput.faultDetected``.
-- ``validImus[3]`` — per-IMU validity flags; index matches the order sensors were
-  added via ``addImuInput()``.
-- ``omegaDifferencesMag[3]`` — per-IMU difference magnitude (rad/s); same ordering.
+The voted angular velocity (``AngVelBody``) and acceleration (``AccelBody``) are available on
+``module.imuSensorBodyOutMsg`` and the fault status on ``module.mimuFaultMsg``. The ``mimuFaultMsg``
+payload fields are:
+
+- ``gyroFaultDetected`` / ``accelFaultDetected`` — ``bool`` per vote.
+- ``gyroImuValid[3]`` / ``accelImuValid[3]`` — per-IMU validity flags per vote; index matches the
+  order sensors were added via ``addImuInput()``.
+- ``gyroImuDifferenceMag[3]`` (rad/s) / ``accelImuDifferenceMag[3]`` (m/s²) — per-IMU difference
+  magnitudes per vote; same ordering.

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
@@ -1,9 +1,10 @@
 #include "mimuMajorityVoteAlgorithm.h"
 
-#include "utilities/fsw/eigenSupport.h"
-#include "utilities/fsw/freestandingInvalidArgument.h"
+MimuMajorityVoteAlgorithm::MimuMajorityVoteAlgorithm(const MimuMajorityVoteConfig& config) : cfg(config) {}
 
-void MimuMajorityVoteAlgorithm::reset() { this->faultPersistenceCount.fill(0U); }
+void MimuMajorityVoteAlgorithm::setConfig(const MimuMajorityVoteConfig& config) { this->cfg = config; }
+
+void MimuMajorityVoteAlgorithm::reInitialize() { this->faultPersistenceCount.fill(0U); }
 
 MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
     const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B) {
@@ -26,11 +27,11 @@ MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
 
     // Update persistence counter for the worst outlier
     bool faultDetected = false;
-    if (output.omegaDifferencesMag.at(maxDiffIndex) >= this->omegaThreshold) {
+    if (output.omegaDifferencesMag.at(maxDiffIndex) >= this->cfg.getOmegaThreshold()) {
         ++this->faultPersistenceCount.at(maxDiffIndex);
 
         // Determine if the outlier has persisted long enough to be faulted
-        if (this->faultPersistenceCount.at(maxDiffIndex) >= this->faultPersistenceLimit) {
+        if (this->faultPersistenceCount.at(maxDiffIndex) >= this->cfg.getFaultPersistenceLimit()) {
             faultDetected = true;
             output.validImus.at(maxDiffIndex) = false;
         }
@@ -57,21 +58,3 @@ MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
 
     return output;
 }
-
-void MimuMajorityVoteAlgorithm::setOmegaThreshold(const float omegaThresholdIn) {
-    if (omegaThresholdIn <= 0.0F) {
-        FSW_THROW_INVALID_ARGUMENT("Zero or negative omegaThreshold is not valid");
-    }
-    this->omegaThreshold = omegaThresholdIn;
-}
-
-float MimuMajorityVoteAlgorithm::getOmegaThreshold() const { return this->omegaThreshold; }
-
-void MimuMajorityVoteAlgorithm::setFaultPersistenceLimit(const uint32_t faultPersistenceLimitIn) {
-    if (faultPersistenceLimitIn <= 0U) {
-        FSW_THROW_INVALID_ARGUMENT("faultPersistenceLimit must be at least 1");
-    }
-    this->faultPersistenceLimit = faultPersistenceLimitIn;
-}
-
-uint32_t MimuMajorityVoteAlgorithm::getFaultPersistenceLimit() const { return this->faultPersistenceLimit; }

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
@@ -4,7 +4,7 @@ MimuMajorityVoteAlgorithm::MimuMajorityVoteAlgorithm(const MimuMajorityVoteConfi
 
 void MimuMajorityVoteAlgorithm::setConfig(const MimuMajorityVoteConfig& config) { this->cfg = config; }
 
-void MimuMajorityVoteAlgorithm::reInitialize() { this->faultPersistenceCount.fill(0U); }
+void MimuMajorityVoteAlgorithm::reInitialize() { this->gyroFaultPersistenceCount.fill(0U); }
 
 MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
     const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B) {
@@ -28,21 +28,21 @@ MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
     // Update persistence counter for the worst outlier
     bool faultDetected = false;
     if (output.omegaDifferencesMag.at(maxDiffIndex) >= this->cfg.getOmegaThreshold()) {
-        ++this->faultPersistenceCount.at(maxDiffIndex);
+        ++this->gyroFaultPersistenceCount.at(maxDiffIndex);
 
         // Determine if the outlier has persisted long enough to be faulted
-        if (this->faultPersistenceCount.at(maxDiffIndex) >= this->cfg.getFaultPersistenceLimit()) {
+        if (this->gyroFaultPersistenceCount.at(maxDiffIndex) >= this->cfg.getGyroFaultPersistenceLimit()) {
             faultDetected = true;
             output.validImus.at(maxDiffIndex) = false;
         }
     } else {
-        this->faultPersistenceCount.at(maxDiffIndex) = 0U;
+        this->gyroFaultPersistenceCount.at(maxDiffIndex) = 0U;
     }
 
     // Reset counters for non-outlier IMUs
     for (size_t i = 0U; i < kMimuCount; ++i) {
         if (i != maxDiffIndex) {
-            this->faultPersistenceCount.at(i) = 0U;
+            this->gyroFaultPersistenceCount.at(i) = 0U;
         }
     }
 

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.cpp
@@ -4,57 +4,84 @@ MimuMajorityVoteAlgorithm::MimuMajorityVoteAlgorithm(const MimuMajorityVoteConfi
 
 void MimuMajorityVoteAlgorithm::setConfig(const MimuMajorityVoteConfig& config) { this->cfg = config; }
 
-void MimuMajorityVoteAlgorithm::reInitialize() { this->gyroFaultPersistenceCount.fill(0U); }
+void MimuMajorityVoteAlgorithm::reInitialize() {
+    this->gyroFaultPersistenceCount.fill(0U);
+    this->accelFaultPersistenceCount.fill(0U);
+}
 
-MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(
-    const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B) {
+/*! Runs the IMU majority vote on one measured quantity: averages the measurements, finds the worst
+ outlier, advances its persistence counter when it exceeds the threshold, and once the counter
+ reaches the persistence limit rejects that IMU and re-averages the remaining ones. The
+ persistenceCount array carries over between calls and is updated in place. */
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+MimuVoteResult MimuMajorityVoteAlgorithm::majorityVote(const std::array<Eigen::Vector3f, kMimuCount>& measurements,
+                                                       float threshold,
+                                                       uint32_t persistenceLimit,
+                                                       std::array<uint32_t, kMimuCount>& persistenceCount) {
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     // Stage 1: Compute average of all IMUs and find differences from average
-    Eigen::Vector3f omegaAverage_BN_B = Eigen::Vector3f::Zero();
+    Eigen::Vector3f average = Eigen::Vector3f::Zero();
     for (size_t i = 0U; i < kMimuCount; ++i) {
-        omegaAverage_BN_B += imuOmegas_BN_B.at(i);
+        average += measurements.at(i);
     }
-    omegaAverage_BN_B /= static_cast<float>(kMimuCount);
+    average /= static_cast<float>(kMimuCount);
 
-    MimuMajorityVoteOutput output{};
-    output.validImus.fill(true);
+    MimuVoteResult result{};
+    result.imuValid.fill(true);
     size_t maxDiffIndex = 0U;
     for (size_t i = 0U; i < kMimuCount; ++i) {
-        output.omegaDifferencesMag.at(i) = (imuOmegas_BN_B.at(i) - omegaAverage_BN_B).norm();
-        if (output.omegaDifferencesMag.at(i) > output.omegaDifferencesMag.at(maxDiffIndex)) {
+        result.imuDifferenceMag.at(i) = (measurements.at(i) - average).norm();
+        if (result.imuDifferenceMag.at(i) > result.imuDifferenceMag.at(maxDiffIndex)) {
             maxDiffIndex = i;
         }
     }
 
     // Update persistence counter for the worst outlier
     bool faultDetected = false;
-    if (output.omegaDifferencesMag.at(maxDiffIndex) >= this->cfg.getOmegaThreshold()) {
-        ++this->gyroFaultPersistenceCount.at(maxDiffIndex);
+    if (result.imuDifferenceMag.at(maxDiffIndex) >= threshold) {
+        ++persistenceCount.at(maxDiffIndex);
 
         // Determine if the outlier has persisted long enough to be faulted
-        if (this->gyroFaultPersistenceCount.at(maxDiffIndex) >= this->cfg.getGyroFaultPersistenceLimit()) {
+        if (persistenceCount.at(maxDiffIndex) >= persistenceLimit) {
             faultDetected = true;
-            output.validImus.at(maxDiffIndex) = false;
+            result.imuValid.at(maxDiffIndex) = false;
         }
     } else {
-        this->gyroFaultPersistenceCount.at(maxDiffIndex) = 0U;
+        persistenceCount.at(maxDiffIndex) = 0U;
     }
 
     // Reset counters for non-outlier IMUs
     for (size_t i = 0U; i < kMimuCount; ++i) {
         if (i != maxDiffIndex) {
-            this->gyroFaultPersistenceCount.at(i) = 0U;
+            persistenceCount.at(i) = 0U;
         }
     }
 
     if (!faultDetected) {
         // No persisted fault - return full average
-        output.avgOmega_BN_B = omegaAverage_BN_B;
+        result.average = average;
     } else {
         // Outlier persisted - exclude it and average the remaining IMUs
-        output.faultDetected = true;
-        output.avgOmega_BN_B = (omegaAverage_BN_B * static_cast<float>(kMimuCount) - imuOmegas_BN_B.at(maxDiffIndex)) /
-                               static_cast<float>(kMimuCount - 1U);
+        result.faultDetected = true;
+        result.average = (average * static_cast<float>(kMimuCount) - measurements.at(maxDiffIndex)) /
+                         static_cast<float>(kMimuCount - 1U);
     }
 
+    return result;
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+MimuMajorityVoteOutput MimuMajorityVoteAlgorithm::update(const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B,
+                                                         const std::array<Eigen::Vector3f, kMimuCount>& imuAccels_B) {
+    // Independent majority votes on the gyro (angular velocity) and accelerometer measurements.
+    MimuMajorityVoteOutput output{};
+    output.gyro = majorityVote(imuOmegas_BN_B,
+                               this->cfg.getOmegaThreshold(),
+                               this->cfg.getGyroFaultPersistenceLimit(),
+                               this->gyroFaultPersistenceCount);
+    output.accel = majorityVote(imuAccels_B,
+                                this->cfg.getAccelThreshold(),
+                                this->cfg.getAccelFaultPersistenceLimit(),
+                                this->accelFaultPersistenceCount);
     return output;
 }

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
@@ -1,11 +1,18 @@
 #ifndef MIMU_MAJORITY_VOTE_ALGORITHM
 #define MIMU_MAJORITY_VOTE_ALGORITHM
 
-#include <Eigen/Core>
-#include <array>
-
 #include "mimuMajorityVoteTypes.h"
 #include "msgPayloadDef/definitions.h"
+#include "utilities/fsw/freestandingInvalidArgument.h"
+#include "utilities/fsw/freestandingIsFinite.hpp"
+
+#include <Eigen/Core>
+#include <array>
+#include <cstdint>
+
+// kMimuCount (definitions.h, C++) and MIMU_COUNT_C (mimuMajorityVoteTypes.h, pure C) are independent
+// declarations of the IMU count; keep them pinned equal.
+static_assert(kMimuCount == MIMU_COUNT_C, "MIMU count mismatch between definitions.h and mimuMajorityVoteTypes.h");
 
 /*! @brief Output from the MIMU majority vote algorithm */
 struct MimuMajorityVoteOutput {
@@ -16,20 +23,51 @@ struct MimuMajorityVoteOutput {
     std::array<bool, kMimuCount> validImus{}; /*!< Whether each IMU is considered valid */
 };
 
-/*!@brief Module to compute the majority vote of the mimus. */
-class MimuMajorityVoteAlgorithm {
+/*!
+ * @brief Validated configuration for the MIMU majority vote algorithm.
+ *
+ * An instance can only exist with a finite, strictly positive omega threshold and a strictly
+ * positive fault persistence limit. Construct via MimuMajorityVoteConfig::create(...).
+ */
+class MimuMajorityVoteConfig final {
    public:
-    MimuMajorityVoteOutput update(const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B);
-    void reset();                                                     //!< Reset fault persistence counters to zero
-    void setOmegaThreshold(float omegaThresholdIn);                   //!< Setter method for omegaThreshold
-    float getOmegaThreshold() const;                                  //!< Getter method for omegaThreshold
-    void setFaultPersistenceLimit(uint32_t faultPersistenceLimitIn);  //!< Setter method for faultPersistenceLimit
-    uint32_t getFaultPersistenceLimit() const;                        //!< Getter method for faultPersistenceLimit
+    static MimuMajorityVoteConfig create(float omegaThreshold, uint32_t faultPersistenceLimit) {
+        if (!isValidOmegaThreshold(omegaThreshold)) {
+            FSW_THROW_INVALID_ARGUMENT("mimuMajorityVote: omegaThreshold must be finite and > 0");
+        }
+        if (!isValidFaultPersistenceLimit(faultPersistenceLimit)) {
+            FSW_THROW_INVALID_ARGUMENT("mimuMajorityVote: faultPersistenceLimit must be > 0");
+        }
+        return {omegaThreshold, faultPersistenceLimit};
+    }
+
+    static bool isValidOmegaThreshold(float omegaThreshold) {
+        return fsw::is_finite(omegaThreshold) && omegaThreshold > 0.0F;
+    }
+    static bool isValidFaultPersistenceLimit(uint32_t faultPersistenceLimit) { return faultPersistenceLimit > 0U; }
+
+    float getOmegaThreshold() const { return omegaThreshold; }
+    uint32_t getFaultPersistenceLimit() const { return faultPersistenceLimit; }
 
    private:
-    float omegaThreshold = 1.0F;          //!< Threshold to determine if a MIMU is faulted (rad/s)
-    uint32_t faultPersistenceLimit = 1U;  //!< Number of consecutive faults needed to trigger faultDetected
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    MimuMajorityVoteConfig(float omegaThreshold, uint32_t faultPersistenceLimit)
+        : omegaThreshold(omegaThreshold), faultPersistenceLimit(faultPersistenceLimit) {}
 
+    float omegaThreshold;
+    uint32_t faultPersistenceLimit;
+};
+
+/*!@brief Module to compute the majority vote of the mimus. */
+class MimuMajorityVoteAlgorithm final {
+   public:
+    explicit MimuMajorityVoteAlgorithm(const MimuMajorityVoteConfig& config);
+    void setConfig(const MimuMajorityVoteConfig& config);  //!< Install configuration parameters
+    void reInitialize();                                   //!< Reset fault persistence counters to zero
+    MimuMajorityVoteOutput update(const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B);
+
+   private:
+    MimuMajorityVoteConfig cfg;
     std::array<uint32_t, kMimuCount> faultPersistenceCount{};
 };
 

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
@@ -31,31 +31,33 @@ struct MimuMajorityVoteOutput {
  */
 class MimuMajorityVoteConfig final {
    public:
-    static MimuMajorityVoteConfig create(float omegaThreshold, uint32_t faultPersistenceLimit) {
+    static MimuMajorityVoteConfig create(float omegaThreshold, uint32_t gyroFaultPersistenceLimit) {
         if (!isValidOmegaThreshold(omegaThreshold)) {
             FSW_THROW_INVALID_ARGUMENT("mimuMajorityVote: omegaThreshold must be finite and > 0");
         }
-        if (!isValidFaultPersistenceLimit(faultPersistenceLimit)) {
-            FSW_THROW_INVALID_ARGUMENT("mimuMajorityVote: faultPersistenceLimit must be > 0");
+        if (!isValidGyroFaultPersistenceLimit(gyroFaultPersistenceLimit)) {
+            FSW_THROW_INVALID_ARGUMENT("mimuMajorityVote: gyroFaultPersistenceLimit must be > 0");
         }
-        return {omegaThreshold, faultPersistenceLimit};
+        return {omegaThreshold, gyroFaultPersistenceLimit};
     }
 
     static bool isValidOmegaThreshold(float omegaThreshold) {
         return fsw::is_finite(omegaThreshold) && omegaThreshold > 0.0F;
     }
-    static bool isValidFaultPersistenceLimit(uint32_t faultPersistenceLimit) { return faultPersistenceLimit > 0U; }
+    static bool isValidGyroFaultPersistenceLimit(uint32_t gyroFaultPersistenceLimit) {
+        return gyroFaultPersistenceLimit > 0U;
+    }
 
     float getOmegaThreshold() const { return omegaThreshold; }
-    uint32_t getFaultPersistenceLimit() const { return faultPersistenceLimit; }
+    uint32_t getGyroFaultPersistenceLimit() const { return gyroFaultPersistenceLimit; }
 
    private:
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-    MimuMajorityVoteConfig(float omegaThreshold, uint32_t faultPersistenceLimit)
-        : omegaThreshold(omegaThreshold), faultPersistenceLimit(faultPersistenceLimit) {}
+    MimuMajorityVoteConfig(float omegaThreshold, uint32_t gyroFaultPersistenceLimit)
+        : omegaThreshold(omegaThreshold), gyroFaultPersistenceLimit(gyroFaultPersistenceLimit) {}
 
     float omegaThreshold;
-    uint32_t faultPersistenceLimit;
+    uint32_t gyroFaultPersistenceLimit;
 };
 
 /*!@brief Module to compute the majority vote of the mimus. */
@@ -68,7 +70,7 @@ class MimuMajorityVoteAlgorithm final {
 
    private:
     MimuMajorityVoteConfig cfg;
-    std::array<uint32_t, kMimuCount> faultPersistenceCount{};
+    std::array<uint32_t, kMimuCount> gyroFaultPersistenceCount{};
 };
 
 #endif

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm.h
@@ -14,31 +14,46 @@
 // declarations of the IMU count; keep them pinned equal.
 static_assert(kMimuCount == MIMU_COUNT_C, "MIMU count mismatch between definitions.h and mimuMajorityVoteTypes.h");
 
-/*! @brief Output from the MIMU majority vote algorithm */
+/*! @brief Result of one majority vote over the kMimuCount IMU measurements of a single quantity. */
+struct MimuVoteResult {
+    Eigen::Vector3f average{}; /*!< Averaged measurement (outlier-excluded once a fault persists) */
+    bool faultDetected{};      /*!< Whether an IMU was rejected for this quantity */
+    std::array<float, kMimuCount> imuDifferenceMag{}; /*!< Each IMU's difference magnitude from the 3-IMU average */
+    std::array<bool, kMimuCount> imuValid{};          /*!< Whether each IMU is considered valid for this quantity */
+};
+
+/*! @brief Output from the MIMU majority vote algorithm: independent gyro and accel votes. */
 struct MimuMajorityVoteOutput {
-    Eigen::Vector3f avgOmega_BN_B{}; /*!< [rad/s] Averaged angular velocity in body frame */
-    bool faultDetected{};            /*!< Whether a MIMU fault was detected */
-    std::array<float, kMimuCount>
-        omegaDifferencesMag{};                /*!< [rad/s] Each IMU's difference magnitude from the 3-IMU average */
-    std::array<bool, kMimuCount> validImus{}; /*!< Whether each IMU is considered valid */
+    MimuVoteResult gyro;  /*!< [rad/s] Angular-velocity vote; gyro.average is in the body frame */
+    MimuVoteResult accel; /*!< [m/s^2] Acceleration vote; accel.average is in the body frame */
 };
 
 /*!
  * @brief Validated configuration for the MIMU majority vote algorithm.
  *
- * An instance can only exist with a finite, strictly positive omega threshold and a strictly
- * positive fault persistence limit. Construct via MimuMajorityVoteConfig::create(...).
+ * An instance can only exist with finite, strictly positive gyro and accel thresholds and strictly
+ * positive gyro and accel fault persistence limits. Construct via MimuMajorityVoteConfig::create(...).
  */
 class MimuMajorityVoteConfig final {
    public:
-    static MimuMajorityVoteConfig create(float omegaThreshold, uint32_t gyroFaultPersistenceLimit) {
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    static MimuMajorityVoteConfig create(float omegaThreshold,
+                                         uint32_t gyroFaultPersistenceLimit,
+                                         float accelThreshold,
+                                         uint32_t accelFaultPersistenceLimit) {
         if (!isValidOmegaThreshold(omegaThreshold)) {
             FSW_THROW_INVALID_ARGUMENT("mimuMajorityVote: omegaThreshold must be finite and > 0");
         }
         if (!isValidGyroFaultPersistenceLimit(gyroFaultPersistenceLimit)) {
             FSW_THROW_INVALID_ARGUMENT("mimuMajorityVote: gyroFaultPersistenceLimit must be > 0");
         }
-        return {omegaThreshold, gyroFaultPersistenceLimit};
+        if (!isValidAccelThreshold(accelThreshold)) {
+            FSW_THROW_INVALID_ARGUMENT("mimuMajorityVote: accelThreshold must be finite and > 0");
+        }
+        if (!isValidAccelFaultPersistenceLimit(accelFaultPersistenceLimit)) {
+            FSW_THROW_INVALID_ARGUMENT("mimuMajorityVote: accelFaultPersistenceLimit must be > 0");
+        }
+        return {omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit};
     }
 
     static bool isValidOmegaThreshold(float omegaThreshold) {
@@ -47,17 +62,33 @@ class MimuMajorityVoteConfig final {
     static bool isValidGyroFaultPersistenceLimit(uint32_t gyroFaultPersistenceLimit) {
         return gyroFaultPersistenceLimit > 0U;
     }
+    static bool isValidAccelThreshold(float accelThreshold) {
+        return fsw::is_finite(accelThreshold) && accelThreshold > 0.0F;
+    }
+    static bool isValidAccelFaultPersistenceLimit(uint32_t accelFaultPersistenceLimit) {
+        return accelFaultPersistenceLimit > 0U;
+    }
 
     float getOmegaThreshold() const { return omegaThreshold; }
     uint32_t getGyroFaultPersistenceLimit() const { return gyroFaultPersistenceLimit; }
+    float getAccelThreshold() const { return accelThreshold; }
+    uint32_t getAccelFaultPersistenceLimit() const { return accelFaultPersistenceLimit; }
 
    private:
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-    MimuMajorityVoteConfig(float omegaThreshold, uint32_t gyroFaultPersistenceLimit)
-        : omegaThreshold(omegaThreshold), gyroFaultPersistenceLimit(gyroFaultPersistenceLimit) {}
+    MimuMajorityVoteConfig(float omegaThreshold,
+                           uint32_t gyroFaultPersistenceLimit,
+                           float accelThreshold,
+                           uint32_t accelFaultPersistenceLimit)
+        : omegaThreshold(omegaThreshold),
+          gyroFaultPersistenceLimit(gyroFaultPersistenceLimit),
+          accelThreshold(accelThreshold),
+          accelFaultPersistenceLimit(accelFaultPersistenceLimit) {}
 
     float omegaThreshold;
     uint32_t gyroFaultPersistenceLimit;
+    float accelThreshold;
+    uint32_t accelFaultPersistenceLimit;
 };
 
 /*!@brief Module to compute the majority vote of the mimus. */
@@ -65,12 +96,23 @@ class MimuMajorityVoteAlgorithm final {
    public:
     explicit MimuMajorityVoteAlgorithm(const MimuMajorityVoteConfig& config);
     void setConfig(const MimuMajorityVoteConfig& config);  //!< Install configuration parameters
-    void reInitialize();                                   //!< Reset fault persistence counters to zero
-    MimuMajorityVoteOutput update(const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B);
+    void reInitialize();                                   //!< Reset gyro and accel persistence counters to zero
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    MimuMajorityVoteOutput update(const std::array<Eigen::Vector3f, kMimuCount>& imuOmegas_BN_B,
+                                  const std::array<Eigen::Vector3f, kMimuCount>& imuAccels_B);
 
    private:
+    //! Runs the IMU majority vote on one measured quantity (see definition for details).
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+    static MimuVoteResult majorityVote(const std::array<Eigen::Vector3f, kMimuCount>& measurements,
+                                       float threshold,
+                                       uint32_t persistenceLimit,
+                                       std::array<uint32_t, kMimuCount>& persistenceCount);
+    // NOLINTEND(bugprone-easily-swappable-parameters)
+
     MimuMajorityVoteConfig cfg;
     std::array<uint32_t, kMimuCount> gyroFaultPersistenceCount{};
+    std::array<uint32_t, kMimuCount> accelFaultPersistenceCount{};
 };
 
 #endif

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
@@ -2,11 +2,20 @@
 #include "mimuMajorityVoteAlgorithm.h"
 #include "mimuMajorityVoteTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/freestandingInvalidArgument.h"
 #include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
 namespace {
+MimuMajorityVoteConfig configFromC(const float omegaThreshold,
+                                   const uint32_t gyroFaultPersistenceLimit,
+                                   const float accelThreshold,
+                                   const uint32_t accelFaultPersistenceLimit) {
+    return MimuMajorityVoteConfig::create(
+        omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit);
+}
+
 std::array<Eigen::Vector3f, MIMU_COUNT_C> toEigenArray(const Vector3fArray3_c& in) {
     std::array<Eigen::Vector3f, MIMU_COUNT_C> out{};
     for (uint32_t i = 0; i < MIMU_COUNT_C; ++i) {
@@ -30,26 +39,26 @@ MimuVoteResult_c toResultC(const MimuVoteResult& result) {
 
 uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void) { return MIMU_COUNT_C; }
 
-bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold,
-                                              uint32_t gyroFaultPersistenceLimit,
-                                              float accelThreshold,
-                                              uint32_t accelFaultPersistenceLimit) {
+bool MimuMajorityVoteAlgorithm_validateConfig(const float omegaThreshold,
+                                              const uint32_t gyroFaultPersistenceLimit,
+                                              const float accelThreshold,
+                                              const uint32_t accelFaultPersistenceLimit) {
+    // Attempt to build the config through the real create path; success means valid,
+    // a throw means invalid. Reusing configFromC keeps validation from drifting.
     try {
-        (void)MimuMajorityVoteConfig::create(
-            omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit);
+        (void)configFromC(omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit);
         return true;
     } catch (const fsw::invalid_argument&) {
         return false;
     }
 }
 
-MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(float omegaThreshold,
-                                                                  uint32_t gyroFaultPersistenceLimit,
-                                                                  float accelThreshold,
-                                                                  uint32_t accelFaultPersistenceLimit) {
-    return reinterpret_cast<MimuMajorityVoteAlgorithmHandle*>(
-        new ::MimuMajorityVoteAlgorithm(MimuMajorityVoteConfig::create(
-            omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit)));
+MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(const float omegaThreshold,
+                                                                  const uint32_t gyroFaultPersistenceLimit,
+                                                                  const float accelThreshold,
+                                                                  const uint32_t accelFaultPersistenceLimit) {
+    return fsw::createHandle<::MimuMajorityVoteAlgorithm, MimuMajorityVoteAlgorithmHandle>(
+        configFromC(omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit));
 }
 
 void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self) {
@@ -57,12 +66,12 @@ void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self) {
 }
 
 void MimuMajorityVoteAlgorithm_setConfig(MimuMajorityVoteAlgorithmHandle* self,
-                                         float omegaThreshold,
-                                         uint32_t gyroFaultPersistenceLimit,
-                                         float accelThreshold,
-                                         uint32_t accelFaultPersistenceLimit) {
-    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setConfig(MimuMajorityVoteConfig::create(
-        omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit));
+                                         const float omegaThreshold,
+                                         const uint32_t gyroFaultPersistenceLimit,
+                                         const float accelThreshold,
+                                         const uint32_t accelFaultPersistenceLimit) {
+    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setConfig(
+        configFromC(omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit));
 }
 
 void MimuMajorityVoteAlgorithm_reInitialize(MimuMajorityVoteAlgorithmHandle* self) {

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
@@ -39,6 +39,8 @@ MimuVoteResult_c toResultC(const MimuVoteResult& result) {
 
 uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void) { return MIMU_COUNT_C; }
 
+uint32_t MimuMajorityVoteAlgorithm_getVoteResultSize(void) { return sizeof(MimuVoteResult_c); }
+
 bool MimuMajorityVoteAlgorithm_validateConfig(const float omegaThreshold,
                                               const uint32_t gyroFaultPersistenceLimit,
                                               const float accelThreshold,

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
@@ -1,21 +1,39 @@
 #include "mimuMajorityVoteAlgorithm_c.h"
 #include "mimuMajorityVoteAlgorithm.h"
+#include "mimuMajorityVoteTypes.h"
 #include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
 uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void) { return MIMU_COUNT_C; }
 
+
 MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(void) {
-    return fsw::createHandle<::MimuMajorityVoteAlgorithm, MimuMajorityVoteAlgorithmHandle>();
+    return fsw::createHandle<::MimuMajorityVoteAlgorithm, MimuMajorityVoteAlgorithmHandle>(
+        MimuMajorityVoteConfig::create(omegaThreshold, faultPersistenceLimit));
+}
+
+bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold, uint32_t faultPersistenceLimit) {
+    try {
+        (void) MimuMajorityVoteConfig::create(omegaThreshold, faultPersistenceLimit);
+        return true;
+    } catch (const fsw::invalid_argument&) {
+        return false;
+    }
 }
 
 void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self) {
     fsw::deleteHandle<::MimuMajorityVoteAlgorithm>(self);
 }
 
-void MimuMajorityVoteAlgorithm_reset(MimuMajorityVoteAlgorithmHandle* self) {
-    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->reset();
+void MimuMajorityVoteAlgorithm_setConfig(MimuMajorityVoteAlgorithmHandle* self,
+                                         float omegaThreshold,
+                                         uint32_t faultPersistenceLimit) {
+    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setConfig(omegaThreshold, faultPersistenceLimit);
+}
+
+void MimuMajorityVoteAlgorithm_reInitialize(MimuMajorityVoteAlgorithmHandle* self) {
+    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->reInitialize();
 }
 
 MimuMajorityVoteOutput_c MimuMajorityVoteAlgorithm_update(MimuMajorityVoteAlgorithmHandle* self,
@@ -50,20 +68,4 @@ MimuMajorityVoteOutput_c MimuMajorityVoteAlgorithm_update(MimuMajorityVoteAlgori
     }
 
     return out;
-}
-
-void MimuMajorityVoteAlgorithm_setOmegaThreshold(MimuMajorityVoteAlgorithmHandle* self, float value) {
-    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setOmegaThreshold(value);
-}
-
-float MimuMajorityVoteAlgorithm_getOmegaThreshold(const MimuMajorityVoteAlgorithmHandle* self) {
-    return fsw::fromHandle<const ::MimuMajorityVoteAlgorithm>(self)->getOmegaThreshold();
-}
-
-void MimuMajorityVoteAlgorithm_setFaultPersistenceLimit(MimuMajorityVoteAlgorithmHandle* self, uint32_t value) {
-    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setFaultPersistenceLimit(value);
-}
-
-uint32_t MimuMajorityVoteAlgorithm_getFaultPersistenceLimit(const MimuMajorityVoteAlgorithmHandle* self) {
-    return fsw::fromHandle<const ::MimuMajorityVoteAlgorithm>(self)->getFaultPersistenceLimit();
 }

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
@@ -19,10 +19,10 @@ std::array<Eigen::Vector3f, MIMU_COUNT_C> toEigenArray(const Vector3fArray3_c& i
 MimuVoteResult_c toResultC(const MimuVoteResult& result) {
     MimuVoteResult_c out{};
     eigenVectorToCArray(result.average, out.average.data);
-    out.faultDetected = result.faultDetected ? 1U : 0U;
+    out.faultDetected = result.faultDetected;
     for (uint32_t i = 0; i < MIMU_COUNT_C; ++i) {
         out.imuDifferenceMag[i] = result.imuDifferenceMag.at(i);
-        out.imuValid[i] = result.imuValid.at(i) ? 1U : 0U;
+        out.imuValid[i] = result.imuValid.at(i);
     }
     return out;
 }

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
@@ -1,15 +1,42 @@
 #include "mimuMajorityVoteAlgorithm_c.h"
 #include "mimuMajorityVoteAlgorithm.h"
 #include "mimuMajorityVoteTypes.h"
+#include "utilities/fsw/eigenSupport.h"
 #include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
+namespace {
+std::array<Eigen::Vector3f, MIMU_COUNT_C> toEigenArray(const Vector3fArray3_c& in) {
+    std::array<Eigen::Vector3f, MIMU_COUNT_C> out{};
+    for (uint32_t i = 0; i < MIMU_COUNT_C; ++i) {
+        out[i] = cArrayToEigenVector3<float>(in.vec[i].data);
+    }
+    return out;
+}
+
+// Marshal one C++ vote result into its POD mirror (full per-IMU fidelity).
+MimuVoteResult_c toResultC(const MimuVoteResult& result) {
+    MimuVoteResult_c out{};
+    eigenVectorToCArray(result.average, out.average.data);
+    out.faultDetected = result.faultDetected ? 1U : 0U;
+    for (uint32_t i = 0; i < MIMU_COUNT_C; ++i) {
+        out.imuDifferenceMag[i] = result.imuDifferenceMag.at(i);
+        out.imuValid[i] = result.imuValid.at(i) ? 1U : 0U;
+    }
+    return out;
+}
+}  // namespace
+
 uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void) { return MIMU_COUNT_C; }
 
-bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold, uint32_t gyroFaultPersistenceLimit) {
+bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold,
+                                              uint32_t gyroFaultPersistenceLimit,
+                                              float accelThreshold,
+                                              uint32_t accelFaultPersistenceLimit) {
     try {
-        (void) MimuMajorityVoteConfig::create(omegaThreshold, gyroFaultPersistenceLimit);
+        (void)MimuMajorityVoteConfig::create(
+            omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit);
         return true;
     } catch (const fsw::invalid_argument&) {
         return false;
@@ -17,9 +44,12 @@ bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold, uint32_t gyr
 }
 
 MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(float omegaThreshold,
-                                                                  uint32_t gyroFaultPersistenceLimit) {
+                                                                  uint32_t gyroFaultPersistenceLimit,
+                                                                  float accelThreshold,
+                                                                  uint32_t accelFaultPersistenceLimit) {
     return reinterpret_cast<MimuMajorityVoteAlgorithmHandle*>(
-        new ::MimuMajorityVoteAlgorithm(MimuMajorityVoteConfig::create(omegaThreshold, gyroFaultPersistenceLimit)));
+        new ::MimuMajorityVoteAlgorithm(MimuMajorityVoteConfig::create(
+            omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit)));
 }
 
 void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self) {
@@ -28,8 +58,11 @@ void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self) {
 
 void MimuMajorityVoteAlgorithm_setConfig(MimuMajorityVoteAlgorithmHandle* self,
                                          float omegaThreshold,
-                                         uint32_t gyroFaultPersistenceLimit) {
-    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setConfig(omegaThreshold, gyroFaultPersistenceLimit);
+                                         uint32_t gyroFaultPersistenceLimit,
+                                         float accelThreshold,
+                                         uint32_t accelFaultPersistenceLimit) {
+    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setConfig(MimuMajorityVoteConfig::create(
+        omegaThreshold, gyroFaultPersistenceLimit, accelThreshold, accelFaultPersistenceLimit));
 }
 
 void MimuMajorityVoteAlgorithm_reInitialize(MimuMajorityVoteAlgorithmHandle* self) {
@@ -37,35 +70,16 @@ void MimuMajorityVoteAlgorithm_reInitialize(MimuMajorityVoteAlgorithmHandle* sel
 }
 
 MimuMajorityVoteOutput_c MimuMajorityVoteAlgorithm_update(MimuMajorityVoteAlgorithmHandle* self,
-                                                          const Vector3fArray3_c* imuOmegas_BN_B) {
+                                                          const Vector3fArray3_c* imuOmegas_BN_B,
+                                                          const Vector3fArray3_c* imuAccels_B) {
     auto* alg = fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self);
 
-    // Convert POD Vector3f_c inputs to C++ Eigen array:
-    std::array<Eigen::Vector3f, MIMU_COUNT_C> inputs{};
-    for (uint32_t i = 0; i < MIMU_COUNT_C; ++i) {
-        inputs[i] << imuOmegas_BN_B->vec[i].data[0], imuOmegas_BN_B->vec[i].data[1], imuOmegas_BN_B->vec[i].data[2];
-    }
+    // Call the C++ algorithm with both quantities:
+    MimuMajorityVoteOutput cppOutput = alg->update(toEigenArray(*imuOmegas_BN_B), toEigenArray(*imuAccels_B));
 
-    // Call the C++ algorithm:
-    MimuMajorityVoteOutput cppOutput = alg->update(inputs);
-
-    // Convert C++ output to POD:
+    // Convert C++ output to POD, preserving each vote's full per-IMU fidelity:
     MimuMajorityVoteOutput_c out{};
-    out.avgOmega_BN_B.data[0] = cppOutput.avgOmega_BN_B[0];
-    out.avgOmega_BN_B.data[1] = cppOutput.avgOmega_BN_B[1];
-    out.avgOmega_BN_B.data[2] = cppOutput.avgOmega_BN_B[2];
-    out.faultDetected = cppOutput.faultDetected ? 1U : 0U;
-
-    // Reduce per-IMU validity to a single faulted index (-1 if no fault):
-    out.mimuIndexFaulted = -1;
-    if (cppOutput.faultDetected) {
-        for (uint32_t i = 0; i < MIMU_COUNT_C; ++i) {
-            if (!cppOutput.validImus[i]) {
-                out.mimuIndexFaulted = static_cast<int32_t>(i);
-                break;
-            }
-        }
-    }
-
+    out.gyro = toResultC(cppOutput.gyro);
+    out.accel = toResultC(cppOutput.accel);
     return out;
 }

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
@@ -7,19 +7,19 @@
 
 uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void) { return MIMU_COUNT_C; }
 
-
-MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(void) {
-    return fsw::createHandle<::MimuMajorityVoteAlgorithm, MimuMajorityVoteAlgorithmHandle>(
-        MimuMajorityVoteConfig::create(omegaThreshold, faultPersistenceLimit));
-}
-
-bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold, uint32_t faultPersistenceLimit) {
+bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold, uint32_t gyroFaultPersistenceLimit) {
     try {
-        (void) MimuMajorityVoteConfig::create(omegaThreshold, faultPersistenceLimit);
+        (void) MimuMajorityVoteConfig::create(omegaThreshold, gyroFaultPersistenceLimit);
         return true;
     } catch (const fsw::invalid_argument&) {
         return false;
     }
+}
+
+MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(float omegaThreshold,
+                                                                  uint32_t gyroFaultPersistenceLimit) {
+    return reinterpret_cast<MimuMajorityVoteAlgorithmHandle*>(
+        new ::MimuMajorityVoteAlgorithm(MimuMajorityVoteConfig::create(omegaThreshold, gyroFaultPersistenceLimit)));
 }
 
 void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self) {
@@ -28,8 +28,8 @@ void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self) {
 
 void MimuMajorityVoteAlgorithm_setConfig(MimuMajorityVoteAlgorithmHandle* self,
                                          float omegaThreshold,
-                                         uint32_t faultPersistenceLimit) {
-    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setConfig(omegaThreshold, faultPersistenceLimit);
+                                         uint32_t gyroFaultPersistenceLimit) {
+    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setConfig(omegaThreshold, gyroFaultPersistenceLimit);
 }
 
 void MimuMajorityVoteAlgorithm_reInitialize(MimuMajorityVoteAlgorithmHandle* self) {

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.h
@@ -1,7 +1,8 @@
 #ifndef F32XMERA_MIMUMAJORITYVOTEALGORITHM_C_H
 #define F32XMERA_MIMUMAJORITYVOTEALGORITHM_C_H
 
-#include "utilities/fsw/plainCAlgorithmDataTypes.h"
+#include "mimuMajorityVoteTypes.h"
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -14,42 +15,29 @@ extern "C" {
 typedef struct MimuMajorityVoteAlgorithmHandle MimuMajorityVoteAlgorithmHandle;
 
 /**
- * @brief Number of IMUs.
- */
-#define MIMU_COUNT_C 3
-
-/**
- * @brief Sized array of 3-vectors.
- */
-typedef struct {
-    Vector3f_c vec[MIMU_COUNT_C];
-} Vector3fArray3_c;
-
-/**
- * @brief POD output from the MIMU majority vote algorithm.
- *
- * Layout must match the Adamant Mimu_Majority_Vote_Output packed record:
- *   Avg_Ang_Vel_Body : Packed_F32x3  (3 floats)
- *   Fault_Detected   : Unsigned_8    (0 = false, nonzero = true)
- *   Mimu_Index_Faulted : Integer_32  (-1 if no fault)
- */
-typedef struct {
-    Vector3f_c avgOmega_BN_B; /*!< [rad/s] Averaged angular velocity in body frame */
-    uint8_t faultDetected;    /*!< Whether a MIMU fault was detected */
-    int32_t mimuIndexFaulted; /*!< Index of faulted MIMU (-1 if no fault) */
-} MimuMajorityVoteOutput_c;
-
-/**
  * @brief Get the kMimuCount constant for Ada validation.
  * @return The IMU count (MIMU_COUNT_C).
  */
 uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void);
 
 /**
- * @brief Construct a new MimuMajorityVoteAlgorithm instance.
- * @return Pointer to a new MimuMajorityVoteAlgorithm (must be destroyed).
+ * @brief Report whether a configuration would be accepted by create/setConfig.
+ * @param omegaThreshold        [rad/s] gyro threshold; must be finite and > 0.
+ * @param faultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
+ * @return true when the configuration is valid. Never throws, so it can guard the
+ *         throwing create/setConfig from an invalid configuration.
  */
-MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(void);
+bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold, uint32_t faultPersistenceLimit);
+
+/**
+ * @brief Construct a new MimuMajorityVoteAlgorithm instance from the supplied configuration.
+ * @param omegaThreshold        [rad/s] gyro threshold; must be finite and > 0.
+ * @param faultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
+ * @return Pointer to a new MimuMajorityVoteAlgorithm (must be destroyed).
+ * Validate the values with validateConfig first; invalid input throws.
+ */
+MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(float omegaThreshold,
+                                                                  uint32_t faultPersistenceLimit);
 
 /**
  * @brief Destroy a previously created MimuMajorityVoteAlgorithm.
@@ -58,10 +46,22 @@ MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(void);
 void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self);
 
 /**
+ * @brief Install the configuration on an existing instance (parameters only; call _reInitialize to
+ *        reset the persistence counters).
+ * @param self                  Pointer to the instance.
+ * @param omegaThreshold        [rad/s] gyro threshold; must be finite and > 0.
+ * @param faultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
+ * Validate the values with validateConfig first; invalid input throws.
+ */
+void MimuMajorityVoteAlgorithm_setConfig(MimuMajorityVoteAlgorithmHandle* self,
+                                         float omegaThreshold,
+                                         uint32_t faultPersistenceLimit);
+
+/**
  * @brief Reset fault persistence counters to zero.
  * @param self Pointer to the instance.
  */
-void MimuMajorityVoteAlgorithm_reset(MimuMajorityVoteAlgorithmHandle* self);
+void MimuMajorityVoteAlgorithm_reInitialize(MimuMajorityVoteAlgorithmHandle* self);
 
 /**
  * @brief Run the majority vote update step.
@@ -71,34 +71,6 @@ void MimuMajorityVoteAlgorithm_reset(MimuMajorityVoteAlgorithmHandle* self);
  */
 MimuMajorityVoteOutput_c MimuMajorityVoteAlgorithm_update(MimuMajorityVoteAlgorithmHandle* self,
                                                           const Vector3fArray3_c* imuOmegas_BN_B);
-
-/**
- * @brief Set the omega threshold for fault detection.
- * @param self  Pointer to the instance.
- * @param value The new omega threshold value [rad/s].
- */
-void MimuMajorityVoteAlgorithm_setOmegaThreshold(MimuMajorityVoteAlgorithmHandle* self, float value);
-
-/**
- * @brief Get the current omega threshold.
- * @param self Pointer to the instance.
- * @return float  The current omega threshold [rad/s].
- */
-float MimuMajorityVoteAlgorithm_getOmegaThreshold(const MimuMajorityVoteAlgorithmHandle* self);
-
-/**
- * @brief Set the fault persistence limit.
- * @param self  Pointer to the instance.
- * @param value The new fault persistence limit.
- */
-void MimuMajorityVoteAlgorithm_setFaultPersistenceLimit(MimuMajorityVoteAlgorithmHandle* self, uint32_t value);
-
-/**
- * @brief Get the current fault persistence limit.
- * @param self Pointer to the instance.
- * @return uint32_t  The current fault persistence limit.
- */
-uint32_t MimuMajorityVoteAlgorithm_getFaultPersistenceLimit(const MimuMajorityVoteAlgorithmHandle* self);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.h
@@ -21,6 +21,15 @@ typedef struct MimuMajorityVoteAlgorithmHandle MimuMajorityVoteAlgorithmHandle;
 uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void);
 
 /**
+ * @brief Get the size in bytes of one MimuVoteResult_c for Ada ABI validation.
+ * @return sizeof(MimuVoteResult_c).
+ * @note MimuVoteResult_c is the first POD on this boundary with interior padding (a bool
+ *       followed by a 4-byte-aligned float array), so its total size is checked rather
+ *       than inferred from the field list.
+ */
+uint32_t MimuMajorityVoteAlgorithm_getVoteResultSize(void);
+
+/**
  * @brief Report whether a configuration would be accepted by create/setConfig.
  * @param omegaThreshold             [rad/s] gyro threshold; must be finite and > 0.
  * @param gyroFaultPersistenceLimit  [-] consecutive gyro faults to trigger; must be > 0.

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.h
@@ -1,5 +1,5 @@
-#ifndef F32XMERA_MIMUMAJORITYVOTEALGORITHM_C_H
-#define F32XMERA_MIMUMAJORITYVOTEALGORITHM_C_H
+#ifndef F32XMERA_MIMU_MAJORITY_VOTE_ALGORITHM_C_H
+#define F32XMERA_MIMU_MAJORITY_VOTE_ALGORITHM_C_H
 
 #include "mimuMajorityVoteTypes.h"
 #include <stdbool.h>
@@ -22,22 +22,31 @@ uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void);
 
 /**
  * @brief Report whether a configuration would be accepted by create/setConfig.
- * @param omegaThreshold        [rad/s] gyro threshold; must be finite and > 0.
- * @param gyroFaultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
+ * @param omegaThreshold             [rad/s] gyro threshold; must be finite and > 0.
+ * @param gyroFaultPersistenceLimit  [-] consecutive gyro faults to trigger; must be > 0.
+ * @param accelThreshold             [m/s^2] accel threshold; must be finite and > 0.
+ * @param accelFaultPersistenceLimit [-] consecutive accel faults to trigger; must be > 0.
  * @return true when the configuration is valid. Never throws, so it can guard the
  *         throwing create/setConfig from an invalid configuration.
  */
-bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold, uint32_t gyroFaultPersistenceLimit);
+bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold,
+                                              uint32_t gyroFaultPersistenceLimit,
+                                              float accelThreshold,
+                                              uint32_t accelFaultPersistenceLimit);
 
 /**
  * @brief Construct a new MimuMajorityVoteAlgorithm instance from the supplied configuration.
- * @param omegaThreshold        [rad/s] gyro threshold; must be finite and > 0.
- * @param gyroFaultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
+ * @param omegaThreshold             [rad/s] gyro threshold; must be finite and > 0.
+ * @param gyroFaultPersistenceLimit  [-] consecutive gyro faults to trigger; must be > 0.
+ * @param accelThreshold             [m/s^2] accel threshold; must be finite and > 0.
+ * @param accelFaultPersistenceLimit [-] consecutive accel faults to trigger; must be > 0.
  * @return Pointer to a new MimuMajorityVoteAlgorithm (must be destroyed).
  * Validate the values with validateConfig first; invalid input throws.
  */
 MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(float omegaThreshold,
-                                                                  uint32_t gyroFaultPersistenceLimit);
+                                                                  uint32_t gyroFaultPersistenceLimit,
+                                                                  float accelThreshold,
+                                                                  uint32_t accelFaultPersistenceLimit);
 
 /**
  * @brief Destroy a previously created MimuMajorityVoteAlgorithm.
@@ -48,14 +57,18 @@ void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self);
 /**
  * @brief Install the configuration on an existing instance (parameters only; call _reInitialize to
  *        reset the persistence counters).
- * @param self                  Pointer to the instance.
- * @param omegaThreshold        [rad/s] gyro threshold; must be finite and > 0.
- * @param gyroFaultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
+ * @param self                       Pointer to the instance.
+ * @param omegaThreshold             [rad/s] gyro threshold; must be finite and > 0.
+ * @param gyroFaultPersistenceLimit  [-] consecutive gyro faults to trigger; must be > 0.
+ * @param accelThreshold             [m/s^2] accel threshold; must be finite and > 0.
+ * @param accelFaultPersistenceLimit [-] consecutive accel faults to trigger; must be > 0.
  * Validate the values with validateConfig first; invalid input throws.
  */
 void MimuMajorityVoteAlgorithm_setConfig(MimuMajorityVoteAlgorithmHandle* self,
                                          float omegaThreshold,
-                                         uint32_t gyroFaultPersistenceLimit);
+                                         uint32_t gyroFaultPersistenceLimit,
+                                         float accelThreshold,
+                                         uint32_t accelFaultPersistenceLimit);
 
 /**
  * @brief Reset fault persistence counters to zero.
@@ -65,15 +78,17 @@ void MimuMajorityVoteAlgorithm_reInitialize(MimuMajorityVoteAlgorithmHandle* sel
 
 /**
  * @brief Run the majority vote update step.
- * @param self      Pointer to the instance.
+ * @param self           Pointer to the instance.
  * @param imuOmegas_BN_B IMU angular velocity 3-vectors.
- * @return MimuMajorityVoteOutput_c  The computed majority vote output.
+ * @param imuAccels_B    IMU apparent acceleration 3-vectors.
+ * @return MimuMajorityVoteOutput_c  The computed majority vote output (gyro + accel).
  */
 MimuMajorityVoteOutput_c MimuMajorityVoteAlgorithm_update(MimuMajorityVoteAlgorithmHandle* self,
-                                                          const Vector3fArray3_c* imuOmegas_BN_B);
+                                                          const Vector3fArray3_c* imuOmegas_BN_B,
+                                                          const Vector3fArray3_c* imuAccels_B);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif
 
-#endif  // F32XMERA_MIMUMAJORITYVOTEALGORITHM_C_H
+#endif  // F32XMERA_MIMU_MAJORITY_VOTE_ALGORITHM_C_H

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.h
@@ -23,21 +23,21 @@ uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void);
 /**
  * @brief Report whether a configuration would be accepted by create/setConfig.
  * @param omegaThreshold        [rad/s] gyro threshold; must be finite and > 0.
- * @param faultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
+ * @param gyroFaultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
  * @return true when the configuration is valid. Never throws, so it can guard the
  *         throwing create/setConfig from an invalid configuration.
  */
-bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold, uint32_t faultPersistenceLimit);
+bool MimuMajorityVoteAlgorithm_validateConfig(float omegaThreshold, uint32_t gyroFaultPersistenceLimit);
 
 /**
  * @brief Construct a new MimuMajorityVoteAlgorithm instance from the supplied configuration.
  * @param omegaThreshold        [rad/s] gyro threshold; must be finite and > 0.
- * @param faultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
+ * @param gyroFaultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
  * @return Pointer to a new MimuMajorityVoteAlgorithm (must be destroyed).
  * Validate the values with validateConfig first; invalid input throws.
  */
 MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(float omegaThreshold,
-                                                                  uint32_t faultPersistenceLimit);
+                                                                  uint32_t gyroFaultPersistenceLimit);
 
 /**
  * @brief Destroy a previously created MimuMajorityVoteAlgorithm.
@@ -50,12 +50,12 @@ void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self);
  *        reset the persistence counters).
  * @param self                  Pointer to the instance.
  * @param omegaThreshold        [rad/s] gyro threshold; must be finite and > 0.
- * @param faultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
+ * @param gyroFaultPersistenceLimit [-] consecutive faults to trigger; must be > 0.
  * Validate the values with validateConfig first; invalid input throws.
  */
 void MimuMajorityVoteAlgorithm_setConfig(MimuMajorityVoteAlgorithmHandle* self,
                                          float omegaThreshold,
-                                         uint32_t faultPersistenceLimit);
+                                         uint32_t gyroFaultPersistenceLimit);
 
 /**
  * @brief Reset fault persistence counters to zero.

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteF32.i
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteF32.i
@@ -3,14 +3,11 @@
    #include "mimuMajorityVote.h"
 %}
 
-%include <attribute.i>
-%attribute(MimuMajorityVote, float, omegaThreshold, getOmegaThreshold, setOmegaThreshold)
-%attribute(MimuMajorityVote, uint32_t, faultPersistenceLimit, getFaultPersistenceLimit, setFaultPersistenceLimit)
-
 %include <std_string.i>
 %include <swig_conly_data.i>
 %include <sys_model.i>
 
+%include "mimuMajorityVoteTypes.h"
 %include "mimuMajorityVote.h"
 
 %include "msgPayloadDef/IMUSensorBodyMsgF32Payload.h"

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
@@ -21,17 +21,29 @@ typedef struct {
 } Vector3fArray3_c;
 
 /**
- * @brief POD output from the MIMU majority vote algorithm.
+ * @brief POD result of one majority vote (gyro or accel), mirroring the C++ MimuVoteResult.
  *
- * Layout must match the Adamant Mimu_Majority_Vote_Output packed record:
- *   Avg_Ang_Vel_Body : Packed_F32x3  (3 floats)
- *   Fault_Detected   : Unsigned_8    (0 = false, nonzero = true)
- *   Mimu_Index_Faulted : Integer_32  (-1 if no fault)
+ * Layout must match the Adamant Mimu_Vote_Result packed record:
+ *   Average            : Packed_F32x3             (3 floats)
+ *   Fault_Detected     : Unsigned_8               (0 = false, nonzero = true)
+ *   Imu_Difference_Mag : array of F32             (MIMU_COUNT_C floats)
+ *   Imu_Valid          : array of Unsigned_8      (MIMU_COUNT_C, 0/1 per IMU)
  */
 typedef struct {
-    Vector3f_c avgOmega_BN_B; /*!< [rad/s] Averaged angular velocity in body frame */
-    uint8_t faultDetected;    /*!< Whether a MIMU fault was detected */
-    int32_t mimuIndexFaulted; /*!< Index of faulted MIMU (-1 if no fault) */
+    Vector3f_c average;                   /*!< Averaged measurement (outlier-excluded once a fault persists) */
+    uint8_t faultDetected;                /*!< Whether an IMU was rejected for this quantity (0/1) */
+    float imuDifferenceMag[MIMU_COUNT_C]; /*!< Each IMU's difference magnitude from the 3-IMU average */
+    uint8_t imuValid[MIMU_COUNT_C];       /*!< Whether each IMU is valid for this quantity (0/1) */
+} MimuVoteResult_c;
+
+/**
+ * @brief POD output from the MIMU majority vote algorithm: independent gyro and accel votes.
+ *
+ * Layout must match the Adamant Mimu_Majority_Vote_Output packed record (gyro result, then accel).
+ */
+typedef struct {
+    MimuVoteResult_c gyro;  /*!< [rad/s] Angular-velocity vote */
+    MimuVoteResult_c accel; /*!< [m/s^2] Acceleration vote */
 } MimuMajorityVoteOutput_c;
 
 #ifdef __cplusplus

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
@@ -1,4 +1,41 @@
 #ifndef F32XMERA_MIMU_MAJORITY_VOTE_TYPES_H
 #define F32XMERA_MIMU_MAJORITY_VOTE_TYPES_H
 
+#include "utilities/fsw/plainCAlgorithmDataTypes.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Number of IMUs.
+ */
+#define MIMU_COUNT_C 3
+
+/**
+ * @brief Sized array of 3-vectors.
+ */
+typedef struct {
+    Vector3f_c vec[MIMU_COUNT_C];
+} Vector3fArray3_c;
+
+/**
+ * @brief POD output from the MIMU majority vote algorithm.
+ *
+ * Layout must match the Adamant Mimu_Majority_Vote_Output packed record:
+ *   Avg_Ang_Vel_Body : Packed_F32x3  (3 floats)
+ *   Fault_Detected   : Unsigned_8    (0 = false, nonzero = true)
+ *   Mimu_Index_Faulted : Integer_32  (-1 if no fault)
+ */
+typedef struct {
+    Vector3f_c avgOmega_BN_B; /*!< [rad/s] Averaged angular velocity in body frame */
+    uint8_t faultDetected;    /*!< Whether a MIMU fault was detected */
+    int32_t mimuIndexFaulted; /*!< Index of faulted MIMU (-1 if no fault) */
+} MimuMajorityVoteOutput_c;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
 #endif  // F32XMERA_MIMU_MAJORITY_VOTE_TYPES_H

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteTypes.h
@@ -2,6 +2,7 @@
 #define F32XMERA_MIMU_MAJORITY_VOTE_TYPES_H
 
 #include "utilities/fsw/plainCAlgorithmDataTypes.h"
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -25,15 +26,15 @@ typedef struct {
  *
  * Layout must match the Adamant Mimu_Vote_Result packed record:
  *   Average            : Packed_F32x3             (3 floats)
- *   Fault_Detected     : Unsigned_8               (0 = false, nonzero = true)
+ *   Fault_Detected     : Boolean                  (C99 bool / _Bool, 0/1)
  *   Imu_Difference_Mag : array of F32             (MIMU_COUNT_C floats)
- *   Imu_Valid          : array of Unsigned_8      (MIMU_COUNT_C, 0/1 per IMU)
+ *   Imu_Valid          : array of Boolean         (MIMU_COUNT_C, C99 bool, 0/1 per IMU)
  */
 typedef struct {
     Vector3f_c average;                   /*!< Averaged measurement (outlier-excluded once a fault persists) */
-    uint8_t faultDetected;                /*!< Whether an IMU was rejected for this quantity (0/1) */
+    bool faultDetected;                   /*!< Whether an IMU was rejected for this quantity (0/1) */
     float imuDifferenceMag[MIMU_COUNT_C]; /*!< Each IMU's difference magnitude from the 3-IMU average */
-    uint8_t imuValid[MIMU_COUNT_C];       /*!< Whether each IMU is valid for this quantity (0/1) */
+    bool imuValid[MIMU_COUNT_C];          /*!< Whether each IMU is valid for this quantity (0/1) */
 } MimuVoteResult_c;
 
 /**

--- a/algorithms/msgPayloadDef/MimuFaultMsgPayload.h
+++ b/algorithms/msgPayloadDef/MimuFaultMsgPayload.h
@@ -7,9 +7,12 @@
 
 /*! @brief Structure used to define the mimu fault message */
 typedef struct {
-    bool gyroFaultDetected;                  //!< fault detected bool
-    bool gyroImuValid[kMimuCount];           //!< valid IMU flags for each IMU
-    float gyroImuDifferenceMag[kMimuCount];  //!< [rad/s] magnitude of each IMU's difference from the 3-IMU average
+    bool gyroFaultDetected;                   //!< gyro fault detected bool
+    bool gyroImuValid[kMimuCount];            //!< gyro-valid flag for each IMU
+    float gyroImuDifferenceMag[kMimuCount];   //!< [rad/s] each IMU's angular-velocity difference magnitude
+    bool accelFaultDetected;                  //!< accel fault detected bool
+    bool accelImuValid[kMimuCount];           //!< accel-valid flag for each IMU
+    float accelImuDifferenceMag[kMimuCount];  //!< [m/s^2] each IMU's acceleration difference magnitude
 } MimuFaultMsgPayload;
 
 #endif /* mimuFaultMsg_h */

--- a/algorithms/msgPayloadDef/MimuFaultMsgPayload.h
+++ b/algorithms/msgPayloadDef/MimuFaultMsgPayload.h
@@ -7,9 +7,9 @@
 
 /*! @brief Structure used to define the mimu fault message */
 typedef struct {
-    bool faultDetected;                     //!< fault detected bool
-    bool validImus[kMimuCount];             //!< valid IMU flags for each IMU
-    float omegaDifferencesMag[kMimuCount];  //!< [rad/s] magnitude of each IMU's difference from the 3-IMU average
+    bool gyroFaultDetected;                  //!< fault detected bool
+    bool gyroImuValid[kMimuCount];           //!< valid IMU flags for each IMU
+    float gyroImuDifferenceMag[kMimuCount];  //!< [rad/s] magnitude of each IMU's difference from the 3-IMU average
 } MimuFaultMsgPayload;
 
 #endif /* mimuFaultMsg_h */


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2267
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
This PR adds acceleration to mimuMajorityVote. 

## Verification
Tests were maintained for the gyro tests unchanged and tests were added for the accels.

## Documentation
Documentation was updated

## Future work
None
