### PR TITLE
Resolve filter clang tidy warnings

### DIFF
--- a/.github/clang-tidy-exclude.txt
+++ b/.github/clang-tidy-exclude.txt
@@ -3,8 +3,6 @@
 
 algorithms/attTrackingError/attTrackingError.h
 algorithms/attTrackingError/attTrackingError.cpp
-algorithms/attTrackingError/attTrackingErrorAlgorithm_c.h
-algorithms/attTrackingError/attTrackingErrorAlgorithm_c.cpp
 algorithms/averageMimuData/averageMimuData.h
 algorithms/averageMimuData/averageMimuData.cpp
 algorithms/bodyRateMiscompare/bodyRateMiscompare.h
@@ -85,8 +83,6 @@ algorithms/stepperMotorController/stepperMotorControllerAlgorithm_c.h
 algorithms/stepperMotorController/stepperMotorControllerAlgorithm_c.cpp
 algorithms/sunSearchPoint/sunSearchPoint.h
 algorithms/sunSearchPoint/sunSearchPoint.cpp
-algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.h
-algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.cpp
 algorithms/sunlineEphem/sunlineEphem.h
 algorithms/sunlineEphem/sunlineEphem.cpp
 algorithms/sunlineEphem/sunlineEphemAlgorithm_c.h

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -35,10 +35,10 @@ jobs:
         os: [ubuntu-24.04, macos-14]
     steps:
       - name: Checkout fp32-fsw-xmera
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Checkout Xmera core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: lasp/basilisk
           path: xmera

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -153,7 +153,7 @@ jobs:
           VCPKG_CMAKE_CONFIGURE_OPTIONS: "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
       - name: Cache vcpkg build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ${{ github.workspace }}/b/vcpkg/installed

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -44,7 +44,7 @@ jobs:
           path: xmera
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Restore fuzz corpus cache
         id: fuzz-corpus-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: .fuzztest_corpus
           key: fuzz-corpus-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -39,12 +39,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout fp32-fsw-xmera
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Checkout Xmera core
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: lasp/xmera
           path: xmera

--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Set up Python 3.11
         id: setup-py
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/downstream-build.yml
+++ b/.github/workflows/downstream-build.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Archive build logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: downstream-test-logs
           path: ${{ github.workspace }}/adamant-xmera-components/build

--- a/.github/workflows/downstream-build.yml
+++ b/.github/workflows/downstream-build.yml
@@ -21,7 +21,7 @@ jobs:
       options: --user root
     steps:
       - name: Check out adamant-xmera-components
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           set-safe-directory: true
           repository: lasp/adamant-xmera-components
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Check out fp32-fsw-xmera at PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           set-safe-directory: true
           ref: ${{ github.event.pull_request.head.sha }}
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Clone adamant repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           set-safe-directory: true
           repository: lasp/adamant
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Clone Eigen with freestanding support
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           set-safe-directory: true
           repository: lasp/eigen

--- a/.github/workflows/freestanding-build.yml
+++ b/.github/workflows/freestanding-build.yml
@@ -28,13 +28,13 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout algorithms repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Checkout freestanding Eigen
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: lasp/eigen
           ref: feature/freestanding

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -100,7 +100,7 @@ jobs:
 
       - name: Set up Python 3.11
         id: setup-py
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: .pre-commit-config.yaml
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -76,13 +76,13 @@ jobs:
       security-events: write
     steps:
       - name: Checkout fp32-fsw-xmera
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Checkout Xmera core
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: lasp/xmera
           path: xmera

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -378,7 +378,7 @@ jobs:
           exit 1
 
       - name: Upload clang-tidy artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: clang-tidy-log
           path: reports/clang-tidy.log

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           files: |
             algorithms/**
-            architecture/**
           files_ignore: |
             **/_tests/**
             **/_test/**
@@ -263,7 +262,7 @@ jobs:
           changed_rel_paths=(${{ needs.detect-changes.outputs.all_changed_files }})
 
           if [ "${#changed_rel_paths[@]}" -eq 0 ]; then
-            echo "No algorithms/architecture files changed in this PR; skipping clang-tidy."
+            echo "No algorithms files changed in this PR; skipping clang-tidy."
             : > reports/clang-tidy.log
             exit 0
           fi
@@ -306,7 +305,7 @@ jobs:
             echo "No exclusion file found at ${exclude_file}; analyzing all changed files."
           fi
 
-          # Gather algorithm + architecture sources that are tracked and skip *.cxx
+          # Gather algorithm sources that are tracked and skip *.cxx
           files=()
           excluded_files=()
           while IFS= read -r path; do
@@ -322,7 +321,7 @@ jobs:
               files+=("$path")
             fi
           done < <(jq -r '.[].file' xmera/build/compile_commands.json \
-            | grep -E '(^|/)(algorithms|architecture)/' \
+            | grep -E '(^|/)(algorithms)/' \
             | grep -vE '\.cxx$' || true)
 
           if [ "${#excluded_files[@]}" -gt 0 ]; then
@@ -331,10 +330,10 @@ jobs:
           fi
 
           if [ "${#files[@]}" -eq 0 ]; then
-            echo "No tracked source files (algorithms/architecture) to analyze after filtering generated outputs."
+            echo "No tracked source files (algorithms) to analyze after filtering generated outputs."
             : > reports/clang-tidy.log
           else
-            echo "Analyzing ${#files[@]} tracked files in algorithms/ + architecture/ (excluding generated .cxx)."
+            echo "Analyzing ${#files[@]} tracked files in algorithms/ (excluding generated .cxx)."
             RUN_CLANG_TIDY_BIN="run-clang-tidy"
             CLANG_TIDY_BIN="clang-tidy-21"
             if command -v run-clang-tidy-21 >/dev/null 2>&1; then

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,7 +35,7 @@ jobs:
       all_changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
       - name: Checkout fp32-fsw-xmera
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -68,14 +68,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout fp32-fsw-xmera
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Checkout Xmera core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: lasp/xmera
           path: xmera

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Set up Python
         id: setup-py
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: "pip"

--- a/algorithms/attTrackingError/attTrackingErrorAlgorithm_c.cpp
+++ b/algorithms/attTrackingError/attTrackingErrorAlgorithm_c.cpp
@@ -2,22 +2,19 @@
 #include "attTrackingErrorAlgorithm.h"
 #include "attTrackingErrorTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
 AttTrackingErrorAlgorithmHandle* AttTrackingErrorAlgorithm_create(void) {
-    // clang-format off
-    return reinterpret_cast<AttTrackingErrorAlgorithmHandle*>(new ::AttTrackingErrorAlgorithm());  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    return fsw::createHandle<::AttTrackingErrorAlgorithm, AttTrackingErrorAlgorithmHandle>();
 }
 
 void AttTrackingErrorAlgorithm_destroy(AttTrackingErrorAlgorithmHandle* self) {
-    // clang-format off
-    delete reinterpret_cast<::AttTrackingErrorAlgorithm*>(self);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
+    fsw::deleteHandle<::AttTrackingErrorAlgorithm>(self);
 }
 
-AttGuidOutput_c AttTrackingErrorAlgorithm_update(AttTrackingErrorAlgorithmHandle* self,
+AttGuidOutput_c AttTrackingErrorAlgorithm_update([[maybe_unused]] AttTrackingErrorAlgorithmHandle* self,
                                                  AttNavInput_c navIn,
                                                  AttRefInput_c refIn) {
     AttNavInput nav{};
@@ -29,9 +26,7 @@ AttGuidOutput_c AttTrackingErrorAlgorithm_update(AttTrackingErrorAlgorithmHandle
     ref.omega_RN_N = cArrayToEigenVector3<float>(refIn.omega_RN_N.data);
     ref.domega_RN_N = cArrayToEigenVector3<float>(refIn.domega_RN_N.data);
 
-    // clang-format off
-    const AttGuidOutput output = reinterpret_cast<::AttTrackingErrorAlgorithm*>(self)->update(nav, ref);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    const AttGuidOutput output = ::AttTrackingErrorAlgorithm::update(nav, ref);
 
     AttGuidOutput_c out{};
     eigenVectorToCArray(output.sigma_BR, out.sigma_BR.data);

--- a/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
+++ b/algorithms/averageMimuData/averageMimuDataAlgorithm_c.cpp
@@ -1,5 +1,6 @@
 #include "averageMimuDataAlgorithm_c.h"
 #include "averageMimuDataAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -8,11 +9,11 @@ uint32_t AverageMimuDataAlgorithm_getMaxMimuPkt(void) { return MAX_MIMU_PKT_C; }
 uint32_t AverageMimuDataAlgorithm_getMaxMimuSamplesPerPkt(void) { return MAX_MIMU_SAMPLES_PER_PKT_C; }
 
 AverageMimuDataAlgorithmHandle* AverageMimuDataAlgorithm_create(void) {
-    return reinterpret_cast<AverageMimuDataAlgorithmHandle*>(new ::AverageMimuDataAlgorithm());
+    return fsw::createHandle<::AverageMimuDataAlgorithm, AverageMimuDataAlgorithmHandle>();
 }
 
 void AverageMimuDataAlgorithm_destroy(AverageMimuDataAlgorithmHandle* self) {
-    delete reinterpret_cast<::AverageMimuDataAlgorithm*>(self);
+    fsw::deleteHandle<::AverageMimuDataAlgorithm>(self);
 }
 
 OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgorithmHandle* self,
@@ -31,7 +32,7 @@ OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgo
         }
     }
 
-    const auto [accel_B, gyroOmega_B] = reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->update(in);
+    const auto [accel_B, gyroOmega_B] = fsw::fromHandle<::AverageMimuDataAlgorithm>(self)->update(in);
 
     OutputAverageAccelAngleVel_c result{};
     result.accel_B = Vector3f_c{{accel_B[0], accel_B[1], accel_B[2]}};
@@ -40,19 +41,19 @@ OutputAverageAccelAngleVel_c AverageMimuDataAlgorithm_update(AverageMimuDataAlgo
 }
 
 void AverageMimuDataAlgorithm_setGyroAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window) {
-    reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->setGyroAveragingWindow(window);
+    fsw::fromHandle<::AverageMimuDataAlgorithm>(self)->setGyroAveragingWindow(window);
 }
 
 double AverageMimuDataAlgorithm_getGyroAveragingWindow(const AverageMimuDataAlgorithmHandle* self) {
-    return reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getGyroAveragingWindow();
+    return fsw::fromHandle<const ::AverageMimuDataAlgorithm>(self)->getGyroAveragingWindow();
 }
 
 void AverageMimuDataAlgorithm_setAccelAveragingWindow(AverageMimuDataAlgorithmHandle* self, double window) {
-    reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->setAccelAveragingWindow(window);
+    fsw::fromHandle<::AverageMimuDataAlgorithm>(self)->setAccelAveragingWindow(window);
 }
 
 double AverageMimuDataAlgorithm_getAccelAveragingWindow(const AverageMimuDataAlgorithmHandle* self) {
-    return reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getAccelAveragingWindow();
+    return fsw::fromHandle<const ::AverageMimuDataAlgorithm>(self)->getAccelAveragingWindow();
 }
 
 void AverageMimuDataAlgorithm_setDcmPltfToBdy(AverageMimuDataAlgorithmHandle* self, Matrix3f_c dcm_BP) {
@@ -62,11 +63,11 @@ void AverageMimuDataAlgorithm_setDcmPltfToBdy(AverageMimuDataAlgorithmHandle* se
             mat(i, j) = dcm_BP.data[i][j];
         }
     }
-    reinterpret_cast<::AverageMimuDataAlgorithm*>(self)->setDcmPltfToBdy(mat);
+    fsw::fromHandle<::AverageMimuDataAlgorithm>(self)->setDcmPltfToBdy(mat);
 }
 
 Matrix3f_c AverageMimuDataAlgorithm_getDcmPltfToBdy(const AverageMimuDataAlgorithmHandle* self) {
-    Eigen::Matrix3f mat = reinterpret_cast<const ::AverageMimuDataAlgorithm*>(self)->getDcmPltfToBdy();
+    Eigen::Matrix3f mat = fsw::fromHandle<const ::AverageMimuDataAlgorithm>(self)->getDcmPltfToBdy();
     Matrix3f_c out;
     for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++) {

--- a/algorithms/bodyRateMiscompare/bodyRateMiscompareAlgorithm_c.cpp
+++ b/algorithms/bodyRateMiscompare/bodyRateMiscompareAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "bodyRateMiscompareAlgorithm.h"
 #include "bodyRateMiscompareTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -12,31 +13,30 @@ BodyRateMiscompareConfig configFromC(const BodyRateMiscompareConfig_c& c) {
 }  // namespace
 
 BodyRateMiscompareAlgorithmHandle* BodyRateMiscompareAlgorithm_create(const BodyRateMiscompareConfig_c* config) {
-    return reinterpret_cast<BodyRateMiscompareAlgorithmHandle*>(
-        new ::BodyRateMiscompareAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::BodyRateMiscompareAlgorithm, BodyRateMiscompareAlgorithmHandle>(configFromC(*config));
 }
 
 void BodyRateMiscompareAlgorithm_destroy(BodyRateMiscompareAlgorithmHandle* self) {
-    delete reinterpret_cast<::BodyRateMiscompareAlgorithm*>(self);
+    fsw::deleteHandle<::BodyRateMiscompareAlgorithm>(self);
 }
 
 void BodyRateMiscompareAlgorithm_setConfig(BodyRateMiscompareAlgorithmHandle* self,
                                            const BodyRateMiscompareConfig_c* config) {
-    reinterpret_cast<::BodyRateMiscompareAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::BodyRateMiscompareAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 void BodyRateMiscompareAlgorithm_reInitializeExceptPersistentStates(BodyRateMiscompareAlgorithmHandle* self) {
-    reinterpret_cast<::BodyRateMiscompareAlgorithm*>(self)->reInitializeExceptPersistentStates();
+    fsw::fromHandle<::BodyRateMiscompareAlgorithm>(self)->reInitializeExceptPersistentStates();
 }
 
 void BodyRateMiscompareAlgorithm_reInitialize(BodyRateMiscompareAlgorithmHandle* self) {
-    reinterpret_cast<::BodyRateMiscompareAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<::BodyRateMiscompareAlgorithm>(self)->reInitialize();
 }
 
 BodyRateMiscompareOutput_c BodyRateMiscompareAlgorithm_update(BodyRateMiscompareAlgorithmHandle* self,
                                                               Vector3f_c imuOmega,
                                                               Vector3f_c stOmega) {
-    const BodyRateMiscompareOutput result = reinterpret_cast<::BodyRateMiscompareAlgorithm*>(self)->update(
+    const BodyRateMiscompareOutput result = fsw::fromHandle<::BodyRateMiscompareAlgorithm>(self)->update(
         cArrayToEigenVector3<float>(imuOmega.data), cArrayToEigenVector3<float>(stOmega.data));
 
     BodyRateMiscompareOutput_c out{};

--- a/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm_c.cpp
+++ b/algorithms/convertStPlatformToBody/convertStPlatformToBodyAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "convertStPlatformToBodyAlgorithm.h"
 #include "convertStPlatformToBodyTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -13,17 +14,17 @@ ConvertStPlatformToBodyConfig configFromC(const ConvertStPlatformToBodyConfig_c&
 
 ConvertStPlatformToBodyAlgorithmHandle* ConvertStPlatformToBodyAlgorithm_create(
     const ConvertStPlatformToBodyConfig_c* config) {
-    return reinterpret_cast<ConvertStPlatformToBodyAlgorithmHandle*>(
-        new ::ConvertStPlatformToBodyAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::ConvertStPlatformToBodyAlgorithm, ConvertStPlatformToBodyAlgorithmHandle>(
+        configFromC(*config));
 }
 
 void ConvertStPlatformToBodyAlgorithm_destroy(ConvertStPlatformToBodyAlgorithmHandle* self) {
-    delete reinterpret_cast<::ConvertStPlatformToBodyAlgorithm*>(self);
+    fsw::deleteHandle<::ConvertStPlatformToBodyAlgorithm>(self);
 }
 
 void ConvertStPlatformToBodyAlgorithm_setConfig(ConvertStPlatformToBodyAlgorithmHandle* self,
                                                 const ConvertStPlatformToBodyConfig_c* config) {
-    reinterpret_cast<::ConvertStPlatformToBodyAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::ConvertStPlatformToBodyAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 StAttitudeOutput_c ConvertStPlatformToBodyAlgorithm_update(ConvertStPlatformToBodyAlgorithmHandle* self,
@@ -32,7 +33,7 @@ StAttitudeOutput_c ConvertStPlatformToBodyAlgorithm_update(ConvertStPlatformToBo
     const Eigen::Vector4f q_CN = cArrayToEigenVector(platformAttitude->q_CN);
     const Eigen::Vector4f dq_CN = cArrayToEigenVector(platformAngularRate->dq_CN);
 
-    const StAttitudeOutput out = reinterpret_cast<::ConvertStPlatformToBodyAlgorithm*>(self)->update(q_CN, dq_CN);
+    const StAttitudeOutput out = fsw::fromHandle<::ConvertStPlatformToBodyAlgorithm>(self)->update(q_CN, dq_CN);
 
     StAttitudeOutput_c result{};
     eigenVectorToCArray(out.sigma_BN, result.sigma_BN);

--- a/algorithms/cssComm/cssCommAlgorithm_c.cpp
+++ b/algorithms/cssComm/cssCommAlgorithm_c.cpp
@@ -1,5 +1,6 @@
 #include "cssCommAlgorithm_c.h"
 #include "cssCommAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <algorithm>
 #include <array>
@@ -15,20 +16,20 @@ CssCommConfig configFromC(const CssCommConfig_c& c) {
 }  // namespace
 
 CssCommAlgorithmHandle* CssCommAlgorithm_create(const CssCommConfig_c* config) {
-    return reinterpret_cast<CssCommAlgorithmHandle*>(new ::CssCommAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::CssCommAlgorithm, CssCommAlgorithmHandle>(configFromC(*config));
 }
 
-void CssCommAlgorithm_destroy(CssCommAlgorithmHandle* self) { delete reinterpret_cast<::CssCommAlgorithm*>(self); }
+void CssCommAlgorithm_destroy(CssCommAlgorithmHandle* self) { fsw::deleteHandle<::CssCommAlgorithm>(self); }
 
 void CssCommAlgorithm_setConfig(CssCommAlgorithmHandle* self, const CssCommConfig_c* config) {
-    reinterpret_cast<::CssCommAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::CssCommAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 CssSensorValues_c CssCommAlgorithm_update(const CssCommAlgorithmHandle* self, const CssSensorValues_c* inputValues) {
     std::array<double, kMaxNumCssSensors> input{};
     std::copy(inputValues->data, inputValues->data + kMaxNumCssSensors, input.begin());
 
-    std::array<double, kMaxNumCssSensors> result = reinterpret_cast<const ::CssCommAlgorithm*>(self)->update(input);
+    std::array<double, kMaxNumCssSensors> result = fsw::fromHandle<const ::CssCommAlgorithm>(self)->update(input);
 
     CssSensorValues_c out{};
     std::copy(result.begin(), result.end(), out.data);

--- a/algorithms/dvAccumulation/dvAccumulationAlgorithm_c.cpp
+++ b/algorithms/dvAccumulation/dvAccumulationAlgorithm_c.cpp
@@ -2,28 +2,29 @@
 #include "dvAccumulationAlgorithm.h"
 #include "msgPayloadDef/AccDataMsgF32Payload.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 uint32_t DvAccumulationAlgorithm_getMaxAccBufPkt(void) { return MAX_ACC_BUF_PKT; }
 
 DvAccumulationAlgorithmHandle* DvAccumulationAlgorithm_create(void) {
-    return reinterpret_cast<DvAccumulationAlgorithmHandle*>(new ::DvAccumulationAlgorithm());
+    return fsw::createHandle<::DvAccumulationAlgorithm, DvAccumulationAlgorithmHandle>();
 }
 
 void DvAccumulationAlgorithm_destroy(DvAccumulationAlgorithmHandle* self) {
-    delete reinterpret_cast<::DvAccumulationAlgorithm*>(self);
+    fsw::deleteHandle<::DvAccumulationAlgorithm>(self);
 }
 
 void DvAccumulationAlgorithm_reInitialize(DvAccumulationAlgorithmHandle* self) {
-    reinterpret_cast<::DvAccumulationAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<::DvAccumulationAlgorithm>(self)->reInitialize();
 }
 
 void DvAccumulationAlgorithm_reInitializeExceptPersistentStates(DvAccumulationAlgorithmHandle* self) {
-    reinterpret_cast<::DvAccumulationAlgorithm*>(self)->reInitializeExceptPersistentStates();
+    fsw::fromHandle<::DvAccumulationAlgorithm>(self)->reInitializeExceptPersistentStates();
 }
 
 DvAccumulationOutput_c DvAccumulationAlgorithm_update(DvAccumulationAlgorithmHandle* self,
                                                       const AccDataMsgF32Payload* accData) {
-    const DvAccumulationOutput out = reinterpret_cast<::DvAccumulationAlgorithm*>(self)->update(*accData);
+    const DvAccumulationOutput out = fsw::fromHandle<::DvAccumulationAlgorithm>(self)->update(*accData);
 
     DvAccumulationOutput_c result{};
     result.timeTag = out.timeTag;

--- a/algorithms/dvGuidance/dvGuidanceAlgorithm_c.cpp
+++ b/algorithms/dvGuidance/dvGuidanceAlgorithm_c.cpp
@@ -1,20 +1,15 @@
 #include "dvGuidanceAlgorithm_c.h"
 #include "dvGuidanceAlgorithm.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
 DvGuidanceAlgorithmHandle* DvGuidanceAlgorithm_create(void) {
-    // clang-format off
-    return reinterpret_cast<DvGuidanceAlgorithmHandle*>(new ::DvGuidanceAlgorithm());  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
+    return fsw::createHandle<::DvGuidanceAlgorithm, DvGuidanceAlgorithmHandle>();
 }
 
-void DvGuidanceAlgorithm_destroy(DvGuidanceAlgorithmHandle* self) {
-    // clang-format off
-    delete reinterpret_cast<::DvGuidanceAlgorithm*>(self);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
-}
+void DvGuidanceAlgorithm_destroy(DvGuidanceAlgorithmHandle* self) { fsw::deleteHandle<::DvGuidanceAlgorithm>(self); }
 
 AttRefMsgF32Payload DvGuidanceAlgorithm_update(const DvGuidanceAlgorithmHandle* self,
                                                Vector3f_c dvInrtlCmd,
@@ -25,9 +20,8 @@ AttRefMsgF32Payload DvGuidanceAlgorithm_update(const DvGuidanceAlgorithmHandle* 
     const Eigen::Vector3f dvInrtlCmd_e = cArrayToEigenVector3<float>(dvInrtlCmd.data);
     const Eigen::Vector3f dvRotVecUnit_e = cArrayToEigenVector3<float>(dvRotVecUnit.data);
 
-    // clang-format off
-    const DvGuidanceOutput out = reinterpret_cast<const ::DvGuidanceAlgorithm*>(self)->update(dvInrtlCmd_e, dvRotVecUnit_e, dvRotVecMag, burnStartTime, callTime);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    const DvGuidanceOutput out = fsw::fromHandle<const ::DvGuidanceAlgorithm>(self)->update(
+        dvInrtlCmd_e, dvRotVecUnit_e, dvRotVecMag, burnStartTime, callTime);
 
     AttRefMsgF32Payload payload{};
     eigenVectorToCArray(out.sigma_RN, payload.sigma_RN);

--- a/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm_c.cpp
+++ b/algorithms/ephemeridesRecenter/ephemeridesRecenterAlgorithm_c.cpp
@@ -1,5 +1,6 @@
 #include "ephemeridesRecenterAlgorithm_c.h"
 #include "ephemeridesRecenterAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <array>
 #include <cstddef>
@@ -18,17 +19,16 @@ EphemeridesRecenterConfig configFromC(const EphemeridesRecenterConfig_c& c) {
 }  // namespace
 
 EphemeridesRecenterAlgorithmHandle* EphemeridesRecenterAlgorithm_create(const EphemeridesRecenterConfig_c* config) {
-    return reinterpret_cast<EphemeridesRecenterAlgorithmHandle*>(
-        new ::EphemeridesRecenterAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::EphemeridesRecenterAlgorithm, EphemeridesRecenterAlgorithmHandle>(configFromC(*config));
 }
 
 void EphemeridesRecenterAlgorithm_destroy(EphemeridesRecenterAlgorithmHandle* self) {
-    delete reinterpret_cast<::EphemeridesRecenterAlgorithm*>(self);
+    fsw::deleteHandle<::EphemeridesRecenterAlgorithm>(self);
 }
 
 void EphemeridesRecenterAlgorithm_setConfig(EphemeridesRecenterAlgorithmHandle* self,
                                             const EphemeridesRecenterConfig_c* config) {
-    reinterpret_cast<::EphemeridesRecenterAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::EphemeridesRecenterAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 BodyEphemerisPayloadArray20_c EphemeridesRecenterAlgorithm_updateState(EphemeridesRecenterAlgorithmHandle* self,
@@ -45,7 +45,7 @@ BodyEphemerisPayloadArray20_c EphemeridesRecenterAlgorithm_updateState(Ephemerid
     }
 
     std::array<BodyEphemerisPayload, MAX_NUM_CHANGE_BODIES> result =
-        reinterpret_cast<::EphemeridesRecenterAlgorithm*>(self)->updateState(input);
+        fsw::fromHandle<::EphemeridesRecenterAlgorithm>(self)->updateState(input);
 
     BodyEphemerisPayloadArray20_c out{};
     for (std::size_t i = 0U; i < MAX_NUM_CHANGE_BODIES; ++i) {

--- a/algorithms/flybyFilter/flybyFilterAlgorithm.cpp
+++ b/algorithms/flybyFilter/flybyFilterAlgorithm.cpp
@@ -2,6 +2,8 @@
 
 #include <Eigen/Core>
 
+#include <utility>
+
 namespace filtering::flybyFilter {
 
 namespace {
@@ -11,14 +13,12 @@ using State = FlybyFilterAlgorithm::State;
 /*! Optical-navigation heading observation = r/|r| (the unit vector pointing from the spacecraft to
  *  the central body, inertial frame). Satisfies the Measurement concept for use inside the SRuKF.
  *  subtract() is the plain vector difference -- the observation and model both live in R^3. */
-// A concept-model helper: members are public by design
-// NOLINTBEGIN(misc-non-private-member-variables-in-classes, clang-diagnostic-unused-member-function,
-// clang-diagnostic-unused-variable)
-struct HeadingMeasurementModel {
+class HeadingMeasurementModel {
+   public:
     static constexpr int size = 3;
 
-    Eigen::Vector3d observed = Eigen::Vector3d::Zero();
-    Eigen::Matrix3d measNoise = Eigen::Matrix3d::Identity();
+    HeadingMeasurementModel(Eigen::Vector3d observation, Eigen::Matrix3d noise)
+        : observed(std::move(observation)), measNoise(std::move(noise)) {}
 
     Eigen::Vector3d observation() const { return this->observed; }
     static Eigen::Vector3d model(State const& state) {
@@ -27,9 +27,11 @@ struct HeadingMeasurementModel {
     }
     Eigen::Matrix3d noise() const { return this->measNoise; }
     static Eigen::Vector3d subtract(Eigen::Vector3d const& a, Eigen::Vector3d const& b) { return a - b; }
+
+   private:
+    Eigen::Vector3d observed;
+    Eigen::Matrix3d measNoise;
 };
-// NOLINTEND(misc-non-private-member-variables-in-classes, clang-diagnostic-unused-member-function,
-// clang-diagnostic-unused-variable)
 
 static_assert(filtering::Measurement<HeadingMeasurementModel, State>);
 
@@ -114,12 +116,10 @@ void FlybyFilterAlgorithm::clear() {
  *  @return true iff the update was applied (state/covariance finite)
  *  @param measurement [-] packed heading measurement (rhat_BN_N, noise) */
 bool FlybyFilterAlgorithm::applyMeasurement(HeadingMeasurement const& measurement) {
-    HeadingMeasurementModel model;
-    model.observed = measurement.rhat_BN_N;
-    model.measNoise = measurement.covar;
+    HeadingMeasurementModel const model{measurement.rhat_BN_N, measurement.covar};
 
     auto const result = this->srukf.measurementUpdate(model);
-    this->lastHeadingResiduals.observation = model.observed;
+    this->lastHeadingResiduals.observation = model.observation();
     if (result.has_value()) {
         this->lastHeadingResiduals.valid = measurement.valid;
         this->lastHeadingResiduals.preFit = result->preFit;

--- a/algorithms/flybyFilter/flybyFilterAlgorithm_c.cpp
+++ b/algorithms/flybyFilter/flybyFilterAlgorithm_c.cpp
@@ -1,6 +1,7 @@
 #include "flybyFilterAlgorithm_c.h"
 
 #include "flybyFilterAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -57,23 +58,17 @@ FlybyFilterOutput_c outputToC(const FlybyFilterOutput& out) {
 uint32_t FlybyFilterAlgorithm_getNumStates(void) { return FLYBY_FILTER_NUM_STATES; }
 
 FlybyFilterAlgorithmHandle* FlybyFilterAlgorithm_create(const FlybyFilterConfig_c* config) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    return reinterpret_cast<FlybyFilterAlgorithmHandle*>(new FlybyFilterAlgorithm(configFromC(*config)));
+    return fsw::createHandle<FlybyFilterAlgorithm, FlybyFilterAlgorithmHandle>(configFromC(*config));
 }
 
-void FlybyFilterAlgorithm_destroy(FlybyFilterAlgorithmHandle* self) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    delete reinterpret_cast<FlybyFilterAlgorithm*>(self);
-}
+void FlybyFilterAlgorithm_destroy(FlybyFilterAlgorithmHandle* self) { fsw::deleteHandle<FlybyFilterAlgorithm>(self); }
 
 void FlybyFilterAlgorithm_reInitializeExceptPersistentStates(FlybyFilterAlgorithmHandle* self) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    reinterpret_cast<FlybyFilterAlgorithm*>(self)->reInitializeExceptPersistentStates();
+    fsw::fromHandle<FlybyFilterAlgorithm>(self)->reInitializeExceptPersistentStates();
 }
 
 void FlybyFilterAlgorithm_reInitialize(FlybyFilterAlgorithmHandle* self) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    reinterpret_cast<FlybyFilterAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<FlybyFilterAlgorithm>(self)->reInitialize();
 }
 
 FlybyFilterOutput_c FlybyFilterAlgorithm_update(FlybyFilterAlgorithmHandle* self,
@@ -83,8 +78,7 @@ FlybyFilterOutput_c FlybyFilterAlgorithm_update(FlybyFilterAlgorithmHandle* self
     in.timeTag = heading->timeTag;
     in.rhat_BN_N = Eigen::Vector3d(heading->rhat_BN_N[0], heading->rhat_BN_N[1], heading->rhat_BN_N[2]);
 
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    auto* algo = reinterpret_cast<FlybyFilterAlgorithm*>(self);
+    auto* algo = fsw::fromHandle<FlybyFilterAlgorithm>(self);
     const FlybyFilterOutput out = algo->update(currentSeconds, in);
     return outputToC(out);
 }

--- a/algorithms/forceTorqueThrForceMapping/forceTorqueThrForceMappingAlgorithm_c.cpp
+++ b/algorithms/forceTorqueThrForceMapping/forceTorqueThrForceMappingAlgorithm_c.cpp
@@ -3,6 +3,7 @@
 #include "forceTorqueThrForceMappingAlgorithm.h"
 #include "forceTorqueThrForceMappingTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 #include <array>
@@ -31,32 +32,27 @@ ForceTorqueThrForceMappingConfig configFromC(const ForceTorqueThrForceMappingCon
 
 uint32_t ForceTorqueThrForceMappingAlgorithm_getMaxEffCnt(void) { return MAX_EFF_CNT; }
 
-ForceTorqueThrForceMappingAlgorithm* ForceTorqueThrForceMappingAlgorithm_create(
+ForceTorqueThrForceMappingAlgorithmHandle* ForceTorqueThrForceMappingAlgorithm_create(
     const ForceTorqueThrForceMappingConfig_c* config) {
-    // clang-format off
-    return reinterpret_cast<ForceTorqueThrForceMappingAlgorithm*>(new ::ForceTorqueThrForceMappingAlgorithm(configFromC(*config)));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
+    return fsw::createHandle<::ForceTorqueThrForceMappingAlgorithm, ForceTorqueThrForceMappingAlgorithmHandle>(
+        configFromC(*config));
 }
 
-void ForceTorqueThrForceMappingAlgorithm_destroy(ForceTorqueThrForceMappingAlgorithm* self) {
-    // clang-format off
-    delete reinterpret_cast<::ForceTorqueThrForceMappingAlgorithm*>(self);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
+void ForceTorqueThrForceMappingAlgorithm_destroy(ForceTorqueThrForceMappingAlgorithmHandle* self) {
+    fsw::deleteHandle<::ForceTorqueThrForceMappingAlgorithm>(self);
 }
 
-void ForceTorqueThrForceMappingAlgorithm_setConfig(ForceTorqueThrForceMappingAlgorithm* self,
+void ForceTorqueThrForceMappingAlgorithm_setConfig(ForceTorqueThrForceMappingAlgorithmHandle* self,
                                                    const ForceTorqueThrForceMappingConfig_c* config) {
-    // clang-format off
-    reinterpret_cast<::ForceTorqueThrForceMappingAlgorithm*>(self)->setConfig(configFromC(*config));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    fsw::fromHandle<::ForceTorqueThrForceMappingAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
-ThrForceArray_c ForceTorqueThrForceMappingAlgorithm_update(const ForceTorqueThrForceMappingAlgorithm* self,
+ThrForceArray_c ForceTorqueThrForceMappingAlgorithm_update(const ForceTorqueThrForceMappingAlgorithmHandle* self,
                                                            const Vector3f_c cmdTorque_B,
                                                            const Vector3f_c cmdForce_B) {
-    // clang-format off
-    const Eigen::Vector<float, MAX_EFF_CNT> out = reinterpret_cast<const ::ForceTorqueThrForceMappingAlgorithm*>(self)->update(cArrayToEigenVector3<float>(cmdTorque_B.data), cArrayToEigenVector3<float>(cmdForce_B.data));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    const Eigen::Vector<float, MAX_EFF_CNT> out =
+        fsw::fromHandle<const ::ForceTorqueThrForceMappingAlgorithm>(self)->update(
+            cArrayToEigenVector3<float>(cmdTorque_B.data), cArrayToEigenVector3<float>(cmdForce_B.data));
 
     ThrForceArray_c result{};
     eigenVectorToCArray(out, result.thrForce);

--- a/algorithms/forceTorqueThrForceMapping/forceTorqueThrForceMappingAlgorithm_c.h
+++ b/algorithms/forceTorqueThrForceMapping/forceTorqueThrForceMappingAlgorithm_c.h
@@ -12,7 +12,7 @@ extern "C" {
 /**
  * @brief Opaque handle to the C++ ForceTorqueThrForceMappingAlgorithm instance.
  */
-typedef struct ForceTorqueThrForceMappingAlgorithm ForceTorqueThrForceMappingAlgorithm;
+typedef struct ForceTorqueThrForceMappingAlgorithmHandle ForceTorqueThrForceMappingAlgorithmHandle;
 
 /**
  * @brief Get the MAX_EFF_CNT constant for Ada validation.
@@ -30,21 +30,21 @@ uint32_t ForceTorqueThrForceMappingAlgorithm_getMaxEffCnt(void);
  * @param config Pointer to the configuration to apply (validated; throws on invalid input).
  * @return Pointer to a new ForceTorqueThrForceMappingAlgorithm (must be destroyed).
  */
-ForceTorqueThrForceMappingAlgorithm* ForceTorqueThrForceMappingAlgorithm_create(
+ForceTorqueThrForceMappingAlgorithmHandle* ForceTorqueThrForceMappingAlgorithm_create(
     const ForceTorqueThrForceMappingConfig_c* config);
 
 /**
  * @brief Destroy a previously created ForceTorqueThrForceMappingAlgorithm.
  * @param self Pointer to the instance to destroy.
  */
-void ForceTorqueThrForceMappingAlgorithm_destroy(ForceTorqueThrForceMappingAlgorithm* self);
+void ForceTorqueThrForceMappingAlgorithm_destroy(ForceTorqueThrForceMappingAlgorithmHandle* self);
 
 /**
  * @brief Replace the configuration at runtime and recompute the thruster mapping matrix.
  * @param self   Pointer to the instance.
  * @param config Pointer to the configuration to apply (validated; throws on invalid input).
  */
-void ForceTorqueThrForceMappingAlgorithm_setConfig(ForceTorqueThrForceMappingAlgorithm* self,
+void ForceTorqueThrForceMappingAlgorithm_setConfig(ForceTorqueThrForceMappingAlgorithmHandle* self,
                                                    const ForceTorqueThrForceMappingConfig_c* config);
 
 /**
@@ -58,7 +58,7 @@ void ForceTorqueThrForceMappingAlgorithm_setConfig(ForceTorqueThrForceMappingAlg
  * @param cmdForce_B  [N]  requested control force in body frame
  * @return ThrForceArray_c per-thruster force commands.
  */
-ThrForceArray_c ForceTorqueThrForceMappingAlgorithm_update(const ForceTorqueThrForceMappingAlgorithm* self,
+ThrForceArray_c ForceTorqueThrForceMappingAlgorithm_update(const ForceTorqueThrForceMappingAlgorithmHandle* self,
                                                            Vector3f_c cmdTorque_B,
                                                            Vector3f_c cmdForce_B);
 

--- a/algorithms/hillPoint/hillPointAlgorithm_c.cpp
+++ b/algorithms/hillPoint/hillPointAlgorithm_c.cpp
@@ -1,20 +1,15 @@
 #include "hillPointAlgorithm_c.h"
 #include "hillPointAlgorithm.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
 HillPointAlgorithmHandle* HillPointAlgorithm_create(void) {
-    // clang-format off
-    return reinterpret_cast<HillPointAlgorithmHandle*>(new ::HillPointAlgorithm());  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
+    return fsw::createHandle<::HillPointAlgorithm, HillPointAlgorithmHandle>();
 }
 
-void HillPointAlgorithm_destroy(HillPointAlgorithmHandle* self) {
-    // clang-format off
-    delete reinterpret_cast<::HillPointAlgorithm*>(self);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
-}
+void HillPointAlgorithm_destroy(HillPointAlgorithmHandle* self) { fsw::deleteHandle<::HillPointAlgorithm>(self); }
 
 AttRefMsgF32Payload HillPointAlgorithm_update(const HillPointAlgorithmHandle* self,
                                               Vector3d_c r_BN_N,
@@ -26,9 +21,8 @@ AttRefMsgF32Payload HillPointAlgorithm_update(const HillPointAlgorithmHandle* se
     const Eigen::Vector3d r_planet_N_e = cArrayToEigenVector3<double>(r_planet_N.data);
     const Eigen::Vector3d v_planet_N_e = cArrayToEigenVector3<double>(v_planet_N.data);
 
-    // clang-format off
-    const HillPointOutput out = reinterpret_cast<const ::HillPointAlgorithm*>(self)->update(r_BN_N_e, v_BN_N_e, r_planet_N_e, v_planet_N_e);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    const HillPointOutput out =
+        fsw::fromHandle<const ::HillPointAlgorithm>(self)->update(r_BN_N_e, v_BN_N_e, r_planet_N_e, v_planet_N_e);
 
     AttRefMsgF32Payload payload{};
     eigenVectorToCArray(out.sigma_RN, payload.sigma_RN);

--- a/algorithms/inertial3D/inertial3DAlgorithm_c.cpp
+++ b/algorithms/inertial3D/inertial3DAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "inertial3DAlgorithm.h"
 #include "inertial3DTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -12,19 +13,17 @@ Inertial3DConfig configFromC(const Inertial3DConfig_c& c) {
 }  // namespace
 
 Inertial3DAlgorithmHandle* Inertial3DAlgorithm_create(const Inertial3DConfig_c* config) {
-    return reinterpret_cast<Inertial3DAlgorithmHandle*>(new ::Inertial3DAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::Inertial3DAlgorithm, Inertial3DAlgorithmHandle>(configFromC(*config));
 }
 
-void Inertial3DAlgorithm_destroy(Inertial3DAlgorithmHandle* self) {
-    delete reinterpret_cast<::Inertial3DAlgorithm*>(self);
-}
+void Inertial3DAlgorithm_destroy(Inertial3DAlgorithmHandle* self) { fsw::deleteHandle<::Inertial3DAlgorithm>(self); }
 
 void Inertial3DAlgorithm_setConfig(Inertial3DAlgorithmHandle* self, const Inertial3DConfig_c* config) {
-    reinterpret_cast<::Inertial3DAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::Inertial3DAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 Vector3f_c Inertial3DAlgorithm_update(const Inertial3DAlgorithmHandle* self) {
-    const Eigen::Vector3f sigma_RN = reinterpret_cast<const ::Inertial3DAlgorithm*>(self)->update();
+    const Eigen::Vector3f sigma_RN = fsw::fromHandle<const ::Inertial3DAlgorithm>(self)->update();
     Vector3f_c out{};
     eigenVectorToCArray(sigma_RN, out.data);
     return out;

--- a/algorithms/inertialFilter/inertialFilterAlgorithm.cpp
+++ b/algorithms/inertialFilter/inertialFilterAlgorithm.cpp
@@ -2,6 +2,7 @@
 
 #include "utilities/fsw/rigidBodyKinematics.hpp"
 
+#include <utility>
 #include <variant>
 
 namespace filtering::inertialFilter {
@@ -14,40 +15,40 @@ using State = InertialFilterAlgorithm::State;
  *  concept for use inside the SRuKF. subtract() forms the MRP-difference
  *  (shadow-set aware) so the innovation stays small across the |sigma| = 1
  *  boundary. */
-// A concept-model helper: members are public by design (aggregate) and some accessors are only
-// odr-used through the SRuKF template, so silence the resulting internal-linkage diagnostics.
-// NOLINTBEGIN(misc-non-private-member-variables-in-classes, clang-diagnostic-unused-member-function,
-// clang-diagnostic-unused-variable)
-struct StAttMeasurementModel {
+class StAttMeasurementModel {
+   public:
     static constexpr int size = 3;
 
-    Eigen::Vector3d observed = Eigen::Vector3d::Zero();
-    Eigen::Matrix3d measNoise = Eigen::Matrix3d::Identity();
+    StAttMeasurementModel(Eigen::Vector3d observation, Eigen::Matrix3d noise)
+        : observed(std::move(observation)), measNoise(std::move(noise)) {}
 
     Eigen::Vector3d observation() const { return this->observed; }
     static Eigen::Vector3d model(State const& state) { return state.get<filtering::MrpAttitude<3>>(); }
     Eigen::Matrix3d noise() const { return this->measNoise; }
     static Eigen::Vector3d subtract(Eigen::Vector3d const& a, Eigen::Vector3d const& b) { return subMrp(a, b); }
+
+   private:
+    Eigen::Vector3d observed;
+    Eigen::Matrix3d measNoise;
 };
-// NOLINTEND(misc-non-private-member-variables-in-classes, clang-diagnostic-unused-member-function,
-// clang-diagnostic-unused-variable)
 
 /*! Predicted gyro observation = omega_BN_B. Satisfies the Measurement concept. */
-// NOLINTBEGIN(misc-non-private-member-variables-in-classes, clang-diagnostic-unused-member-function,
-// clang-diagnostic-unused-variable)
-struct RateMeasurementModel {
+class RateMeasurementModel {
+   public:
     static constexpr int size = 3;
 
-    Eigen::Vector3d observed = Eigen::Vector3d::Zero();
-    Eigen::Matrix3d measNoise = Eigen::Matrix3d::Identity();
+    RateMeasurementModel(Eigen::Vector3d observation, Eigen::Matrix3d noise)
+        : observed(std::move(observation)), measNoise(std::move(noise)) {}
 
     Eigen::Vector3d observation() const { return this->observed; }
     static Eigen::Vector3d model(State const& state) { return state.get<filtering::AngularRate<3>>(); }
     Eigen::Matrix3d noise() const { return this->measNoise; }
     static Eigen::Vector3d subtract(Eigen::Vector3d const& a, Eigen::Vector3d const& b) { return a - b; }
+
+   private:
+    Eigen::Vector3d observed;
+    Eigen::Matrix3d measNoise;
 };
-// NOLINTEND(misc-non-private-member-variables-in-classes, clang-diagnostic-unused-member-function,
-// clang-diagnostic-unused-variable)
 
 static_assert(filtering::Measurement<StAttMeasurementModel, State>);
 static_assert(filtering::Measurement<RateMeasurementModel, State>);
@@ -144,12 +145,10 @@ void InertialFilterAlgorithm::clear() {
  *  @return true iff the update was applied (state/covariance finite)
  *  @param measurement [-] packed ST measurement (sigma_BN, noise) */
 bool InertialFilterAlgorithm::applyMeasurement(StAttMeasurement const& measurement) {
-    StAttMeasurementModel model;
-    model.observed = measurement.sigma_BN;
-    model.measNoise = measurement.covar;
+    StAttMeasurementModel const model{measurement.sigma_BN, measurement.covar};
 
     auto const result = this->srukf.measurementUpdate(model);
-    this->lastStAttResiduals.observation = model.observed;
+    this->lastStAttResiduals.observation = model.observation();
     if (result.has_value()) {
         this->lastStAttResiduals.valid = measurement.valid;
         this->lastStAttResiduals.preFit = result->preFit;
@@ -163,12 +162,10 @@ bool InertialFilterAlgorithm::applyMeasurement(StAttMeasurement const& measureme
  *  @return true iff the update was applied (state/covariance finite)
  *  @param measurement [-] packed rate measurement (omega, noise) */
 bool InertialFilterAlgorithm::applyMeasurement(RateMeasurement const& measurement) {
-    RateMeasurementModel model;
-    model.observed = measurement.omega_BN_B;
-    model.measNoise = measurement.covar;
+    RateMeasurementModel const model{measurement.omega_BN_B, measurement.covar};
 
     auto const result = this->srukf.measurementUpdate(model);
-    this->lastRateResiduals.observation = model.observed;
+    this->lastRateResiduals.observation = model.observation();
     if (result.has_value()) {
         this->lastRateResiduals.valid = measurement.valid;
         this->lastRateResiduals.preFit = result->preFit;

--- a/algorithms/inertialFilter/inertialFilterAlgorithm_c.cpp
+++ b/algorithms/inertialFilter/inertialFilterAlgorithm_c.cpp
@@ -1,6 +1,7 @@
 #include "inertialFilterAlgorithm_c.h"
 
 #include "inertialFilterAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -68,23 +69,19 @@ InertialFilterOutput_c outputToC(const InertialFilterOutput& out) {
 uint32_t InertialFilterAlgorithm_getNumStates(void) { return INERTIAL_FILTER_NUM_STATES; }
 
 InertialFilterAlgorithmHandle* InertialFilterAlgorithm_create(const InertialFilterConfig_c* config) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    return reinterpret_cast<InertialFilterAlgorithmHandle*>(new InertialFilterAlgorithm(configFromC(*config)));
+    return fsw::createHandle<InertialFilterAlgorithm, InertialFilterAlgorithmHandle>(configFromC(*config));
 }
 
 void InertialFilterAlgorithm_destroy(InertialFilterAlgorithmHandle* self) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    delete reinterpret_cast<InertialFilterAlgorithm*>(self);
+    fsw::deleteHandle<InertialFilterAlgorithm>(self);
 }
 
 void InertialFilterAlgorithm_reInitializeExceptPersistentStates(InertialFilterAlgorithmHandle* self) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    reinterpret_cast<InertialFilterAlgorithm*>(self)->reInitializeExceptPersistentStates();
+    fsw::fromHandle<InertialFilterAlgorithm>(self)->reInitializeExceptPersistentStates();
 }
 
 void InertialFilterAlgorithm_reInitialize(InertialFilterAlgorithmHandle* self) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    reinterpret_cast<InertialFilterAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<InertialFilterAlgorithm>(self)->reInitialize();
 }
 
 InertialFilterOutput_c InertialFilterAlgorithm_update(InertialFilterAlgorithmHandle* self,
@@ -99,8 +96,7 @@ InertialFilterOutput_c InertialFilterAlgorithm_update(InertialFilterAlgorithmHan
     rateIn.timeTag = rate->timeTag;
     rateIn.rate = Eigen::Vector3d(rate->rate[0], rate->rate[1], rate->rate[2]);
 
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    auto* algo = reinterpret_cast<InertialFilterAlgorithm*>(self);
+    auto* algo = fsw::fromHandle<InertialFilterAlgorithm>(self);
     const InertialFilterOutput out = algo->update(currentSeconds, stIn, rateIn);
     return outputToC(out);
 }

--- a/algorithms/inertialUKF/inertialUKFAlgorithm_c.cpp
+++ b/algorithms/inertialUKF/inertialUKFAlgorithm_c.cpp
@@ -1,5 +1,6 @@
 #include "inertialUKFAlgorithm_c.h"
 #include "inertialUKFAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 

--- a/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVoteAlgorithm_c.cpp
@@ -1,25 +1,26 @@
 #include "mimuMajorityVoteAlgorithm_c.h"
 #include "mimuMajorityVoteAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
 uint32_t MimuMajorityVoteAlgorithm_getMimuCount(void) { return MIMU_COUNT_C; }
 
 MimuMajorityVoteAlgorithmHandle* MimuMajorityVoteAlgorithm_create(void) {
-    return reinterpret_cast<MimuMajorityVoteAlgorithmHandle*>(new ::MimuMajorityVoteAlgorithm());
+    return fsw::createHandle<::MimuMajorityVoteAlgorithm, MimuMajorityVoteAlgorithmHandle>();
 }
 
 void MimuMajorityVoteAlgorithm_destroy(MimuMajorityVoteAlgorithmHandle* self) {
-    delete reinterpret_cast<::MimuMajorityVoteAlgorithm*>(self);
+    fsw::deleteHandle<::MimuMajorityVoteAlgorithm>(self);
 }
 
 void MimuMajorityVoteAlgorithm_reset(MimuMajorityVoteAlgorithmHandle* self) {
-    reinterpret_cast<::MimuMajorityVoteAlgorithm*>(self)->reset();
+    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->reset();
 }
 
 MimuMajorityVoteOutput_c MimuMajorityVoteAlgorithm_update(MimuMajorityVoteAlgorithmHandle* self,
                                                           const Vector3fArray3_c* imuOmegas_BN_B) {
-    auto* alg = reinterpret_cast<::MimuMajorityVoteAlgorithm*>(self);
+    auto* alg = fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self);
 
     // Convert POD Vector3f_c inputs to C++ Eigen array:
     std::array<Eigen::Vector3f, MIMU_COUNT_C> inputs{};
@@ -52,17 +53,17 @@ MimuMajorityVoteOutput_c MimuMajorityVoteAlgorithm_update(MimuMajorityVoteAlgori
 }
 
 void MimuMajorityVoteAlgorithm_setOmegaThreshold(MimuMajorityVoteAlgorithmHandle* self, float value) {
-    reinterpret_cast<::MimuMajorityVoteAlgorithm*>(self)->setOmegaThreshold(value);
+    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setOmegaThreshold(value);
 }
 
 float MimuMajorityVoteAlgorithm_getOmegaThreshold(const MimuMajorityVoteAlgorithmHandle* self) {
-    return reinterpret_cast<const ::MimuMajorityVoteAlgorithm*>(self)->getOmegaThreshold();
+    return fsw::fromHandle<const ::MimuMajorityVoteAlgorithm>(self)->getOmegaThreshold();
 }
 
 void MimuMajorityVoteAlgorithm_setFaultPersistenceLimit(MimuMajorityVoteAlgorithmHandle* self, uint32_t value) {
-    reinterpret_cast<::MimuMajorityVoteAlgorithm*>(self)->setFaultPersistenceLimit(value);
+    fsw::fromHandle<::MimuMajorityVoteAlgorithm>(self)->setFaultPersistenceLimit(value);
 }
 
 uint32_t MimuMajorityVoteAlgorithm_getFaultPersistenceLimit(const MimuMajorityVoteAlgorithmHandle* self) {
-    return reinterpret_cast<const ::MimuMajorityVoteAlgorithm*>(self)->getFaultPersistenceLimit();
+    return fsw::fromHandle<const ::MimuMajorityVoteAlgorithm>(self)->getFaultPersistenceLimit();
 }

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.cpp
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "mrpFeedbackAlgorithm.h"
 #include "mrpFeedbackTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -17,30 +18,20 @@ MrpFeedbackConfig configFromC(const MrpFeedbackConfig_c& c) {
 }  // namespace
 
 MrpFeedbackAlgorithmHandle* MrpFeedbackAlgorithm_create(const MrpFeedbackConfig_c* config) {
-    // clang-format off
-    return reinterpret_cast<MrpFeedbackAlgorithmHandle*>(new ::MrpFeedbackAlgorithm(configFromC(*config)));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
+    return fsw::createHandle<::MrpFeedbackAlgorithm, MrpFeedbackAlgorithmHandle>(configFromC(*config));
 }
 
-void MrpFeedbackAlgorithm_destroy(MrpFeedbackAlgorithmHandle* self) {
-    // clang-format off
-    delete reinterpret_cast<::MrpFeedbackAlgorithm*>(self);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
-}
+void MrpFeedbackAlgorithm_destroy(MrpFeedbackAlgorithmHandle* self) { fsw::deleteHandle<::MrpFeedbackAlgorithm>(self); }
 
 void MrpFeedbackAlgorithm_setConfig(MrpFeedbackAlgorithmHandle* self, const MrpFeedbackConfig_c* config) {
-    // clang-format off
-    reinterpret_cast<::MrpFeedbackAlgorithm*>(self)->setConfig(configFromC(*config));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    fsw::fromHandle<::MrpFeedbackAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 void MrpFeedbackAlgorithm_reset(MrpFeedbackAlgorithmHandle* self,
                                 const VehicleConfigMsgF32Payload* vehConfigMsg,
                                 const RWArrayConfigMsgF32Payload* rwConfigMsg,
                                 int rwIsLinked) {
-    // clang-format off
-    reinterpret_cast<::MrpFeedbackAlgorithm*>(self)->reset(*vehConfigMsg, *rwConfigMsg, rwIsLinked != 0);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    fsw::fromHandle<::MrpFeedbackAlgorithm>(self)->reset(*vehConfigMsg, *rwConfigMsg, rwIsLinked != 0);
 }
 
 MrpFeedbackOutput_c MrpFeedbackAlgorithm_update(MrpFeedbackAlgorithmHandle* self,
@@ -48,9 +39,8 @@ MrpFeedbackOutput_c MrpFeedbackAlgorithm_update(MrpFeedbackAlgorithmHandle* self
                                                 const AttGuidMsgF32Payload* guidCmd,
                                                 const RWSpeedMsgF32Payload* wheelSpeeds,
                                                 const RWAvailabilityMsgPayload* wheelsAvailability) {
-    // clang-format off
-    const MrpFeedbackOutput out = reinterpret_cast<::MrpFeedbackAlgorithm*>(self)->update(callTime, *guidCmd, *wheelSpeeds, *wheelsAvailability);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    const MrpFeedbackOutput out =
+        fsw::fromHandle<::MrpFeedbackAlgorithm>(self)->update(callTime, *guidCmd, *wheelSpeeds, *wheelsAvailability);
 
     MrpFeedbackOutput_c result{};
     result.controlOut = out.controlOut;

--- a/algorithms/mrpPD/mrpPDAlgorithm_c.cpp
+++ b/algorithms/mrpPD/mrpPDAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "mrpPDAlgorithm.h"
 #include "mrpPDTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -13,13 +14,13 @@ MrpPDConfig configFromC(const MrpPDConfig_c& c) {
 }  // namespace
 
 MrpPDAlgorithmHandle* MrpPDAlgorithm_create(const MrpPDConfig_c* config) {
-    return reinterpret_cast<MrpPDAlgorithmHandle*>(new ::MrpPDAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::MrpPDAlgorithm, MrpPDAlgorithmHandle>(configFromC(*config));
 }
 
-void MrpPDAlgorithm_destroy(MrpPDAlgorithmHandle* self) { delete reinterpret_cast<::MrpPDAlgorithm*>(self); }
+void MrpPDAlgorithm_destroy(MrpPDAlgorithmHandle* self) { fsw::deleteHandle<::MrpPDAlgorithm>(self); }
 
 void MrpPDAlgorithm_setConfig(MrpPDAlgorithmHandle* self, const MrpPDConfig_c* config) {
-    reinterpret_cast<::MrpPDAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::MrpPDAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 Vector3f_c MrpPDAlgorithm_update(const MrpPDAlgorithmHandle* self,
@@ -27,9 +28,9 @@ Vector3f_c MrpPDAlgorithm_update(const MrpPDAlgorithmHandle* self,
                                  Vector3f_c omega_BR_B,
                                  Vector3f_c domega_RN_B) {
     const Eigen::Vector3f torque =
-        reinterpret_cast<const ::MrpPDAlgorithm*>(self)->update(cArrayToEigenVector3<float>(sigma_BR.data),
-                                                                cArrayToEigenVector3<float>(omega_BR_B.data),
-                                                                cArrayToEigenVector3<float>(domega_RN_B.data));
+        fsw::fromHandle<const ::MrpPDAlgorithm>(self)->update(cArrayToEigenVector3<float>(sigma_BR.data),
+                                                              cArrayToEigenVector3<float>(omega_BR_B.data),
+                                                              cArrayToEigenVector3<float>(domega_RN_B.data));
 
     Vector3f_c out{};
     eigenVectorToCArray(torque, out.data);

--- a/algorithms/mrpRotation/mrpRotationAlgorithm_c.cpp
+++ b/algorithms/mrpRotation/mrpRotationAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "mrpRotationAlgorithm.h"
 #include "mrpRotationTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -30,33 +31,21 @@ MrpRotationOutput_c outputToC(const MrpRotationOutput& out) {
 }  // namespace
 
 MrpRotationAlgorithmHandle* MrpRotationAlgorithm_create(const MrpRotationConfig_c* config) {
-    // clang-format off
-    return reinterpret_cast<MrpRotationAlgorithmHandle*>(new ::MrpRotationAlgorithm(configFromC(*config)));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
+    return fsw::createHandle<::MrpRotationAlgorithm, MrpRotationAlgorithmHandle>(configFromC(*config));
 }
 
-void MrpRotationAlgorithm_destroy(MrpRotationAlgorithmHandle* self) {
-    // clang-format off
-    delete reinterpret_cast<::MrpRotationAlgorithm*>(self);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
-}
+void MrpRotationAlgorithm_destroy(MrpRotationAlgorithmHandle* self) { fsw::deleteHandle<::MrpRotationAlgorithm>(self); }
 
 void MrpRotationAlgorithm_setConfig(MrpRotationAlgorithmHandle* self, const MrpRotationConfig_c* config) {
-    // clang-format off
-    reinterpret_cast<::MrpRotationAlgorithm*>(self)->setConfig(configFromC(*config));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    fsw::fromHandle<::MrpRotationAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 MrpRotationOutput_c MrpRotationAlgorithm_update(MrpRotationAlgorithmHandle* self,
                                                 const MrpRotationAttRefInputs_c* attRef) {
-    // clang-format off
-    const MrpRotationOutput out = reinterpret_cast<::MrpRotationAlgorithm*>(self)->update(attRefFromC(*attRef));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    const MrpRotationOutput out = fsw::fromHandle<::MrpRotationAlgorithm>(self)->update(attRefFromC(*attRef));
     return outputToC(out);
 }
 
 void MrpRotationAlgorithm_reInitialize(MrpRotationAlgorithmHandle* self) {
-    // clang-format off
-    reinterpret_cast<::MrpRotationAlgorithm*>(self)->reInitialize();  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    fsw::fromHandle<::MrpRotationAlgorithm>(self)->reInitialize();
 }

--- a/algorithms/mrpSteering/mrpSteeringAlgorithm_c.cpp
+++ b/algorithms/mrpSteering/mrpSteeringAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "mrpSteeringAlgorithm.h"
 #include "mrpSteeringTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 #include <optional>
@@ -49,19 +50,17 @@ MrpSteeringConfig configFromC(const MrpSteeringConfig_c& c) {
 uint32_t MrpSteeringAlgorithm_getMaxNumRw(void) { return MRP_STEERING_MAX_NUM_RW; }
 
 MrpSteeringAlgorithmHandle* MrpSteeringAlgorithm_create(const MrpSteeringConfig_c* config) {
-    return reinterpret_cast<MrpSteeringAlgorithmHandle*>(new ::MrpSteeringAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::MrpSteeringAlgorithm, MrpSteeringAlgorithmHandle>(configFromC(*config));
 }
 
-void MrpSteeringAlgorithm_destroy(MrpSteeringAlgorithmHandle* self) {
-    delete reinterpret_cast<::MrpSteeringAlgorithm*>(self);
-}
+void MrpSteeringAlgorithm_destroy(MrpSteeringAlgorithmHandle* self) { fsw::deleteHandle<::MrpSteeringAlgorithm>(self); }
 
 void MrpSteeringAlgorithm_setConfig(MrpSteeringAlgorithmHandle* self, const MrpSteeringConfig_c* config) {
-    reinterpret_cast<::MrpSteeringAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::MrpSteeringAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 void MrpSteeringAlgorithm_reInitialize(MrpSteeringAlgorithmHandle* self) {
-    reinterpret_cast<::MrpSteeringAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<::MrpSteeringAlgorithm>(self)->reInitialize();
 }
 
 Vector3f_c MrpSteeringAlgorithm_update(MrpSteeringAlgorithmHandle* self,
@@ -78,7 +77,7 @@ Vector3f_c MrpSteeringAlgorithm_update(MrpSteeringAlgorithmHandle* self,
         speeds[i] = wheelSpeeds->wheelSpeeds[i];
     }
 
-    const Eigen::Vector3f torque = reinterpret_cast<::MrpSteeringAlgorithm*>(self)->update(attGuidInputData, speeds);
+    const Eigen::Vector3f torque = fsw::fromHandle<::MrpSteeringAlgorithm>(self)->update(attGuidInputData, speeds);
 
     Vector3f_c out{};
     eigenVectorToCArray(torque, out.data);

--- a/algorithms/navAggregate/navAggregateAlgorithm_c.cpp
+++ b/algorithms/navAggregate/navAggregateAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "navAggregateAlgorithm.h"
 #include "navAggregateTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <array>
 
@@ -32,15 +33,15 @@ f32::NavAggregateConfig configFromC(const NavAggregateConfig_c& c) {
 uint32_t NavAggregateAlgorithm_getMaxAggNavMsg(void) { return MAX_AGG_NAV_MSG; }
 
 NavAggregateAlgorithmHandle* NavAggregateAlgorithm_create(const NavAggregateConfig_c* config) {
-    return reinterpret_cast<NavAggregateAlgorithmHandle*>(new ::f32::NavAggregateAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::f32::NavAggregateAlgorithm, NavAggregateAlgorithmHandle>(configFromC(*config));
 }
 
 void NavAggregateAlgorithm_destroy(NavAggregateAlgorithmHandle* self) {
-    delete reinterpret_cast<::f32::NavAggregateAlgorithm*>(self);
+    fsw::deleteHandle<::f32::NavAggregateAlgorithm>(self);
 }
 
 void NavAggregateAlgorithm_setConfig(NavAggregateAlgorithmHandle* self, const NavAggregateConfig_c* config) {
-    reinterpret_cast<::f32::NavAggregateAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::f32::NavAggregateAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 AggregateOutput_c NavAggregateAlgorithm_update(const NavAggregateAlgorithmHandle* self,
@@ -63,7 +64,7 @@ AggregateOutput_c NavAggregateAlgorithm_update(const NavAggregateAlgorithmHandle
     }
 
     const f32::AggregateOutput result =
-        reinterpret_cast<const ::f32::NavAggregateAlgorithm*>(self)->update(attArray, transArray);
+        fsw::fromHandle<const ::f32::NavAggregateAlgorithm>(self)->update(attArray, transArray);
 
     /* Convert Eigen-based output back to C-compatible POD types */
     AggregateOutput_c out{};

--- a/algorithms/oeStateEphem/oeStateEphemAlgorithm_c.cpp
+++ b/algorithms/oeStateEphem/oeStateEphemAlgorithm_c.cpp
@@ -1,5 +1,6 @@
 #include "oeStateEphemAlgorithm_c.h"
 #include "oeStateEphemAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <algorithm>
 #include <array>
@@ -41,19 +42,19 @@ OEStateEphemConfig configFromC(const OEStateEphemConfig_c& config) {
 }  // namespace
 
 OEStateEphemAlgorithmHandle* OEStateEphemAlgorithm_create(const OEStateEphemConfig_c* config) {
-    return reinterpret_cast<OEStateEphemAlgorithmHandle*>(new ::OEStateEphemAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::OEStateEphemAlgorithm, OEStateEphemAlgorithmHandle>(configFromC(*config));
 }
 
 void OEStateEphemAlgorithm_destroy(OEStateEphemAlgorithmHandle* self) {
-    delete reinterpret_cast<::OEStateEphemAlgorithm*>(self);
+    fsw::deleteHandle<::OEStateEphemAlgorithm>(self);
 }
 
 void OEStateEphemAlgorithm_setConfig(OEStateEphemAlgorithmHandle* self, const OEStateEphemConfig_c* config) {
-    reinterpret_cast<::OEStateEphemAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::OEStateEphemAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 CartesianState_c OEStateEphemAlgorithm_update(OEStateEphemAlgorithmHandle* self, const uint64_t callTime) {
-    const orbitalMotion::CartesianState result = reinterpret_cast<::OEStateEphemAlgorithm*>(self)->update(callTime);
+    const orbitalMotion::CartesianState result = fsw::fromHandle<::OEStateEphemAlgorithm>(self)->update(callTime);
     CartesianState_c out;
     out.position[0] = result.position[0];
     out.position[1] = result.position[1];

--- a/algorithms/rateControl/rateControlAlgorithm_c.cpp
+++ b/algorithms/rateControl/rateControlAlgorithm_c.cpp
@@ -1,16 +1,15 @@
 #include "rateControlAlgorithm_c.h"
 #include "rateControlAlgorithm.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
 RateControlAlgorithmHandle* RateControlAlgorithm_create(void) {
-    return reinterpret_cast<RateControlAlgorithmHandle*>(new ::RateControlAlgorithm());
+    return fsw::createHandle<::RateControlAlgorithm, RateControlAlgorithmHandle>();
 }
 
-void RateControlAlgorithm_destroy(RateControlAlgorithmHandle* self) {
-    delete reinterpret_cast<::RateControlAlgorithm*>(self);
-}
+void RateControlAlgorithm_destroy(RateControlAlgorithmHandle* self) { fsw::deleteHandle<::RateControlAlgorithm>(self); }
 
 Vector3f_c RateControlAlgorithm_update(const RateControlAlgorithmHandle* self,
                                        const Vector3f_c& omega_BR_B,
@@ -18,32 +17,31 @@ Vector3f_c RateControlAlgorithm_update(const RateControlAlgorithmHandle* self,
     const Eigen::Vector3f vec_omega_BR_B = cArrayToEigenVector3(omega_BR_B.data);
     const Eigen::Vector3f vec_domega_RN_B = cArrayToEigenVector3(domega_RN_B.data);
     const Eigen::Vector3f vec =
-        reinterpret_cast<const ::RateControlAlgorithm*>(self)->update(vec_omega_BR_B, vec_domega_RN_B);
+        fsw::fromHandle<const ::RateControlAlgorithm>(self)->update(vec_omega_BR_B, vec_domega_RN_B);
     Vector3f_c out{};
     eigenVectorToCArray(vec, out.data);
     return out;
 }
 
 void RateControlAlgorithm_setSpacecraftInertia(RateControlAlgorithmHandle* self, const Matrix3f_c& spacecraftInertia) {
-    reinterpret_cast<::RateControlAlgorithm*>(self)->setSpacecraftInertia(
-        c2DArrayToEigenMatrix3(spacecraftInertia.data));
+    fsw::fromHandle<::RateControlAlgorithm>(self)->setSpacecraftInertia(c2DArrayToEigenMatrix3(spacecraftInertia.data));
 }
 
 void RateControlAlgorithm_setDerivativeGainP(RateControlAlgorithmHandle* self, const float P) {
-    reinterpret_cast<::RateControlAlgorithm*>(self)->setDerivativeGainP(P);
+    fsw::fromHandle<::RateControlAlgorithm>(self)->setDerivativeGainP(P);
 }
 
 float RateControlAlgorithm_getDerivativeGainP(const RateControlAlgorithmHandle* self) {
-    return reinterpret_cast<const ::RateControlAlgorithm*>(self)->getDerivativeGainP();
+    return fsw::fromHandle<const ::RateControlAlgorithm>(self)->getDerivativeGainP();
 }
 
 void RateControlAlgorithm_setKnownTorquePntB_B(RateControlAlgorithmHandle* self, const Vector3f_c knownTorquePntB_B) {
     const Eigen::Vector3f eigenVec = cArrayToEigenVector3(knownTorquePntB_B.data);
-    reinterpret_cast<::RateControlAlgorithm*>(self)->setKnownTorquePntB_B(eigenVec);
+    fsw::fromHandle<::RateControlAlgorithm>(self)->setKnownTorquePntB_B(eigenVec);
 }
 
 Vector3f_c RateControlAlgorithm_getKnownTorquePntB_B(const RateControlAlgorithmHandle* self) {
-    const Eigen::Vector3f& eigenVec = reinterpret_cast<const ::RateControlAlgorithm*>(self)->getKnownTorquePntB_B();
+    const Eigen::Vector3f& eigenVec = fsw::fromHandle<const ::RateControlAlgorithm>(self)->getKnownTorquePntB_B();
     Vector3f_c out{};
     eigenVectorToCArray(eigenVec, out.data);
     return out;

--- a/algorithms/rwMotorTorque/rwMotorTorqueAlgorithm.cpp
+++ b/algorithms/rwMotorTorque/rwMotorTorqueAlgorithm.cpp
@@ -147,6 +147,7 @@ bool RwMotorTorqueConfig::isValidMapping(const std::array<bool, 3>& desiredContr
     return computeRwMapping(desiredControlAxes_B, rwConfiguration).has_value();
 }
 
+// Config is fixed-size/trivially copyable, so move == copy; pass-by-value would only add an extra copy.
 RwMotorTorqueAlgorithm::RwMotorTorqueAlgorithm(const RwMotorTorqueConfig& config)  // NOLINT(modernize-pass-by-value)
     : cfg(config) {
     setConfig(config);

--- a/algorithms/rwMotorTorque/rwMotorTorqueAlgorithm_c.cpp
+++ b/algorithms/rwMotorTorque/rwMotorTorqueAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "rwMotorTorqueAlgorithm.h"
 #include "rwMotorTorqueTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -26,15 +27,15 @@ RwMotorTorqueConfig configFromC(const RwMotorTorqueConfig_c& c) {
 uint32_t RwMotorTorqueAlgorithm_getMaxNumRw(void) { return RW_MOTOR_TORQUE_MAX_NUM_RW; }
 
 RwMotorTorqueAlgorithmHandle* RwMotorTorqueAlgorithm_create(const RwMotorTorqueConfig_c* config) {
-    return reinterpret_cast<RwMotorTorqueAlgorithmHandle*>(new ::RwMotorTorqueAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::RwMotorTorqueAlgorithm, RwMotorTorqueAlgorithmHandle>(configFromC(*config));
 }
 
 void RwMotorTorqueAlgorithm_destroy(RwMotorTorqueAlgorithmHandle* self) {
-    delete reinterpret_cast<::RwMotorTorqueAlgorithm*>(self);
+    fsw::deleteHandle<::RwMotorTorqueAlgorithm>(self);
 }
 
 void RwMotorTorqueAlgorithm_setConfig(RwMotorTorqueAlgorithmHandle* self, const RwMotorTorqueConfig_c* config) {
-    reinterpret_cast<::RwMotorTorqueAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::RwMotorTorqueAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 RwMotorTorqueOutput_c RwMotorTorqueAlgorithm_update(const RwMotorTorqueAlgorithmHandle* self,
@@ -46,7 +47,7 @@ RwMotorTorqueOutput_c RwMotorTorqueAlgorithm_update(const RwMotorTorqueAlgorithm
     speeds.rwDesiredSpeeds = cArrayToEigenVector(rwDesiredSpeeds->wheelSpeeds);
 
     const Eigen::Vector<float, kMaxNumRw> out =
-        reinterpret_cast<const ::RwMotorTorqueAlgorithm*>(self)->update(cArrayToEigenVector3<float>(Lr_B.data), speeds);
+        fsw::fromHandle<const ::RwMotorTorqueAlgorithm>(self)->update(cArrayToEigenVector3<float>(Lr_B.data), speeds);
 
     RwMotorTorqueOutput_c result{};
     eigenVectorToCArray(out, result.motorTorque);

--- a/algorithms/solarArrayReference/solarArrayReferenceAlgorithm_c.cpp
+++ b/algorithms/solarArrayReference/solarArrayReferenceAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "solarArrayReferenceAlgorithm.h"
 #include "solarArrayReferenceTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -17,17 +18,16 @@ SolarArrayReferenceConfig configFromC(const SolarArrayReferenceConfig_c& c) {
 }  // namespace
 
 SolarArrayReferenceAlgorithmHandle* SolarArrayReferenceAlgorithm_create(const SolarArrayReferenceConfig_c* config) {
-    return reinterpret_cast<SolarArrayReferenceAlgorithmHandle*>(
-        new ::SolarArrayReferenceAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::SolarArrayReferenceAlgorithm, SolarArrayReferenceAlgorithmHandle>(configFromC(*config));
 }
 
 void SolarArrayReferenceAlgorithm_destroy(SolarArrayReferenceAlgorithmHandle* self) {
-    delete reinterpret_cast<::SolarArrayReferenceAlgorithm*>(self);
+    fsw::deleteHandle<::SolarArrayReferenceAlgorithm>(self);
 }
 
 void SolarArrayReferenceAlgorithm_setConfig(SolarArrayReferenceAlgorithmHandle* self,
                                             const SolarArrayReferenceConfig_c* config) {
-    reinterpret_cast<::SolarArrayReferenceAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::SolarArrayReferenceAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 float SolarArrayReferenceAlgorithm_update(const SolarArrayReferenceAlgorithmHandle* self,
@@ -35,7 +35,7 @@ float SolarArrayReferenceAlgorithm_update(const SolarArrayReferenceAlgorithmHand
                                           const Vector3f_c sigma_RN,
                                           const Vector3f_c rHatIn_SB_B,
                                           const float theta) {
-    return reinterpret_cast<const ::SolarArrayReferenceAlgorithm*>(self)->update(
+    return fsw::fromHandle<const ::SolarArrayReferenceAlgorithm>(self)->update(
         cArrayToEigenVector3<float>(sigma_BN.data),
         cArrayToEigenVector3<float>(sigma_RN.data),
         cArrayToEigenVector3<float>(rHatIn_SB_B.data),

--- a/algorithms/stepperMotorController/stepperMotorControllerAlgorithm_c.cpp
+++ b/algorithms/stepperMotorController/stepperMotorControllerAlgorithm_c.cpp
@@ -1,6 +1,7 @@
 #include "stepperMotorControllerAlgorithm_c.h"
 #include "stepperMotorControllerAlgorithm.h"
 #include "stepperMotorControllerTypes.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 namespace {
 StepperMotorControllerConfig configFromC(const StepperMotorControllerConfig_c& c) {
@@ -13,32 +14,32 @@ StepperMotorControllerConfig configFromC(const StepperMotorControllerConfig_c& c
 
 StepperMotorControllerAlgorithmHandle* StepperMotorControllerAlgorithm_create(
     const StepperMotorControllerConfig_c* config) {
-    return reinterpret_cast<StepperMotorControllerAlgorithmHandle*>(
-        new ::StepperMotorControllerAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::StepperMotorControllerAlgorithm, StepperMotorControllerAlgorithmHandle>(
+        configFromC(*config));
 }
 
 void StepperMotorControllerAlgorithm_destroy(StepperMotorControllerAlgorithmHandle* self) {
-    delete reinterpret_cast<::StepperMotorControllerAlgorithm*>(self);
+    fsw::deleteHandle<::StepperMotorControllerAlgorithm>(self);
 }
 
 void StepperMotorControllerAlgorithm_setConfig(StepperMotorControllerAlgorithmHandle* self,
                                                const StepperMotorControllerConfig_c* config) {
-    reinterpret_cast<::StepperMotorControllerAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::StepperMotorControllerAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 void StepperMotorControllerAlgorithm_reInitialize(StepperMotorControllerAlgorithmHandle* self) {
-    reinterpret_cast<::StepperMotorControllerAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<::StepperMotorControllerAlgorithm>(self)->reInitialize();
 }
 
 StepperMotorControllerOutput StepperMotorControllerAlgorithm_update(StepperMotorControllerAlgorithmHandle* self,
                                                                     const int32_t currentPosition,
                                                                     const float referenceAngle,
                                                                     const bool isMotorMoving) {
-    return reinterpret_cast<::StepperMotorControllerAlgorithm*>(self)->update(
+    return fsw::fromHandle<::StepperMotorControllerAlgorithm>(self)->update(
         currentPosition, referenceAngle, isMotorMoving);
 }
 
 int32_t StepperMotorControllerAlgorithm_angleToSteps(const StepperMotorControllerAlgorithmHandle* self,
                                                      const float angle) {
-    return reinterpret_cast<const ::StepperMotorControllerAlgorithm*>(self)->angleToSteps(angle);
+    return fsw::fromHandle<const ::StepperMotorControllerAlgorithm>(self)->angleToSteps(angle);
 }

--- a/algorithms/sunAvoidance/sunAvoidanceAlgorithm_c.cpp
+++ b/algorithms/sunAvoidance/sunAvoidanceAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "sunAvoidanceAlgorithm.h"
 #include "sunAvoidanceTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -29,27 +30,19 @@ SunAvoidanceOutput_c outputToC(const SunAvoidanceOutput& out) {
 }  // namespace
 
 SunAvoidanceAlgorithmHandle* SunAvoidanceAlgorithm_create(const SunAvoidanceConfig_c* config) {
-    // clang-format off
-    return reinterpret_cast<SunAvoidanceAlgorithmHandle*>(new ::SunAvoidanceAlgorithm(configFromC(*config)));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
+    return fsw::createHandle<::SunAvoidanceAlgorithm, SunAvoidanceAlgorithmHandle>(configFromC(*config));
 }
 
 void SunAvoidanceAlgorithm_destroy(SunAvoidanceAlgorithmHandle* self) {
-    // clang-format off
-    delete reinterpret_cast<::SunAvoidanceAlgorithm*>(self);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-owning-memory)
-    // clang-format on
+    fsw::deleteHandle<::SunAvoidanceAlgorithm>(self);
 }
 
 void SunAvoidanceAlgorithm_setConfig(SunAvoidanceAlgorithmHandle* self, const SunAvoidanceConfig_c* config) {
-    // clang-format off
-    reinterpret_cast<::SunAvoidanceAlgorithm*>(self)->setConfig(configFromC(*config));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    fsw::fromHandle<::SunAvoidanceAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 void SunAvoidanceAlgorithm_reInitialize(SunAvoidanceAlgorithmHandle* self) {
-    // clang-format off
-    reinterpret_cast<::SunAvoidanceAlgorithm*>(self)->reInitialize();  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    // clang-format on
+    fsw::fromHandle<::SunAvoidanceAlgorithm>(self)->reInitialize();
 }
 
 SunAvoidanceOutput_c SunAvoidanceAlgorithm_update(SunAvoidanceAlgorithmHandle* self,
@@ -58,10 +51,11 @@ SunAvoidanceOutput_c SunAvoidanceAlgorithm_update(SunAvoidanceAlgorithmHandle* s
                                                   const Vector3d_c* r_BN_N,
                                                   const Vector3d_c* r_SN_N,
                                                   uint64_t callTime) {
-    // clang-format off
-    const SunAvoidanceOutput out = reinterpret_cast<::SunAvoidanceAlgorithm*>(self)->update(  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-        cArrayToEigenVector3<float>(sigma_BN->data), refFromC(*ref), cArrayToEigenVector3<double>(r_BN_N->data),
-        cArrayToEigenVector3<double>(r_SN_N->data), callTime);
-    // clang-format on
+    const SunAvoidanceOutput out =
+        fsw::fromHandle<::SunAvoidanceAlgorithm>(self)->update(cArrayToEigenVector3<float>(sigma_BN->data),
+                                                               refFromC(*ref),
+                                                               cArrayToEigenVector3<double>(r_BN_N->data),
+                                                               cArrayToEigenVector3<double>(r_SN_N->data),
+                                                               callTime);
     return outputToC(out);
 }

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.cpp
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "sunSearchPointAlgorithm.h"
 #include "sunSearchPointTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 #include <array>
@@ -26,26 +27,26 @@ SunSearchPointConfig configFromC(const SunSearchPointConfig_c& c) {
 uint32_t SunSearchPointAlgorithm_getNumRotations(void) { return SUN_SEARCH_POINT_NUM_ROTATIONS; }
 
 SunSearchPointAlgorithmHandle* SunSearchPointAlgorithm_create(const SunSearchPointConfig_c* config) {
-    return reinterpret_cast<SunSearchPointAlgorithmHandle*>(new ::SunSearchPointAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::SunSearchPointAlgorithm, SunSearchPointAlgorithmHandle>(configFromC(*config));
 }
 
 void SunSearchPointAlgorithm_destroy(SunSearchPointAlgorithmHandle* self) {
-    delete reinterpret_cast<::SunSearchPointAlgorithm*>(self);
+    fsw::deleteHandle<::SunSearchPointAlgorithm>(self);
 }
 
 void SunSearchPointAlgorithm_setConfig(SunSearchPointAlgorithmHandle* self, const SunSearchPointConfig_c* config) {
-    reinterpret_cast<::SunSearchPointAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::SunSearchPointAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 void SunSearchPointAlgorithm_reInitialize(SunSearchPointAlgorithmHandle* self) {
-    reinterpret_cast<::SunSearchPointAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<::SunSearchPointAlgorithm>(self)->reInitialize();
 }
 
 SunSearchPointOutput_c SunSearchPointAlgorithm_update(SunSearchPointAlgorithmHandle* self,
                                                       const Vector3f_c rHat_SB_B,
                                                       const Vector3f_c omega_BN_B,
                                                       const int numCssViewingSun) {
-    const SunSearchPointOutput out = reinterpret_cast<::SunSearchPointAlgorithm*>(self)->update(
+    const SunSearchPointOutput out = fsw::fromHandle<::SunSearchPointAlgorithm>(self)->update(
         cArrayToEigenVector3<float>(rHat_SB_B.data), cArrayToEigenVector3<float>(omega_BN_B.data), numCssViewingSun);
 
     SunSearchPointOutput_c result{};

--- a/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.cpp
+++ b/algorithms/sunlineEphem/sunlineEphemAlgorithm_c.cpp
@@ -1,14 +1,15 @@
 #include "sunlineEphemAlgorithm_c.h"
 #include "sunlineEphemAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
 SunlineEphemAlgorithmHandle* SunlineEphemAlgorithm_create(void) {
-    return reinterpret_cast<SunlineEphemAlgorithmHandle*>(new ::SunlineEphemAlgorithm());
+    return fsw::createHandle<::SunlineEphemAlgorithm, SunlineEphemAlgorithmHandle>();
 }
 
 void SunlineEphemAlgorithm_destroy(SunlineEphemAlgorithmHandle* self) {
-    delete reinterpret_cast<::SunlineEphemAlgorithm*>(self);
+    fsw::deleteHandle<::SunlineEphemAlgorithm>(self);
 }
 
 void SunlineEphemAlgorithm_update(const SunlineEphemAlgorithmHandle* self,
@@ -26,7 +27,7 @@ void SunlineEphemAlgorithm_update(const SunlineEphemAlgorithmHandle* self,
     sigma_BN << sigmaBN->data[0], sigmaBN->data[1], sigmaBN->data[2];
 
     const Eigen::Vector3f rHat_SB_B =
-        reinterpret_cast<const ::SunlineEphemAlgorithm*>(self)->update(r_SN_N, r_BN_N, sigma_BN);
+        fsw::fromHandle<const ::SunlineEphemAlgorithm>(self)->update(r_SN_N, r_BN_N, sigma_BN);
 
     result->data[0] = rHat_SB_B[0];
     result->data[1] = rHat_SB_B[1];

--- a/algorithms/sunlineFilter/sunlineFilterAlgorithm.cpp
+++ b/algorithms/sunlineFilter/sunlineFilterAlgorithm.cpp
@@ -4,6 +4,7 @@
 #include "utilities/fsw/validPSDCheck.h"
 
 #include <algorithm>
+#include <utility>
 #include <variant>
 
 namespace filtering::sunlineFilter {
@@ -14,18 +15,14 @@ using State = SunlineFilterAlgorithm::State;
 
 /*! CSS observation = bias * H * s_hat. Satisfies the Measurement
  *  concept for use inside the SRuKF. */
-struct CssMeasurementModel {
+class CssMeasurementModel {
+   public:
     static constexpr int size = MaxCss;
 
-    // Concept-model aggregate: these fields are populated directly by
-    // applyMeasurement() and read back through the accessors below to satisfy
-    // the filtering::Measurement concept. Public data is the point of the type,
-    // so the private-member guidance does not apply here.
-    // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
-    Eigen::Vector<double, size> observed = Eigen::Vector<double, size>::Zero();
-    Eigen::Matrix<double, size, 3> hMatrix = Eigen::Matrix<double, size, 3>::Zero();
-    Eigen::Matrix<double, size, size> measNoise = Eigen::Matrix<double, size, size>::Identity();
-    // NOLINTEND(misc-non-private-member-variables-in-classes)
+    CssMeasurementModel(Eigen::Vector<double, size> observation,
+                        Eigen::Matrix<double, size, 3> hMatrix,
+                        Eigen::Matrix<double, size, size> noise)
+        : observed(std::move(observation)), hMatrix(std::move(hMatrix)), measNoise(std::move(noise)) {}
 
     Eigen::Vector<double, size> observation() const { return this->observed; }
     Eigen::Vector<double, size> model(State const& state) const {
@@ -38,22 +35,29 @@ struct CssMeasurementModel {
                                                 Eigen::Vector<double, size> const& b) {
         return a - b;
     }
+
+   private:
+    Eigen::Vector<double, size> observed;
+    Eigen::Matrix<double, size, 3> hMatrix;
+    Eigen::Matrix<double, size, size> measNoise;
 };
 
 /*! Predicted gyro observation = omega_BN_B. Satisfies the Measurement concept. */
-struct RateMeasurementModel {
+class RateMeasurementModel {
+   public:
     static constexpr int size = 3;
 
-    // Concept-model aggregate; see CssMeasurementModel for the rationale.
-    // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
-    Eigen::Vector3d observed = Eigen::Vector3d::Zero();
-    Eigen::Matrix3d measNoise = Eigen::Matrix3d::Identity();
-    // NOLINTEND(misc-non-private-member-variables-in-classes)
+    RateMeasurementModel(Eigen::Vector3d observation, Eigen::Matrix3d noise)
+        : observed(std::move(observation)), measNoise(std::move(noise)) {}
 
     Eigen::Vector3d observation() const { return this->observed; }
     static Eigen::Vector3d model(State const& state) { return state.get<filtering::Velocity<3>>(); }
     Eigen::Matrix3d noise() const { return this->measNoise; }
     static Eigen::Vector3d subtract(Eigen::Vector3d const& a, Eigen::Vector3d const& b) { return a - b; }
+
+   private:
+    Eigen::Vector3d observed;
+    Eigen::Matrix3d measNoise;
 };
 
 static_assert(filtering::Measurement<CssMeasurementModel, State>);
@@ -151,14 +155,11 @@ void SunlineFilterAlgorithm::clear() {
  *  @return true iff the update was applied (state/covariance finite)
  *  @param measurement [-] packed CSS measurement (cosValues, H, noise) */
 bool SunlineFilterAlgorithm::applyMeasurement(CssMeasurement const& measurement) {
-    CssMeasurementModel model;
-    model.observed = measurement.cssCosValues;
-    model.hMatrix = measurement.hMatrix;
-    model.measNoise = measurement.covar;
+    CssMeasurementModel const model{measurement.cssCosValues, measurement.hMatrix, measurement.covar};
 
     auto const result = this->srukf.measurementUpdate(model);
     this->lastCssResiduals.numberOfActiveCss = measurement.numberOfActiveCss;
-    this->lastCssResiduals.observation = model.observed;
+    this->lastCssResiduals.observation = model.observation();
     if (result.has_value()) {
         this->lastCssResiduals.valid = measurement.valid;
         this->lastCssResiduals.preFit = result->preFit;
@@ -172,12 +173,10 @@ bool SunlineFilterAlgorithm::applyMeasurement(CssMeasurement const& measurement)
  *  @return true iff the update was applied (state/covariance finite)
  *  @param measurement [-] packed rate measurement (omega, noise) */
 bool SunlineFilterAlgorithm::applyMeasurement(RateMeasurement const& measurement) {
-    RateMeasurementModel model;
-    model.observed = measurement.omega_BN_B;
-    model.measNoise = measurement.covar;
+    RateMeasurementModel const model{measurement.omega_BN_B, measurement.covar};
 
     auto const result = this->srukf.measurementUpdate(model);
-    this->lastRateResiduals.observation = model.observed;
+    this->lastRateResiduals.observation = model.observation();
     if (result.has_value()) {
         this->lastRateResiduals.valid = measurement.valid;
         this->lastRateResiduals.preFit = result->preFit;

--- a/algorithms/sunlineFilter/sunlineFilterAlgorithm_c.cpp
+++ b/algorithms/sunlineFilter/sunlineFilterAlgorithm_c.cpp
@@ -1,6 +1,7 @@
 #include "sunlineFilterAlgorithm_c.h"
 #include "sunlineFilterAlgorithm.h"
 #include "sunlineFilterTypes.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -108,15 +109,15 @@ uint32_t SunlineFilterAlgorithm_getMaxCss(void) { return SUNLINE_FILTER_MAX_CSS;
 uint32_t SunlineFilterAlgorithm_getNumStates(void) { return SUNLINE_FILTER_NUM_STATES; }
 
 SunlineFilterAlgorithmHandle* SunlineFilterAlgorithm_create(const SunlineFilterConfig_c* config) {
-    return reinterpret_cast<SunlineFilterAlgorithmHandle*>(new ::SunlineFilterAlgorithm(configFromC(*config)));
+    return fsw::createHandle<::SunlineFilterAlgorithm, SunlineFilterAlgorithmHandle>(configFromC(*config));
 }
 
 void SunlineFilterAlgorithm_destroy(SunlineFilterAlgorithmHandle* self) {
-    delete reinterpret_cast<::SunlineFilterAlgorithm*>(self);
+    fsw::deleteHandle<::SunlineFilterAlgorithm>(self);
 }
 
 void SunlineFilterAlgorithm_setConfig(SunlineFilterAlgorithmHandle* self, const SunlineFilterConfig_c* config) {
-    reinterpret_cast<::SunlineFilterAlgorithm*>(self)->setConfig(configFromC(*config));
+    fsw::fromHandle<::SunlineFilterAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
 SunlineFilterOutput_c SunlineFilterAlgorithm_update(SunlineFilterAlgorithmHandle* self,
@@ -134,26 +135,26 @@ SunlineFilterOutput_c SunlineFilterAlgorithm_update(SunlineFilterAlgorithmHandle
     rateDataCpp.rate << rateData->rate[0], rateData->rate[1], rateData->rate[2];
 
     const SunlineFilterOutput out =
-        reinterpret_cast<::SunlineFilterAlgorithm*>(self)->update(currentSeconds, cssDataCpp, rateDataCpp);
+        fsw::fromHandle<::SunlineFilterAlgorithm>(self)->update(currentSeconds, cssDataCpp, rateDataCpp);
     return outputToC(out);
 }
 
 void SunlineFilterAlgorithm_reInitializeExceptPersistentStates(SunlineFilterAlgorithmHandle* self) {
-    reinterpret_cast<::SunlineFilterAlgorithm*>(self)->reInitializeExceptPersistentStates();
+    fsw::fromHandle<::SunlineFilterAlgorithm>(self)->reInitializeExceptPersistentStates();
 }
 
 void SunlineFilterAlgorithm_reInitialize(SunlineFilterAlgorithmHandle* self) {
-    reinterpret_cast<::SunlineFilterAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<::SunlineFilterAlgorithm>(self)->reInitialize();
 }
 
 SunlineFilterStateOutput_c SunlineFilterAlgorithm_getFilterOutput(const SunlineFilterAlgorithmHandle* self) {
-    return filterStateToC(reinterpret_cast<const ::SunlineFilterAlgorithm*>(self)->getFilterOutput());
+    return filterStateToC(fsw::fromHandle<const ::SunlineFilterAlgorithm>(self)->getFilterOutput());
 }
 
 SunlineCssResidualsOutput_c SunlineFilterAlgorithm_getLastCssResiduals(const SunlineFilterAlgorithmHandle* self) {
-    return cssResidualsToC(reinterpret_cast<const ::SunlineFilterAlgorithm*>(self)->getLastCssResiduals());
+    return cssResidualsToC(fsw::fromHandle<const ::SunlineFilterAlgorithm>(self)->getLastCssResiduals());
 }
 
 SunlineRateResidualsOutput_c SunlineFilterAlgorithm_getLastRateResiduals(const SunlineFilterAlgorithmHandle* self) {
-    return rateResidualsToC(reinterpret_cast<const ::SunlineFilterAlgorithm*>(self)->getLastRateResiduals());
+    return rateResidualsToC(fsw::fromHandle<const ::SunlineFilterAlgorithm>(self)->getLastRateResiduals());
 }

--- a/algorithms/thrFiringRemainder/thrFiringRemainderAlgorithm_c.cpp
+++ b/algorithms/thrFiringRemainder/thrFiringRemainderAlgorithm_c.cpp
@@ -1,5 +1,6 @@
 #include "thrFiringRemainderAlgorithm_c.h"
 #include "thrFiringRemainderAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <algorithm>
 
@@ -27,20 +28,20 @@ ThrFiringRemainderConfig toConfig(const ThrFiringRemainderConfig_c* config) {
 uint32_t ThrFiringRemainderAlgorithm_getMaxThrusterCount(void) { return THR_FIRING_REMAINDER_MAX_THRUSTER_COUNT; }
 
 ThrFiringRemainderAlgorithmHandle* ThrFiringRemainderAlgorithm_create(const ThrFiringRemainderConfig_c* config) {
-    return reinterpret_cast<ThrFiringRemainderAlgorithmHandle*>(new ::ThrFiringRemainderAlgorithm(toConfig(config)));
+    return fsw::createHandle<::ThrFiringRemainderAlgorithm, ThrFiringRemainderAlgorithmHandle>(toConfig(config));
 }
 
 void ThrFiringRemainderAlgorithm_destroy(ThrFiringRemainderAlgorithmHandle* self) {
-    delete reinterpret_cast<::ThrFiringRemainderAlgorithm*>(self);
+    fsw::deleteHandle<::ThrFiringRemainderAlgorithm>(self);
 }
 
 void ThrFiringRemainderAlgorithm_setConfig(ThrFiringRemainderAlgorithmHandle* self,
                                            const ThrFiringRemainderConfig_c* config) {
-    reinterpret_cast<::ThrFiringRemainderAlgorithm*>(self)->setConfig(toConfig(config));
+    fsw::fromHandle<::ThrFiringRemainderAlgorithm>(self)->setConfig(toConfig(config));
 }
 
 void ThrFiringRemainderAlgorithm_reInitialize(ThrFiringRemainderAlgorithmHandle* self) {
-    reinterpret_cast<::ThrFiringRemainderAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<::ThrFiringRemainderAlgorithm>(self)->reInitialize();
 }
 
 ThrFiringRemainderOnTimeCmd ThrFiringRemainderAlgorithm_update(ThrFiringRemainderAlgorithmHandle* self,
@@ -48,7 +49,7 @@ ThrFiringRemainderOnTimeCmd ThrFiringRemainderAlgorithm_update(ThrFiringRemainde
     ThrusterForceCmd cppCmd{};
     std::ranges::copy_n(forceCmd->thrForce, kMaxThrusterCount, cppCmd.thrForce.data());
 
-    const auto [onTimeRequest] = reinterpret_cast<::ThrFiringRemainderAlgorithm*>(self)->update(cppCmd);
+    const auto [onTimeRequest] = fsw::fromHandle<::ThrFiringRemainderAlgorithm>(self)->update(cppCmd);
 
     ThrFiringRemainderOnTimeCmd result{};
     std::ranges::copy_n(onTimeRequest.data(), kMaxThrusterCount, result.onTimeRequest);

--- a/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.cpp
+++ b/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.cpp
@@ -1,5 +1,6 @@
 #include "thrFiringSchmittAlgorithm_c.h"
 #include "thrFiringSchmittAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <algorithm>
 
@@ -30,20 +31,20 @@ ThrFiringSchmittConfig toConfig(const ThrFiringSchmittConfig_c* config) {
 uint32_t ThrFiringSchmittAlgorithm_getMaxThrusterCount(void) { return THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT; }
 
 ThrFiringSchmittAlgorithmHandle* ThrFiringSchmittAlgorithm_create(const ThrFiringSchmittConfig_c* config) {
-    return reinterpret_cast<ThrFiringSchmittAlgorithmHandle*>(new ::ThrFiringSchmittAlgorithm(toConfig(config)));
+    return fsw::createHandle<::ThrFiringSchmittAlgorithm, ThrFiringSchmittAlgorithmHandle>(toConfig(config));
 }
 
 void ThrFiringSchmittAlgorithm_destroy(ThrFiringSchmittAlgorithmHandle* self) {
-    delete reinterpret_cast<::ThrFiringSchmittAlgorithm*>(self);
+    fsw::deleteHandle<::ThrFiringSchmittAlgorithm>(self);
 }
 
 void ThrFiringSchmittAlgorithm_setConfig(ThrFiringSchmittAlgorithmHandle* self,
                                          const ThrFiringSchmittConfig_c* config) {
-    reinterpret_cast<::ThrFiringSchmittAlgorithm*>(self)->setConfig(toConfig(config));
+    fsw::fromHandle<::ThrFiringSchmittAlgorithm>(self)->setConfig(toConfig(config));
 }
 
 void ThrFiringSchmittAlgorithm_reInitialize(ThrFiringSchmittAlgorithmHandle* self) {
-    reinterpret_cast<::ThrFiringSchmittAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<::ThrFiringSchmittAlgorithm>(self)->reInitialize();
 }
 
 ThrFiringSchmittOnTimeCmd ThrFiringSchmittAlgorithm_update(ThrFiringSchmittAlgorithmHandle* self,
@@ -51,7 +52,7 @@ ThrFiringSchmittOnTimeCmd ThrFiringSchmittAlgorithm_update(ThrFiringSchmittAlgor
     ThrusterForceCmd cppCmd{};
     std::ranges::copy_n(forceCmd->thrForce, kMaxThrusterCount, cppCmd.thrForce.data());
 
-    const auto [onTimeRequest] = reinterpret_cast<::ThrFiringSchmittAlgorithm*>(self)->update(cppCmd);
+    const auto [onTimeRequest] = fsw::fromHandle<::ThrFiringSchmittAlgorithm>(self)->update(cppCmd);
 
     ThrFiringSchmittOnTimeCmd result{};
     std::ranges::copy_n(onTimeRequest.data(), kMaxThrusterCount, result.onTimeRequest);

--- a/algorithms/timeClosestApproach/timeClosestApproachAlgorithm_c.cpp
+++ b/algorithms/timeClosestApproach/timeClosestApproachAlgorithm_c.cpp
@@ -1,16 +1,17 @@
 #include "timeClosestApproachAlgorithm_c.h"
 #include "timeClosestApproachAlgorithm.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
 uint32_t TimeClosestApproachAlgorithm_getMaxFilterStates(void) { return 6U; }
 
 TimeClosestApproachAlgorithmHandle* TimeClosestApproachAlgorithm_create(void) {
-    return reinterpret_cast<TimeClosestApproachAlgorithmHandle*>(new ::TimeClosestApproachAlgorithm());
+    return fsw::createHandle<::TimeClosestApproachAlgorithm, TimeClosestApproachAlgorithmHandle>();
 }
 
 void TimeClosestApproachAlgorithm_destroy(TimeClosestApproachAlgorithmHandle* self) {
-    delete reinterpret_cast<::TimeClosestApproachAlgorithm*>(self);
+    fsw::deleteHandle<::TimeClosestApproachAlgorithm>(self);
 }
 
 TimeClosestApproachOutput_c TimeClosestApproachAlgorithm_update(const TimeClosestApproachAlgorithmHandle* self,
@@ -21,8 +22,7 @@ TimeClosestApproachOutput_c TimeClosestApproachAlgorithm_update(const TimeCloses
     const Eigen::Vector3d v = Eigen::Map<const Eigen::Vector3d>(v_BN_N->data);
     const Eigen::Matrix<double, 6, 6> P = Eigen::Map<const Eigen::Matrix<float, 6, 6>>(covariance->data).cast<double>();
 
-    const TimeClosestApproachOutput out =
-        reinterpret_cast<const ::TimeClosestApproachAlgorithm*>(self)->update(r, v, P);
+    const TimeClosestApproachOutput out = fsw::fromHandle<const ::TimeClosestApproachAlgorithm>(self)->update(r, v, P);
 
     TimeClosestApproachOutput_c result{};
     result.tCA = out.tCA;

--- a/algorithms/utilities/fsw/opaqueHandle.h
+++ b/algorithms/utilities/fsw/opaqueHandle.h
@@ -1,0 +1,36 @@
+#ifndef F32XMERA_UTILITIES_FSW_OPAQUEHANDLE_H
+#define F32XMERA_UTILITIES_FSW_OPAQUEHANDLE_H
+
+#include <utility>
+
+// Bridges an opaque C handle (a forward-declared, never-completed struct) to its C++
+// implementation for the Ada/FFI shims. reinterpret_cast is required because the handle
+// type stays incomplete, and _create/_destroy own the allocation across a C ABI boundary
+// where unique_ptr/gsl::owner cannot be carried. Those unavoidable-but-flagged casts and
+// the owning new/delete are confined and audited here so the shims stay suppression-free.
+
+namespace fsw {
+
+//! Allocate an Impl and return it as an opaque Handle* (for <Name>Algorithm_create).
+template <class Impl, class Handle, class... Args>
+Handle* createHandle(Args&&... args) {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<Handle*>(new Impl(std::forward<Args>(args)...));
+}
+
+//! Recover the Impl* (or const Impl*) behind a Handle* (for every accessor/mutator).
+template <class Impl, class Handle>
+Impl* fromHandle(Handle* handle) {
+    return reinterpret_cast<Impl*>(handle);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+}
+
+//! Destroy the Impl behind a Handle* (for <Name>Algorithm_destroy).
+template <class Impl, class Handle>
+void deleteHandle(Handle* handle) {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-pro-type-reinterpret-cast)
+    delete reinterpret_cast<Impl*>(handle);
+}
+
+}  // namespace fsw
+
+#endif


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2234
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR introduces an small helper that localizes the `reinterpret_cast` to a single place. This allows us to NOLINT the specific uses of `reinterpret_cast` and absolve the C-shim author of their responsibility to handle clang-tidy's checks. 

The PR begins by updating the github actions for this repo. Next a few clang-tidy warnings that we side stepped during review of the filters are resolved. The final 8 commits and `opaqueHandle.h` and subsequent are refactored to use it.

## Verification
Tests pass as expected and no clang-tidy analysis warnings.

## Documentation
NA

## Future work
None
