### PR TITLE
Feature/2004 change input of dv accumulation

### DIFF
--- a/algorithms/dvAccumulation/_tests/dvAccumulationTestHelpers.hpp
+++ b/algorithms/dvAccumulation/_tests/dvAccumulationTestHelpers.hpp
@@ -2,15 +2,12 @@
 #define TEST_DV_ACCUMULATION_HELPERS_H
 
 #include "dvAccumulation/dvAccumulationAlgorithm.h"
-#include "msgPayloadDef/AccDataMsgF32Payload.h"
-#include "utilities/fsw/eigenSupport.h"
 #include "utilities/fsw/timeConstants.h"
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>
-#include <array>
+#include <cmath>
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 /*! @brief Reference algorithm state, mirroring DvAccumulationAlgorithm's private members. */
@@ -19,78 +16,21 @@ struct ReferenceState {
     uint64_t previousTime{0U};
 };
 
-/*! @brief Reference sort mirroring the algorithm's iterative quicksort exactly, so the reference
- *         agrees with the algorithm on the order of equal-measTime packets (integration is
- *         order-sensitive when timestamps repeat). */
-inline void referenceSortByMeasTime(AccDataMsgF32Payload& accData) {
-    std::array<int, MAX_ACC_BUF_PKT> indexStack{};
-    int top = -1;
-    ++top;
-    indexStack[static_cast<size_t>(top)] = 0;
-    ++top;
-    indexStack[static_cast<size_t>(top)] = MAX_ACC_BUF_PKT - 1;
-
-    while (top >= 1) {
-        auto const end = indexStack[static_cast<size_t>(top)];
-        auto const start = indexStack[static_cast<size_t>(top - 1)];
-        top -= 2;
-
-        auto const pivot = accData.accPkts[static_cast<size_t>(end)].measTime;
-        int partitionIndex = start;
-        for (int i = start; i < end; ++i) {
-            if (accData.accPkts[static_cast<size_t>(i)].measTime <= pivot) {
-                std::swap(accData.accPkts[static_cast<size_t>(i)],
-                          accData.accPkts[static_cast<size_t>(partitionIndex)]);
-                ++partitionIndex;
-            }
-        }
-        std::swap(accData.accPkts[static_cast<size_t>(partitionIndex)], accData.accPkts[static_cast<size_t>(end)]);
-
-        if (partitionIndex - 1 > start) {
-            ++top;
-            indexStack[static_cast<size_t>(top)] = start;
-            ++top;
-            indexStack[static_cast<size_t>(top)] = partitionIndex - 1;
-        }
-        if (partitionIndex + 1 < end) {
-            ++top;
-            indexStack[static_cast<size_t>(top)] = partitionIndex + 1;
-            ++top;
-            indexStack[static_cast<size_t>(top)] = end;
-        }
-    }
-}
-
-/*! @brief Reference reInitialize: reset all state (accumulator, previousTime), so the first update()
- *         sets the time reference from the first newer packet. */
+/*! @brief Reference reInitialize: reset all state (accumulator and previousTime). */
 inline void referenceReInitialize(ReferenceState& s) {
     s.vehAccumDV_B = Eigen::Vector3f::Zero();
     s.previousTime = 0U;
 }
 
-/*! @brief Reference update: sort by measTime; on the first call (previousTime == 0) set the time
- *         reference from the first newer packet (skip it), then integrate every subsequent packet
- *         via dt * accel. */
-inline DvAccumulationOutput referenceUpdate(ReferenceState& s, const AccDataMsgF32Payload& accData) {
-    AccDataMsgF32Payload sorted = accData;
-    referenceSortByMeasTime(sorted);
-
+/*! @brief Reference update: the first call (previousTime == 0) only sets the time reference; otherwise
+ *         integrate dt * accel over the elapsed step when callTime advances. */
+inline DvAccumulationOutput referenceUpdate(ReferenceState& s, uint64_t callTime, const Eigen::Vector3f& accel_B) {
     if (s.previousTime == 0U) {
-        for (uint32_t i = 0U; i < MAX_ACC_BUF_PKT; i++) {
-            if (sorted.accPkts[i].measTime > s.previousTime) {
-                s.previousTime = sorted.accPkts[i].measTime;
-                break;
-            }
-        }
-    }
-
-    for (uint32_t i = 0U; i < MAX_ACC_BUF_PKT; i++) {
-        if (sorted.accPkts[i].measTime > s.previousTime) {
-            const float dt = static_cast<float>(sorted.accPkts[i].measTime - s.previousTime) * kNano2SecF;
-            const Eigen::Vector3f accel_B = cArrayToEigenVector3(sorted.accPkts[i].accel_B);
-            s.vehAccumDV_B += dt * accel_B;
-            s.previousTime = sorted.accPkts[i].measTime;
-        }
+        s.previousTime = callTime;
+    } else if (callTime > s.previousTime) {
+        const float dt = static_cast<float>(callTime - s.previousTime) * kNano2SecF;
+        s.vehAccumDV_B += dt * accel_B;
+        s.previousTime = callTime;
     }
 
     DvAccumulationOutput out{};
@@ -99,70 +39,57 @@ inline DvAccumulationOutput referenceUpdate(ReferenceState& s, const AccDataMsgF
     return out;
 }
 
-/*! @brief Build a 120-packet AccDataMsgF32Payload from caller-supplied per-packet times and accels.
- *         If `measTimes.size() < MAX_ACC_BUF_PKT`, remaining slots have measTime=0 (invalid). */
-inline AccDataMsgF32Payload buildAccData(const std::vector<uint64_t>& measTimes,
-                                         const std::vector<Eigen::Vector3f>& accels) {
-    EXPECT_EQ(measTimes.size(), accels.size());
-    EXPECT_LE(measTimes.size(), static_cast<size_t>(MAX_ACC_BUF_PKT));
+/*! @brief One (callTime, acceleration) sample driving a single update() call. */
+struct Sample {
+    uint64_t callTime{0U};
+    Eigen::Vector3f accel_B{Eigen::Vector3f::Zero()};
+};
 
-    AccDataMsgF32Payload accData{};
-    for (size_t i = 0; i < measTimes.size(); ++i) {
-        accData.accPkts[i].measTime = measTimes[i];
-        accData.accPkts[i].accel_B[0] = accels[i].x();
-        accData.accPkts[i].accel_B[1] = accels[i].y();
-        accData.accPkts[i].accel_B[2] = accels[i].z();
-    }
-    return accData;
-}
-
-/*! @brief Fuzz-friendly driver: build one snapshot from caller-supplied measTimes/accels and
- *         drive the algorithm + reference for a single update step from an empty reset. */
-inline void testDvAccumulationFuzz(const std::vector<uint64_t>& measTimes, const std::vector<Eigen::Vector3f>& accels) {
-    if (measTimes.size() != accels.size()) {
-        return;  // fuzz domain may produce mismatched lengths; ignore
-    }
-    if (measTimes.size() > static_cast<size_t>(MAX_ACC_BUF_PKT)) {
-        return;  // ignore over-sized inputs
-    }
-
-    const AccDataMsgF32Payload snap = buildAccData(measTimes, accels);
-
-    DvAccumulationAlgorithm alg{};
-    alg.reInitialize();
-    DvAccumulationOutput algOut{};
-    EXPECT_NO_THROW(algOut = alg.update(snap));
-
-    ReferenceState ref{};
-    referenceReInitialize(ref);
-    const DvAccumulationOutput refOut = referenceUpdate(ref, snap);
-
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_NEAR(algOut.vehAccumDV_B[i], refOut.vehAccumDV_B[i], 1e-5F);
-        EXPECT_TRUE(std::isfinite(algOut.vehAccumDV_B[i]));
-    }
-    EXPECT_TRUE(std::isfinite(algOut.timeTag));
-}
-
-/*! @brief Drive the algorithm through a sequence of input snapshots and compare to the reference
- *         at every step. */
-inline void testDvAccumulation(const std::vector<AccDataMsgF32Payload>& snapshots) {
+/*! @brief Drive the algorithm through a sequence of samples and compare to the reference at every
+ *         step. */
+inline void testDvAccumulation(const std::vector<Sample>& samples) {
     DvAccumulationAlgorithm alg{};
     alg.reInitialize();
 
     ReferenceState ref{};
     referenceReInitialize(ref);
 
-    for (const AccDataMsgF32Payload& snap : snapshots) {
+    for (const Sample& sample : samples) {
         DvAccumulationOutput algOut{};
-        EXPECT_NO_THROW(algOut = alg.update(snap));
-        const DvAccumulationOutput refOut = referenceUpdate(ref, snap);
+        EXPECT_NO_THROW(algOut = alg.update(sample.callTime, sample.accel_B));
+        const DvAccumulationOutput refOut = referenceUpdate(ref, sample.callTime, sample.accel_B);
 
         for (int i = 0; i < 3; ++i) {
             EXPECT_NEAR(algOut.vehAccumDV_B[i], refOut.vehAccumDV_B[i], 1e-6F);
             EXPECT_TRUE(std::isfinite(algOut.vehAccumDV_B[i]));
         }
         EXPECT_NEAR(algOut.timeTag, refOut.timeTag, 1e-9);
+    }
+}
+
+/*! @brief Fuzz-friendly driver: drive the algorithm through parallel (callTime, accel) sequences and
+ *         compare to the reference step-by-step (finite output that matches the reference). callTimes
+ *         are not required to be monotonic, so this also exercises the strictly-greater gate. */
+inline void testDvAccumulationFuzz(const std::vector<uint64_t>& callTimes, const std::vector<Eigen::Vector3f>& accels) {
+    if (callTimes.size() != accels.size()) {
+        return;  // fuzz domain may produce mismatched lengths; ignore
+    }
+
+    DvAccumulationAlgorithm alg{};
+    alg.reInitialize();
+    ReferenceState ref{};
+    referenceReInitialize(ref);
+
+    for (size_t k = 0U; k < callTimes.size(); ++k) {
+        DvAccumulationOutput algOut{};
+        EXPECT_NO_THROW(algOut = alg.update(callTimes[k], accels[k]));
+        const DvAccumulationOutput refOut = referenceUpdate(ref, callTimes[k], accels[k]);
+
+        for (int i = 0; i < 3; ++i) {
+            EXPECT_NEAR(algOut.vehAccumDV_B[i], refOut.vehAccumDV_B[i], 1e-5F);
+            EXPECT_TRUE(std::isfinite(algOut.vehAccumDV_B[i]));
+        }
+        EXPECT_TRUE(std::isfinite(algOut.timeTag));
     }
 }
 

--- a/algorithms/dvAccumulation/_tests/dvAccumulationTestHelpers.hpp
+++ b/algorithms/dvAccumulation/_tests/dvAccumulationTestHelpers.hpp
@@ -17,7 +17,6 @@
 struct ReferenceState {
     Eigen::Vector3f vehAccumDV_B{Eigen::Vector3f::Zero()};
     uint64_t previousTime{0U};
-    uint32_t dvInitialized{0U};
 };
 
 /*! @brief Reference sort mirroring the algorithm's iterative quicksort exactly, so the reference
@@ -62,25 +61,24 @@ inline void referenceSortByMeasTime(AccDataMsgF32Payload& accData) {
     }
 }
 
-/*! @brief Reference reInitialize: reset all state (accumulator, previousTime, dvInitialized), so the
- *         first update() bootstraps on the first newer packet (the algorithm's bootstrap behavior). */
+/*! @brief Reference reInitialize: reset all state (accumulator, previousTime), so the first update()
+ *         sets the time reference from the first newer packet. */
 inline void referenceReInitialize(ReferenceState& s) {
     s.vehAccumDV_B = Eigen::Vector3f::Zero();
     s.previousTime = 0U;
-    s.dvInitialized = 0U;
 }
 
-/*! @brief Reference update: sort by measTime, run the dvInitialized bootstrap (skips the first
- *         newer packet), then integrate every subsequent packet via dt * accel. */
+/*! @brief Reference update: sort by measTime; on the first call (previousTime == 0) set the time
+ *         reference from the first newer packet (skip it), then integrate every subsequent packet
+ *         via dt * accel. */
 inline DvAccumulationOutput referenceUpdate(ReferenceState& s, const AccDataMsgF32Payload& accData) {
     AccDataMsgF32Payload sorted = accData;
     referenceSortByMeasTime(sorted);
 
-    if (s.dvInitialized == 0U) {
+    if (s.previousTime == 0U) {
         for (uint32_t i = 0U; i < MAX_ACC_BUF_PKT; i++) {
             if (sorted.accPkts[i].measTime > s.previousTime) {
                 s.previousTime = sorted.accPkts[i].measTime;
-                s.dvInitialized = 1U;
                 break;
             }
         }

--- a/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
+++ b/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
@@ -125,3 +125,23 @@ TEST(DvAccumulationTest, ReInitializeExceptPersistentStatesKeepsTimeReference) {
     EXPECT_NEAR(after.vehAccumDV_B[2], 0.0F, 1e-5F);
     EXPECT_NEAR(after.timeTag, 2.0, 1e-9);
 }
+
+TEST(DvAccumulationTest, ReInitializeResetsTimeReference) {
+    /*! - reInitialize (unlike reInitializeExceptPersistentStates) also resets previousTime, so the next
+     *    update re-sets the time reference: zero DV, no integration, regardless of elapsed time. Contrast
+     *    with ReInitializeExceptPersistentStatesKeepsTimeReference, whose next call yields [1,0,0]. */
+    DvAccumulationAlgorithm alg{};
+    alg.reInitialize();
+
+    const Eigen::Vector3f accel{2.0F, 0.0F, 0.0F};
+    alg.update(static_cast<uint64_t>(1e9), accel);   // callTime 1.0 s: sets ref
+    alg.update(static_cast<uint64_t>(15e8), accel);  // callTime 1.5 s: dt=0.5 -> [1,0,0]
+
+    alg.reInitialize();  // accumulator->0 AND previousTime->0
+
+    const DvAccumulationOutput after = alg.update(static_cast<uint64_t>(2e9), accel);  // callTime 2.0 s: re-sets ref
+    EXPECT_FLOAT_EQ(after.vehAccumDV_B[0], 0.0F);
+    EXPECT_FLOAT_EQ(after.vehAccumDV_B[1], 0.0F);
+    EXPECT_FLOAT_EQ(after.vehAccumDV_B[2], 0.0F);
+    EXPECT_NEAR(after.timeTag, 2.0, 1e-9);  // reference re-set to the new callTime
+}

--- a/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
+++ b/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <array>
 #include <cmath>
 #include <cstdint>
 
@@ -83,4 +84,20 @@ TEST(DvAccumulationTest, KnownAccelerationProducesExpectedDeltaV) {
     EXPECT_NEAR(out.vehAccumDV_B[1], -2.0F, 1e-5F);
     EXPECT_NEAR(out.vehAccumDV_B[2], 0.0F, 1e-5F);
     EXPECT_NEAR(out.timeTag, 1.5, 1e-9);
+}
+
+TEST(DvAccumulationTest, FirstCallIgnoresAcceleration) {
+    /*! - the first update after reInitialize never integrates, whatever acceleration it carries: it only
+     *    sets the time reference. Sweep extreme magnitudes; every one must yield zero accumulated DV. */
+    const std::array<Eigen::Vector3f, 3> firstCallAccels{
+        Eigen::Vector3f{1.0e6F, -1.0e6F, 1.0e6F}, Eigen::Vector3f{-1.0e9F, 1.0e9F, -1.0e9F}, Eigen::Vector3f::Zero()};
+
+    for (const Eigen::Vector3f& accel : firstCallAccels) {
+        DvAccumulationAlgorithm alg{};
+        alg.reInitialize();
+        const DvAccumulationOutput out = alg.update(static_cast<uint64_t>(5e7), accel);
+        EXPECT_FLOAT_EQ(out.vehAccumDV_B[0], 0.0F);
+        EXPECT_FLOAT_EQ(out.vehAccumDV_B[1], 0.0F);
+        EXPECT_FLOAT_EQ(out.vehAccumDV_B[2], 0.0F);
+    }
 }

--- a/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
+++ b/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
@@ -1,61 +1,49 @@
 #include "dvAccumulation/dvAccumulationAlgorithm.h"
 #include "dvAccumulationTestHelpers.hpp"
-#include "msgPayloadDef/AccDataMsgF32Payload.h"
+#include "utilities/fsw/timeConstants.h"
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <cmath>
 #include <cstdint>
-#include <vector>
 
 TEST(DvAccumulationTest, SetupTest) { testDvAccumulationSetup(); }
 
 TEST(DvAccumulationTest, ReferenceTest) {
-    /*! - first update snapshot; its first packet bootstraps previousTime, the rest integrate */
-    const AccDataMsgF32Payload snap1 = buildAccData(
-        {static_cast<uint64_t>(6e7), static_cast<uint64_t>(7e7), static_cast<uint64_t>(8e7)},
-        {Eigen::Vector3f{0.1F, -0.2F, 0.3F}, Eigen::Vector3f{0.2F, -0.1F, 0.4F}, Eigen::Vector3f{-0.1F, 0.5F, 0.1F}});
-
-    /*! - a second snapshot mixing already-seen and new packets */
-    const AccDataMsgF32Payload snap2 = buildAccData(
-        {static_cast<uint64_t>(7e7), static_cast<uint64_t>(9e7), static_cast<uint64_t>(1.1e8)},
-        {Eigen::Vector3f{0.0F, 0.0F, 0.0F}, Eigen::Vector3f{0.05F, 0.1F, -0.15F}, Eigen::Vector3f{-0.05F, 0.0F, 0.1F}});
-
-    testDvAccumulation({snap1, snap2});
+    /*! - a sequence exercising the first call (sets the time reference), integration over advancing
+     *    callTimes, and a non-advancing callTime (gated out) — compared to the reference at every step */
+    testDvAccumulation({
+        {static_cast<uint64_t>(6e7), Eigen::Vector3f{0.1F, -0.2F, 0.3F}},     // first call: sets ref, no integrate
+        {static_cast<uint64_t>(7e7), Eigen::Vector3f{0.2F, -0.1F, 0.4F}},     // integrate
+        {static_cast<uint64_t>(8e7), Eigen::Vector3f{-0.1F, 0.5F, 0.1F}},     // integrate
+        {static_cast<uint64_t>(8e7), Eigen::Vector3f{9.9F, 9.9F, 9.9F}},      // non-advancing -> gated
+        {static_cast<uint64_t>(1.1e8), Eigen::Vector3f{-0.05F, 0.0F, 0.1F}},  // integrate
+    });
 }
 
-TEST(DvAccumulationTest, EmptyBufferProducesZero) {
-    /*! - all-zero measTimes mean no packets are valid */
-    AccDataMsgF32Payload empty{};
+TEST(DvAccumulationTest, FirstCallSetsTimeReferenceOnly) {
+    /*! - the first update after reInitialize (previousTime == 0) only sets the time reference: zero DV,
+     *    time-tag set to the call time */
     DvAccumulationAlgorithm alg{};
     alg.reInitialize();
 
-    const DvAccumulationOutput out = alg.update(empty);
+    const DvAccumulationOutput out = alg.update(static_cast<uint64_t>(5e7), Eigen::Vector3f{1.0F, 2.0F, 3.0F});
+
     EXPECT_FLOAT_EQ(out.vehAccumDV_B[0], 0.0F);
     EXPECT_FLOAT_EQ(out.vehAccumDV_B[1], 0.0F);
     EXPECT_FLOAT_EQ(out.vehAccumDV_B[2], 0.0F);
-    EXPECT_DOUBLE_EQ(out.timeTag, 0.0);
+    EXPECT_NEAR(out.timeTag, 5e7 * kNano2Sec, 1e-9);
 }
 
-TEST(DvAccumulationTest, OutOfOrderInputStillSortsCorrectly) {
-    /*! - packets arrive shuffled in the buffer; the algorithm sorts internally */
-    const AccDataMsgF32Payload shuffled = buildAccData(
-        {static_cast<uint64_t>(3e7), static_cast<uint64_t>(1e7), static_cast<uint64_t>(2e7)},
-        {Eigen::Vector3f{0.3F, 0.0F, 0.0F}, Eigen::Vector3f{0.1F, 0.0F, 0.0F}, Eigen::Vector3f{0.2F, 0.0F, 0.0F}});
-
-    testDvAccumulation({shuffled});
-}
-
-TEST(DvAccumulationTest, RepeatedIdenticalInputsDoNotDoubleAccumulate) {
-    /*! - feeding the same snapshot twice should integrate only the first time */
-    const AccDataMsgF32Payload snap = buildAccData(
-        {static_cast<uint64_t>(1e7), static_cast<uint64_t>(2e7), static_cast<uint64_t>(3e7)},
-        {Eigen::Vector3f{0.1F, 0.2F, 0.3F}, Eigen::Vector3f{0.1F, 0.2F, 0.3F}, Eigen::Vector3f{0.1F, 0.2F, 0.3F}});
-
+TEST(DvAccumulationTest, NonAdvancingCallTimeDoesNotAccumulate) {
+    /*! - feeding the same callTime twice integrates only once (strictly-greater gate) */
     DvAccumulationAlgorithm alg{};
     alg.reInitialize();
 
-    const DvAccumulationOutput first = alg.update(snap);
-    const DvAccumulationOutput second = alg.update(snap);
+    const Eigen::Vector3f accel{0.5F, 0.0F, 0.0F};
+    alg.update(static_cast<uint64_t>(1e7), accel);                                      // first call: sets ref
+    const DvAccumulationOutput first = alg.update(static_cast<uint64_t>(2e7), accel);   // integrate
+    const DvAccumulationOutput second = alg.update(static_cast<uint64_t>(2e7), accel);  // gated
 
     EXPECT_FLOAT_EQ(first.vehAccumDV_B[0], second.vehAccumDV_B[0]);
     EXPECT_FLOAT_EQ(first.vehAccumDV_B[1], second.vehAccumDV_B[1]);
@@ -64,39 +52,18 @@ TEST(DvAccumulationTest, RepeatedIdenticalInputsDoNotDoubleAccumulate) {
 }
 
 TEST(DvAccumulationTest, BoundedInputProducesFiniteOutput) {
-    /*! - with bounded accels and a bounded measTime span, the accumulator must stay finite */
+    /*! - bounded accel over a bounded callTime span keeps the accumulator finite */
     DvAccumulationAlgorithm alg{};
     alg.reInitialize();
 
-    /*! - 10 packets spanning 100 ms with a 10 m/s^2 accel — within range of any realistic sensor */
-    std::vector<uint64_t> measTimes;
-    std::vector<Eigen::Vector3f> accels;
+    const Eigen::Vector3f accel{10.0F, -10.0F, 5.0F};
+    DvAccumulationOutput out{};
     for (uint64_t k = 1U; k <= 10U; ++k) {
-        measTimes.push_back(k * static_cast<uint64_t>(1e7));
-        accels.emplace_back(10.0F, -10.0F, 5.0F);
+        out = alg.update(k * static_cast<uint64_t>(1e7), accel);
     }
-    const AccDataMsgF32Payload snap = buildAccData(measTimes, accels);
 
-    const DvAccumulationOutput out = alg.update(snap);
     for (int i = 0; i < 3; ++i) {
         EXPECT_TRUE(std::isfinite(out.vehAccumDV_B[i]));
     }
     EXPECT_TRUE(std::isfinite(out.timeTag));
-}
-
-TEST(DvAccumulationTest, SingleNewPacketBootstrapSkipsFirst) {
-    /*! - after reInitialize, the first update's first packet > 0 is consumed by the
-     *    dvInitialized bootstrap (sets previousTime, no integration); subsequent packets
-     *    integrate normally. Verify a single-packet snapshot leaves accumulator at zero. */
-    DvAccumulationAlgorithm alg{};
-    alg.reInitialize();
-
-    const AccDataMsgF32Payload singlePacket =
-        buildAccData({static_cast<uint64_t>(5e7)}, {Eigen::Vector3f{1.0F, 2.0F, 3.0F}});
-    const DvAccumulationOutput out = alg.update(singlePacket);
-
-    EXPECT_FLOAT_EQ(out.vehAccumDV_B[0], 0.0F);
-    EXPECT_FLOAT_EQ(out.vehAccumDV_B[1], 0.0F);
-    EXPECT_FLOAT_EQ(out.vehAccumDV_B[2], 0.0F);
-    EXPECT_NEAR(out.timeTag, 5e7 * kNano2Sec, 1e-9);
 }

--- a/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
+++ b/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
@@ -67,3 +67,20 @@ TEST(DvAccumulationTest, BoundedInputProducesFiniteOutput) {
     }
     EXPECT_TRUE(std::isfinite(out.timeTag));
 }
+
+TEST(DvAccumulationTest, KnownAccelerationProducesExpectedDeltaV) {
+    /*! - checks the integration against a hand-computed expected value. The first call only sets the
+     *    time reference; the second, 0.5 s later, integrates dt * accel = 0.5 * [2, -4, 0] = [1, -2, 0]. */
+    DvAccumulationAlgorithm alg{};
+    alg.reInitialize();
+
+    const uint64_t t0 = static_cast<uint64_t>(1e9);                                       // 1.0 s
+    const uint64_t t1 = static_cast<uint64_t>(15e8);                                      // 1.5 s  (dt = 0.5 s)
+    alg.update(t0, Eigen::Vector3f::Zero());                                              // sets the time reference
+    const DvAccumulationOutput out = alg.update(t1, Eigen::Vector3f{2.0F, -4.0F, 0.0F});  // integrate dt * accel
+
+    EXPECT_NEAR(out.vehAccumDV_B[0], 1.0F, 1e-5F);
+    EXPECT_NEAR(out.vehAccumDV_B[1], -2.0F, 1e-5F);
+    EXPECT_NEAR(out.vehAccumDV_B[2], 0.0F, 1e-5F);
+    EXPECT_NEAR(out.timeTag, 1.5, 1e-9);
+}

--- a/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
+++ b/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
@@ -101,3 +101,27 @@ TEST(DvAccumulationTest, FirstCallIgnoresAcceleration) {
         EXPECT_FLOAT_EQ(out.vehAccumDV_B[2], 0.0F);
     }
 }
+
+TEST(DvAccumulationTest, ReInitializeExceptPersistentStatesKeepsTimeReference) {
+    /*! - reInitializeExceptPersistentStates zeros the accumulator but keeps previousTime, so the next
+     *    update integrates immediately from the retained time (no re-set of the reference, no lost
+     *    interval). The result [1,0,0] rules out both failure modes: [2,0,0] if the accumulator hadn't
+     *    reset, [0,0,0] if the time reference had been dropped. */
+    DvAccumulationAlgorithm alg{};
+    alg.reInitialize();
+
+    const Eigen::Vector3f accel{2.0F, 0.0F, 0.0F};
+    alg.update(static_cast<uint64_t>(1e9), accel);  // callTime 1.0 s: sets ref
+    const DvAccumulationOutput before =
+        alg.update(static_cast<uint64_t>(15e8), accel);  // callTime 1.5 s: dt=0.5 -> [1,0,0]
+    EXPECT_NEAR(before.vehAccumDV_B[0], 1.0F, 1e-5F);
+
+    alg.reInitializeExceptPersistentStates();  // accumulator->0, previousTime kept
+
+    const DvAccumulationOutput after =
+        alg.update(static_cast<uint64_t>(2e9), accel);  // callTime 2.0 s: dt=0.5 from 1.5 s
+    EXPECT_NEAR(after.vehAccumDV_B[0], 1.0F, 1e-5F);
+    EXPECT_NEAR(after.vehAccumDV_B[1], 0.0F, 1e-5F);
+    EXPECT_NEAR(after.vehAccumDV_B[2], 0.0F, 1e-5F);
+    EXPECT_NEAR(after.timeTag, 2.0, 1e-9);
+}

--- a/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
+++ b/algorithms/dvAccumulation/_tests/test_dvAccumulation.cpp
@@ -145,3 +145,22 @@ TEST(DvAccumulationTest, ReInitializeResetsTimeReference) {
     EXPECT_FLOAT_EQ(after.vehAccumDV_B[2], 0.0F);
     EXPECT_NEAR(after.timeTag, 2.0, 1e-9);  // reference re-set to the new callTime
 }
+
+TEST(DvAccumulationTest, BackwardCallTimeIsIgnored) {
+    /*! - a callTime strictly earlier than previousTime (clock stepped backward / out-of-order) is
+     *    dropped by the strictly-greater gate: accumulator and time reference stay unchanged. */
+    DvAccumulationAlgorithm alg{};
+    alg.reInitialize();
+
+    const Eigen::Vector3f accel{2.0F, 0.0F, 0.0F};
+    alg.update(static_cast<uint64_t>(1e9), accel);  // callTime 1.0 s: sets ref
+    const DvAccumulationOutput forward =
+        alg.update(static_cast<uint64_t>(2e9), accel);  // callTime 2.0 s: dt=1.0 -> [2,0,0]
+    const DvAccumulationOutput backward =
+        alg.update(static_cast<uint64_t>(15e8), accel);  // callTime 1.5 s < 2.0 s: ignored
+
+    EXPECT_FLOAT_EQ(backward.vehAccumDV_B[0], forward.vehAccumDV_B[0]);  // accumulator unchanged
+    EXPECT_FLOAT_EQ(backward.vehAccumDV_B[1], forward.vehAccumDV_B[1]);
+    EXPECT_FLOAT_EQ(backward.vehAccumDV_B[2], forward.vehAccumDV_B[2]);
+    EXPECT_DOUBLE_EQ(backward.timeTag, forward.timeTag);  // time reference unchanged (still 2.0 s)
+}

--- a/algorithms/dvAccumulation/_tests/test_dvAccumulationF32.py
+++ b/algorithms/dvAccumulation/_tests/test_dvAccumulationF32.py
@@ -1,82 +1,61 @@
 """
 Module Name:        dvAccumulation
 
-Regression test for the fp32 dvAccumulation port. Faithful port of the original Xmera
-dvAccumulation unit test: drives two accelerometer snapshots through the SysModel adapter and
-checks the accumulated body-frame Delta-V (and time-tag) against the original test's hardcoded
-expected values. The fp32 port reproduces the original double-precision oracle to within float32
-tolerance, which is the point of the test.
+Smoke / interface test for the fp32 dvAccumulation module. dvAccumulation integrates a single
+body-frame acceleration sample per update (an IMUSensorBodyMsgF32 input), using the module call time
+for the integration step. This test exercises every interface end-to-end through the SysModel adapter
+-- link the input message, run several steps, and confirm the module executes and produces a finite,
+correctly-signed accumulated Delta-V.
 """
 
 import numpy as np
-from numpy import random
 from xmera.architecture import messaging
 from xmera.fp32 import dvAccumulationF32
 from xmera.utilities import SimulationBaseClass, macros
 
 
-def generateAccData(num_packets=120):
-    """Return a list of `num_packets` AccPktDataMsgF32Payload with random measTime / accel_B,
-    generated identically to the original Xmera test (legacy numpy global RNG)."""
-    accPktList = []
-    for _ in range(num_packets):
-        packet = messaging.AccPktDataMsgF32Payload()
-        packet.measTime = abs(int(random.normal(5e7, 1e7)))
-        packet.accel_B = random.normal(0.1, 0.2, 3)  # [m/s^2]; stored as float32 in the F32 payload
-        accPktList.append(packet)
-    return accPktList
-
-
 def test_dv_accumulation():
-    """End-to-end: drive two snapshots through the adapter and compare against the original
-    Xmera test's hardcoded expected Delta-V and time-tag series."""
+    """End-to-end smoke test: drive a constant body-frame acceleration through the adapter over
+    several control steps and confirm the accumulated Delta-V is finite and grows as expected."""
 
-    random.seed(12345)
-
-    unitTestSim = SimulationBaseClass.SimBaseClass()
-    testProcessRate = macros.sec2nano(0.5)
-    testProc = unitTestSim.CreateNewProcess("TestProcess")
-    testProc.addTask(unitTestSim.CreateNewTask("unitTask", testProcessRate))
+    unit_test_sim = SimulationBaseClass.SimBaseClass()
+    test_process_rate = macros.sec2nano(0.5)
+    test_proc = unit_test_sim.CreateNewProcess("TestProcess")
+    test_proc.addTask(unit_test_sim.CreateNewTask("unitTask", test_process_rate))
 
     module = dvAccumulationF32.DvAccumulation()
     module.modelTag = "dvAccumulation"
-    unitTestSim.AddModelToTask("unitTask", module)
+    unit_test_sim.AddModelToTask("unitTask", module)
 
-    dataLog = module.dvAccumulationOutMsg.recorder()
-    unitTestSim.AddModelToTask("unitTask", dataLog)
+    data_log = module.dvAccumulationOutMsg.recorder()
+    unit_test_sim.AddModelToTask("unitTask", data_log)
 
-    # First snapshot
-    firstInput = messaging.AccDataMsgF32Payload()
-    firstInput.accPkts = generateAccData()
-    inMsg = messaging.AccDataMsgF32()
-    module.accPktInMsg.subscribeTo(inMsg)
+    # Constant body-frame acceleration [m/s^2] on the input IMU message.
+    accel_body = [0.1, -0.2, 0.3]
+    input_data = messaging.IMUSensorBodyMsgF32Payload()
+    input_data.AccelBody = accel_body
+    in_msg = messaging.IMUSensorBodyMsgF32().write(input_data)
+    module.imuInMsg.subscribeTo(in_msg)
 
-    unitTestSim.InitializeSimulation()
-    inMsg.write(firstInput)
+    unit_test_sim.InitializeSimulation()
+    unit_test_sim.ConfigureStopTime(macros.sec2nano(2.0))
+    unit_test_sim.ExecuteSimulation()
 
-    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
-    unitTestSim.ExecuteSimulation()
+    accum_dv = np.array(data_log.vehAccumDV)
+    time_tag = np.array(data_log.timeTag)
 
-    # Second snapshot — same module, fresh accel data (continues the seeded RNG stream)
-    secondInput = messaging.AccDataMsgF32Payload()
-    secondInput.accPkts = generateAccData()
-    inMsg.write(secondInput)
+    # Every interface ran and produced finite output.
+    assert accum_dv.shape[0] > 0
+    assert np.all(np.isfinite(accum_dv))
+    assert np.all(np.isfinite(time_tag))
 
-    unitTestSim.ConfigureStopTime(macros.sec2nano(2.0))
-    unitTestSim.ExecuteSimulation()
-
-    # Expected values from the original Xmera dvAccumulation unit test. reset() runs before the
-    # first message is written, so it seeds previousTime = 0; the first update integrates the first
-    # snapshot (skipping the earliest packet via the dvInitialized latch), and the second update adds
-    # the packets newer than the first snapshot's latest measTime.
-    trueDVVector = np.array(
-        [[4.82820079e-03, 7.81971465e-03, 2.29605663e-03]] * 3
-        + [[6.44596343e-03, 9.00203561e-03, 2.60580728e-03]] * 2
-    )
-    trueTime = np.array([7.2123026e07] * 3 + [7.6667436e07] * 2) * macros.NANO2SEC
-
-    np.testing.assert_allclose(dataLog.vehAccumDV, trueDVVector, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(dataLog.timeTag, trueTime, rtol=0, atol=1e-6)
+    # The first call only sets the time reference (no integration), so the final accumulated Delta-V is
+    # positive time * accel: it must be non-zero and share the sign of the input acceleration.
+    final_dv = accum_dv[-1]
+    assert np.linalg.norm(final_dv) > 0.0
+    assert np.sign(final_dv[0]) == np.sign(accel_body[0])
+    assert np.sign(final_dv[1]) == np.sign(accel_body[1])
+    assert np.sign(final_dv[2]) == np.sign(accel_body[2])
 
 
 if __name__ == "__main__":

--- a/algorithms/dvAccumulation/_tests/test_dvAccumulationF32.py
+++ b/algorithms/dvAccumulation/_tests/test_dvAccumulationF32.py
@@ -42,7 +42,7 @@ def test_dv_accumulation():
     module.modelTag = "dvAccumulation"
     unitTestSim.AddModelToTask("unitTask", module)
 
-    dataLog = module.dvAcumOutMsg.recorder()
+    dataLog = module.dvAccumulationOutMsg.recorder()
     unitTestSim.AddModelToTask("unitTask", dataLog)
 
     # First snapshot

--- a/algorithms/dvAccumulation/_tests/test_dvAccumulation_fuzz.cpp
+++ b/algorithms/dvAccumulation/_tests/test_dvAccumulation_fuzz.cpp
@@ -3,11 +3,10 @@
 
 #include <fuzztest/fuzztest.h>
 
-/*! Fuzz domain: variable-length parallel vectors of measTimes and accels (capped at
- *  MAX_ACC_BUF_PKT). Each accel component is bounded to ±100 m/s², measTimes are bounded
- *  to the [0, 1e10] ns range to keep dt finite. */
+/*! Fuzz domain: parallel sequences of callTimes (ns) and body-frame accelerations, driving a
+ *  sequence of update() calls. callTimes are unconstrained in order (so both the first-call
+ *  time-reference set and the strictly-greater gate are exercised); accels are bounded to ±100 m/s² and callTimes to
+ *  the [0, 1e10] ns range to keep dt finite. */
 FUZZ_TEST(DvAccumulationFuzz, testDvAccumulationFuzz)
-    .WithDomains(fuzztest::VectorOf(fuzztest::InRange<uint64_t>(0U, static_cast<uint64_t>(1e10)))
-                     .WithMaxSize(static_cast<size_t>(MAX_ACC_BUF_PKT)),
-                 fuzztest::VectorOf(xmera::fuzz::Vector3fInRange(-100.0F, 100.0F))
-                     .WithMaxSize(static_cast<size_t>(MAX_ACC_BUF_PKT)));
+    .WithDomains(fuzztest::VectorOf(fuzztest::InRange<uint64_t>(0U, static_cast<uint64_t>(1e10))).WithMaxSize(128U),
+                 fuzztest::VectorOf(xmera::fuzz::Vector3fInRange(-100.0F, 100.0F)).WithMaxSize(128U));

--- a/algorithms/dvAccumulation/dvAccumulation.cpp
+++ b/algorithms/dvAccumulation/dvAccumulation.cpp
@@ -4,7 +4,7 @@
 
 #include <stdexcept>
 
-void DvAccumulation::reset(const uint64_t callTime) {
+void DvAccumulation::reset(const uint64_t /*callTime*/) {
     if (!this->accPktInMsg.isLinked()) {
         throw std::invalid_argument("dvAccumulation.accPktInMsg wasn't connected.");
     }
@@ -36,5 +36,5 @@ void DvAccumulation::updateState(const uint64_t callTime) {
     outputData.timeTag = out.timeTag;
     eigenVectorToCArray(out.vehAccumDV_B, outputData.vehAccumDV);
 
-    this->dvAcumOutMsg.write(&outputData, this->moduleID, callTime);
+    this->dvAcumOutMsg.write(outputData, this->moduleID, callTime);
 }

--- a/algorithms/dvAccumulation/dvAccumulation.cpp
+++ b/algorithms/dvAccumulation/dvAccumulation.cpp
@@ -5,8 +5,8 @@
 #include <stdexcept>
 
 void DvAccumulation::reset(const uint64_t /*callTime*/) {
-    if (!this->accPktInMsg.isLinked()) {
-        throw std::invalid_argument("dvAccumulation.accPktInMsg wasn't connected.");
+    if (!this->imuInMsg.isLinked()) {
+        throw std::invalid_argument("dvAccumulation.imuInMsg wasn't connected.");
     }
 
     this->algorithm = std::make_unique<DvAccumulationAlgorithm>();
@@ -29,8 +29,9 @@ void DvAccumulation::updateState(const uint64_t callTime) {
         throw XmeraLifecycleException("DvAccumulation reset() has not been called.");
     }
 
-    const AccDataMsgF32Payload inputAccData = this->accPktInMsg();
-    const DvAccumulationOutput out = this->algorithm->update(inputAccData);
+    const IMUSensorBodyMsgF32Payload imuData = this->imuInMsg();
+    const Eigen::Vector3f rDDotNoGravity_BN_B = cArrayToEigenVector(imuData.AccelBody);
+    const DvAccumulationOutput out = this->algorithm->update(callTime, rDDotNoGravity_BN_B);
 
     NavTransMsgF32Payload outputData = NavTransMsgF32Payload();
     outputData.timeTag = out.timeTag;

--- a/algorithms/dvAccumulation/dvAccumulation.cpp
+++ b/algorithms/dvAccumulation/dvAccumulation.cpp
@@ -36,5 +36,5 @@ void DvAccumulation::updateState(const uint64_t callTime) {
     outputData.timeTag = out.timeTag;
     eigenVectorToCArray(out.vehAccumDV_B, outputData.vehAccumDV);
 
-    this->dvAcumOutMsg.write(outputData, this->moduleID, callTime);
+    this->dvAccumulationOutMsg.write(outputData, this->moduleID, callTime);
 }

--- a/algorithms/dvAccumulation/dvAccumulation.h
+++ b/algorithms/dvAccumulation/dvAccumulation.h
@@ -19,8 +19,8 @@ class DvAccumulation final : public SysModel {
     void reInitialize();                        //!< Reset all algorithm state (state-transition hook)
     void reInitializeExceptPersistentStates();  //!< Reset only non-persistent algorithm state
 
-    Message<NavTransMsgF32Payload> dvAcumOutMsg;    //!< accumulated DV output message
-    ReadFunctor<AccDataMsgF32Payload> accPktInMsg;  //!< [-] input accelerometer message
+    Message<NavTransMsgF32Payload> dvAccumulationOutMsg;  //!< accumulated DV output message
+    ReadFunctor<AccDataMsgF32Payload> accPktInMsg;        //!< [-] input accelerometer message
 
    private:
     std::unique_ptr<DvAccumulationAlgorithm> algorithm = nullptr;

--- a/algorithms/dvAccumulation/dvAccumulation.h
+++ b/algorithms/dvAccumulation/dvAccumulation.h
@@ -2,15 +2,15 @@
 #define F32XMERA_DV_ACCUMULATION_H
 
 #include "dvAccumulationAlgorithm.h"
-#include "msgPayloadDef/AccDataMsgF32Payload.h"
+#include "msgPayloadDef/IMUSensorBodyMsgF32Payload.h"
 #include "msgPayloadDef/NavTransMsgF32Payload.h"
 
 #include <architecture/_GeneralModuleFiles/sys_model.h>
 #include <architecture/messaging/messaging.h>
 #include <memory>
 
-/*! @brief SysModel adapter for DvAccumulationAlgorithm. Reads the input accelerometer-packet
- message, runs the algorithm, and writes the accumulated body-frame Delta-V to the output
+/*! @brief SysModel adapter for DvAccumulationAlgorithm. Reads the body-frame acceleration from the
+ input IMU message, runs the algorithm, and writes the accumulated body-frame Delta-V to the output
  navigation message. */
 class DvAccumulation final : public SysModel {
    public:
@@ -20,7 +20,7 @@ class DvAccumulation final : public SysModel {
     void reInitializeExceptPersistentStates();  //!< Reset only non-persistent algorithm state
 
     Message<NavTransMsgF32Payload> dvAccumulationOutMsg;  //!< accumulated DV output message
-    ReadFunctor<AccDataMsgF32Payload> accPktInMsg;        //!< [-] input accelerometer message
+    ReadFunctor<IMUSensorBodyMsgF32Payload> imuInMsg;     //!< [-] input IMU body message
 
    private:
     std::unique_ptr<DvAccumulationAlgorithm> algorithm = nullptr;

--- a/algorithms/dvAccumulation/dvAccumulation.rst
+++ b/algorithms/dvAccumulation/dvAccumulation.rst
@@ -25,7 +25,7 @@ Message Connection Descriptions
       - ``AccDataMsgF32Payload``
       - Input snapshot of up to 120 accelerometer packets, each carrying a ``measTime`` (uint64 ns)
         and a body-frame ``accel_B`` (float[3]).
-    * - dvAcumOutMsg
+    * - dvAccumulationOutMsg
       - ``NavTransMsgF32Payload``
       - Output navigation message. The algorithm populates ``timeTag`` (seconds, double) and
         ``vehAccumDV`` (m/s, float[3]); the position and velocity fields are left zero.
@@ -106,7 +106,7 @@ The required module configuration is::
     module = dvAccumulationF32.DvAccumulation()
     module.modelTag = "dvAccumulation"
     module.accPktInMsg.subscribeTo(accPktSource)
-    # Subscribe a downstream consumer to module.dvAcumOutMsg.
+    # Subscribe a downstream consumer to module.dvAccumulationOutMsg.
 
 There is no further setup — no parameters to set, no validators to satisfy. Call
 ``reset(callTime)`` once before the first ``updateState(callTime)``; ``reset`` throws

--- a/algorithms/dvAccumulation/dvAccumulation.rst
+++ b/algorithms/dvAccumulation/dvAccumulation.rst
@@ -4,13 +4,13 @@
 
 Executive Summary
 -----------------
-``dvAccumulation`` integrates body-frame accelerometer measurements into a running Delta-V
-accumulator. Each input snapshot carries up to ``MAX_ACC_BUF_PKT`` (120) ``AccPktDataMsgF32Payload``
-slots — every slot has a per-packet ``measTime`` (ns) and a ``accel_B`` (3-component float). The
-algorithm sorts the snapshot by ``measTime``, integrates every packet whose timestamp is *strictly*
-greater than the previously-seen latest time via
-:math:`\Delta\mathbf{v} = \Delta\mathbf{v} + \Delta t \cdot \mathbf{a}_B`, and outputs the running
-accumulator plus the time-tag of the most-recently-ingested sample.
+``dvAccumulation`` integrates a single body-frame acceleration sample into a running Delta-V
+accumulator. Each ``updateState()`` reads one ``IMUSensorBodyMsgF32Payload`` and takes its
+``AccelBody`` field as the body-frame non-gravitational acceleration :math:`\ddot{\mathbf{r}}_{B}`.
+The time step comes from the module call time,
+:math:`\Delta t = (\text{callTime} - \text{previousTime})`, so the sample is integrated via
+:math:`\Delta\mathbf{v} = \Delta\mathbf{v} + \Delta t \cdot \ddot{\mathbf{r}}_{B}`. The module
+outputs the running accumulator plus the time-tag of the most-recently-ingested sample.
 
 Message Connection Descriptions
 -------------------------------
@@ -21,13 +21,13 @@ Message Connection Descriptions
     * - Variable Name
       - Type
       - Description
-    * - accPktInMsg
-      - ``AccDataMsgF32Payload``
-      - Input snapshot of up to 120 accelerometer packets, each carrying a ``measTime`` (uint64 ns)
-        and a body-frame ``accel_B`` (float[3]).
+    * - imuInMsg
+      - ``IMUSensorBodyMsgF32Payload``
+      - Input IMU body message. Only ``AccelBody`` (m/s^2, float[3], the body-frame non-gravitational
+        acceleration) is consumed.
     * - dvAccumulationOutMsg
       - ``NavTransMsgF32Payload``
-      - Output navigation message. The algorithm populates ``timeTag`` (seconds, double) and
+      - Output navigation message. The module populates ``timeTag`` (seconds, double) and
         ``vehAccumDV`` (m/s, float[3]); the position and velocity fields are left zero.
 
 Module Parameters
@@ -37,22 +37,23 @@ default-constructed by the adapter's ``reset()``.
 
 Module Assumptions and Limitations
 ----------------------------------
-- ``measTime`` is in nanoseconds.
+- ``callTime`` is in nanoseconds and is assumed to advance once per new sample. ``dvAccumulation`` runs
+  at the same cadence as its upstream producer and immediately after it, so the acceleration sample is
+  fresh on every call and the call-time delta is the correct integration step.
 - The algorithm holds running state split into **non-persistent** (``vehAccumDV_B``) and
-  **persistent** (``previousTime``, ``dvInitialized``). ``reInitialize()`` resets all of it;
-  ``reInitializeExceptPersistentStates()`` resets only ``vehAccumDV_B``, keeping the integration
-  bookkeeping so a continuously-running module ignores the backlog already ingested.
+  **persistent** (``previousTime``). ``reInitialize()`` resets all of it;
+  ``reInitializeExceptPersistentStates()`` resets only ``vehAccumDV_B``, keeping the time reference so
+  a continuously-running module keeps integrating across the boundary.
 - Lifecycle: the adapter constructs the algorithm in ``reset()`` (startup only). State-transition
   hooks call ``reInitialize()`` / ``reInitializeExceptPersistentStates()``; ``reset()`` is not
   re-invoked on transitions.
-- Bootstrap: on the first ``update()`` after ``reInitialize()`` (``dvInitialized == 0``,
-  ``previousTime == 0``), the first packet with ``measTime`` greater than ``previousTime`` is
-  *consumed* by the bootstrap (it becomes the new ``previousTime``, no integration), and only
-  subsequent packets contribute. This is faithful to the original Xmera module semantics.
-- Packets with ``measTime`` not strictly greater than ``previousTime`` are dropped at ingest, so
-  out-of-order or repeated input is safe (sorting is done inside the algorithm).
-- If the ring is empty or no packet beats ``previousTime`` on a given snapshot, the output
-  vector and time-tag are zero.
+- Time reference: on the first ``update()`` after ``reInitialize()`` (``previousTime == 0``), the call
+  only sets the time reference ``previousTime = callTime`` (no integration), so ``dt`` does not blow up
+  against a zero baseline. ``previousTime == 0`` doubles as the "time reference not yet set" marker, which
+  relies on ``callTime`` being non-zero on the first call after a re-initialization (always true for the
+  flight mission clock).
+- A call whose ``callTime`` is not strictly greater than ``previousTime`` is ignored (no integration),
+  so a repeated or non-advancing call time does not double-count.
 - The accumulator is float-precision (``Eigen::Vector3f``). ``dt`` is computed in float using
   ``kNano2SecF``. ``timeTag`` stays double in the output message.
 
@@ -61,42 +62,39 @@ Module Architecture
 Three-layer split:
 
 - **Adapter (``dvAccumulation.h/.cpp``, ``class DvAccumulation : SysModel``).** Reads the input
-  message, drives the algorithm, writes the output message. The adapter owns the algorithm via
-  ``std::unique_ptr`` and constructs it inside ``reset()`` after validating that
-  ``accPktInMsg`` is linked.
+  message, converts ``AccelBody`` to an ``Eigen::Vector3f`` via ``utilities/fsw/eigenSupport.h``,
+  drives the algorithm with the current ``callTime``, and writes the output message. The adapter owns
+  the algorithm via ``std::unique_ptr`` and constructs it inside ``reset()`` after validating that
+  ``imuInMsg`` is linked.
 - **Algorithm (``dvAccumulationAlgorithm.h/.cpp``, ``class DvAccumulationAlgorithm``).** Pure
-  algorithm — no SysModel, no messaging. Takes ``AccDataMsgF32Payload`` and returns a
-  ``DvAccumulationOutput`` carrying ``timeTag`` (double, s) and ``vehAccumDV_B``
-  (``Eigen::Vector3f``, m/s). Default-constructed — no configuration.
+  algorithm — no SysModel, no messaging. ``update(callTime, rDDotNoGravity_BN_B)`` takes the call time
+  and an ``Eigen::Vector3f`` and returns a ``DvAccumulationOutput`` carrying ``timeTag`` (double, s)
+  and ``vehAccumDV_B`` (``Eigen::Vector3f``, m/s). Default-constructed — no configuration.
 - **C shim (``dvAccumulationAlgorithm_c.h/.cpp``, ``dvAccumulationTypes.h``).** Pure-C interface
   for Ada FFI: opaque handle plus ``DvAccumulationAlgorithm_create``/``_destroy``/
-  ``_reInitialize``/``_reInitializeExceptPersistentStates``/``_update``. ``dvAccumulationTypes.h``
-  (pure C) declares ``DvAccumulationOutput_c``, which is
-  the POD mirror of the C++ output using the shared ``Vector3f_c`` from
-  ``utilities/fsw/plainCAlgorithmDataTypes.h``. The shim exposes
-  ``DvAccumulationAlgorithm_getMaxAccBufPkt()`` for Ada elaboration-time validation against
-  ``MAX_ACC_BUF_PKT``.
+  ``_reInitialize``/``_reInitializeExceptPersistentStates``/``_update``. ``_update`` takes the call
+  time and a ``Vector3f_c`` acceleration. ``dvAccumulationTypes.h`` (pure C) declares
+  ``DvAccumulationOutput_c``, the POD mirror of the C++ output using the shared ``Vector3f_c`` from
+  ``utilities/fsw/plainCAlgorithmDataTypes.h``.
 
 Algorithm Layer
 ---------------
-Given an input snapshot ``localPkts`` and the previously-seen latest time ``previousTime``:
+Given the call time ``callTime``, the body-frame acceleration ``rDDotNoGravity_BN_B``, and the
+previously-seen call time ``previousTime``:
 
-1. Sort ``localPkts.accPkts`` in place (a local copy) by ascending ``measTime`` using an
-   iterative quicksort (a hand-written sort is used rather than ``std::ranges::sort`` to avoid a
-   libstdc++ ``clang-analyzer-security.ArrayBound`` false positive on the raw C array).
-2. On the first ``update()`` after ``reInitialize()`` (``dvInitialized == 0``), scan the sorted
-   buffer for the first packet with ``measTime > previousTime`` and latch it as the new
-   ``previousTime`` (consuming that packet — it doesn't integrate). Mark ``dvInitialized = 1``.
-3. Iterate the sorted buffer. For each packet with ``measTime > previousTime``:
+1. On the first ``update()`` after ``reInitialize()`` (``previousTime == 0``), latch
+   ``previousTime = callTime`` and return without integrating.
+2. Otherwise, if ``callTime > previousTime``, integrate the elapsed step:
 
    .. math::
 
-      \Delta t = (\text{measTime} - \text{previousTime}) \cdot \mathtt{kNano2SecF}
+      \Delta t = (\text{callTime} - \text{previousTime}) \cdot \mathtt{kNano2SecF}
       \quad,\quad
-      \Delta\mathbf{v} = \Delta\mathbf{v} + \Delta t \cdot \mathbf{a}_B
+      \Delta\mathbf{v} = \Delta\mathbf{v} + \Delta t \cdot \ddot{\mathbf{r}}_{B}
       \quad,\quad
-      \text{previousTime} \leftarrow \text{measTime}
+      \text{previousTime} \leftarrow \text{callTime}
 
+3. A ``callTime`` that does not advance past ``previousTime`` is ignored (no integration).
 4. Emit ``timeTag = previousTime * kNano2Sec`` and ``vehAccumDV_B = \Delta\mathbf{v}``.
 
 User Guide
@@ -105,9 +103,10 @@ The required module configuration is::
 
     module = dvAccumulationF32.DvAccumulation()
     module.modelTag = "dvAccumulation"
-    module.accPktInMsg.subscribeTo(accPktSource)
-    # Subscribe a downstream consumer to module.dvAccumulationOutMsg.
+    module.imuInMsg.subscribeTo(mimuMajorityVote.imuSensorBodyOutMsg)
+    # Subscribe a downstream consumer (e.g. dvExecuteGuidance) to module.dvAccumulationOutMsg.
 
 There is no further setup — no parameters to set, no validators to satisfy. Call
 ``reset(callTime)`` once before the first ``updateState(callTime)``; ``reset`` throws
-``std::invalid_argument`` if ``accPktInMsg`` is not linked.
+``std::invalid_argument`` if ``imuInMsg`` is not linked. On a state transition the flight software
+calls ``reInitialize()`` (or ``reInitializeExceptPersistentStates()``) rather than ``reset()``.

--- a/algorithms/dvAccumulation/dvAccumulationAlgorithm.cpp
+++ b/algorithms/dvAccumulation/dvAccumulationAlgorithm.cpp
@@ -57,7 +57,7 @@ void sortByMeasTime(AccDataMsgF32Payload& accData) {
 DvAccumulationAlgorithm::DvAccumulationAlgorithm() { this->reInitialize(); }
 
 void DvAccumulationAlgorithm::reInitializeExceptPersistentStates() {
-    /*! - reset only the non-persistent accumulator; previousTime and dvInitialized persist */
+    /*! - reset only the non-persistent accumulator; previousTime persists */
     this->vehAccumDV_B = Eigen::Vector3f::Zero();
 }
 
@@ -65,7 +65,6 @@ void DvAccumulationAlgorithm::reInitialize() {
     /*! - reset all state, including the persistent integration bookkeeping */
     this->reInitializeExceptPersistentStates();
     this->previousTime = 0U;
-    this->dvInitialized = 0U;
 }
 
 DvAccumulationOutput DvAccumulationAlgorithm::update(const AccDataMsgF32Payload& accData) {
@@ -73,13 +72,12 @@ DvAccumulationOutput DvAccumulationAlgorithm::update(const AccDataMsgF32Payload&
     AccDataMsgF32Payload sorted = accData;
     sortByMeasTime(sorted);
 
-    /*! - On the first call ever, if reset's seed found nothing, latch onto the first new measTime
-     *    here so dt doesn't blow up against a zero baseline */
-    if (this->dvInitialized == 0U) {
+    /*! - On the first call after a reInitialize (previousTime == 0), latch onto the first new
+     *    measTime here so dt doesn't blow up against a zero baseline */
+    if (this->previousTime == 0U) {
         for (auto const& accPkt : sorted.accPkts) {
             if (accPkt.measTime > this->previousTime) {
                 this->previousTime = accPkt.measTime;
-                this->dvInitialized = 1U;
                 break;
             }
         }

--- a/algorithms/dvAccumulation/dvAccumulationAlgorithm.cpp
+++ b/algorithms/dvAccumulation/dvAccumulationAlgorithm.cpp
@@ -1,58 +1,5 @@
 #include "dvAccumulationAlgorithm.h"
-#include "utilities/fsw/eigenSupport.h"
 #include "utilities/fsw/timeConstants.h"
-
-#include <array>
-#include <utility>
-
-namespace {
-/*! @brief Sort an AccDataMsgF32Payload::accPkts buffer in place by ascending measTime.
- *
- * Iterative (stack-based) quicksort, mirroring the original Xmera dvAccumulation sort. A hand-written
- * sort is used rather than std::ranges::sort because libstdc++'s sort implementation trips
- * clang-analyzer-security.ArrayBound (its unguarded insertion-sort reads one element before the
- * array) when applied to the raw C array. */
-void sortByMeasTime(AccDataMsgF32Payload& accData) {
-    std::array<int, MAX_ACC_BUF_PKT> indexStack{};
-    int top = -1;
-    ++top;
-    indexStack[static_cast<size_t>(top)] = 0;
-    ++top;
-    indexStack[static_cast<size_t>(top)] = MAX_ACC_BUF_PKT - 1;
-
-    while (top >= 1) {
-        auto const end = indexStack[static_cast<size_t>(top)];
-        auto const start = indexStack[static_cast<size_t>(top - 1)];
-        top -= 2;
-
-        /*! - Lomuto partition on measTime with the last element as pivot */
-        auto const pivot = accData.accPkts[static_cast<size_t>(end)].measTime;
-        int partitionIndex = start;
-        for (int i = start; i < end; ++i) {
-            if (accData.accPkts[static_cast<size_t>(i)].measTime <= pivot) {
-                std::swap(accData.accPkts[static_cast<size_t>(i)],
-                          accData.accPkts[static_cast<size_t>(partitionIndex)]);
-                ++partitionIndex;
-            }
-        }
-        std::swap(accData.accPkts[static_cast<size_t>(partitionIndex)], accData.accPkts[static_cast<size_t>(end)]);
-
-        /*! - push sub-ranges that still contain more than one element */
-        if (partitionIndex - 1 > start) {
-            ++top;
-            indexStack[static_cast<size_t>(top)] = start;
-            ++top;
-            indexStack[static_cast<size_t>(top)] = partitionIndex - 1;
-        }
-        if (partitionIndex + 1 < end) {
-            ++top;
-            indexStack[static_cast<size_t>(top)] = partitionIndex + 1;
-            ++top;
-            indexStack[static_cast<size_t>(top)] = end;
-        }
-    }
-}
-}  // namespace
 
 DvAccumulationAlgorithm::DvAccumulationAlgorithm() { this->reInitialize(); }
 
@@ -62,35 +9,21 @@ void DvAccumulationAlgorithm::reInitializeExceptPersistentStates() {
 }
 
 void DvAccumulationAlgorithm::reInitialize() {
-    /*! - reset all state, including the persistent integration bookkeeping */
+    /*! - reset all state, including the persistent time reference */
     this->reInitializeExceptPersistentStates();
     this->previousTime = 0U;
 }
 
-DvAccumulationOutput DvAccumulationAlgorithm::update(const AccDataMsgF32Payload& accData) {
-    /*! - work on a local sorted copy */
-    AccDataMsgF32Payload sorted = accData;
-    sortByMeasTime(sorted);
-
-    /*! - On the first call after a reInitialize (previousTime == 0), latch onto the first new
-     *    measTime here so dt doesn't blow up against a zero baseline */
+DvAccumulationOutput DvAccumulationAlgorithm::update(const uint64_t callTime,
+                                                     const Eigen::Vector3f& rDDotNoGravity_BN_B) {
+    /*! - On the first call after a reInitialize (previousTime == 0), latch the clock so dt doesn't
+     *    blow up against a zero baseline; otherwise integrate over the elapsed step */
     if (this->previousTime == 0U) {
-        for (auto const& accPkt : sorted.accPkts) {
-            if (accPkt.measTime > this->previousTime) {
-                this->previousTime = accPkt.measTime;
-                break;
-            }
-        }
-    }
-
-    /*! - integrate every packet newer than previousTime */
-    for (auto const& accPkt : sorted.accPkts) {
-        if (accPkt.measTime > this->previousTime) {
-            const float dt = static_cast<float>(accPkt.measTime - this->previousTime) * kNano2SecF;
-            const Eigen::Vector3f accel_B = cArrayToEigenVector3(accPkt.accel_B);
-            this->vehAccumDV_B += dt * accel_B;
-            this->previousTime = accPkt.measTime;
-        }
+        this->previousTime = callTime;
+    } else if (callTime > this->previousTime) {
+        const float dt = static_cast<float>(callTime - this->previousTime) * kNano2SecF;
+        this->vehAccumDV_B += dt * rDDotNoGravity_BN_B;
+        this->previousTime = callTime;
     }
 
     DvAccumulationOutput out{};

--- a/algorithms/dvAccumulation/dvAccumulationAlgorithm.h
+++ b/algorithms/dvAccumulation/dvAccumulationAlgorithm.h
@@ -20,21 +20,21 @@ struct DvAccumulationOutput {
  * to the running accumulator.
  *
  * dvAccumulation has no tunable parameters, so there is no Config. State splits into persistent
- * (previousTime, dvInitialized — carried across a re-initialization so a continuously-running
- * module ignores the backlog already ingested) and non-persistent (vehAccumDV_B).
+ * (previousTime — carried across a re-initialization so a continuously-running module ignores the
+ * backlog already ingested) and non-persistent (vehAccumDV_B). previousTime == 0 doubles as the
+ * "time reference not yet set" marker for the first update() after a reInitialize().
  */
 class DvAccumulationAlgorithm final {
    public:
     DvAccumulationAlgorithm();
 
-    void reInitialize();                        //!< Reset all state: accumulator, previousTime, dvInitialized
+    void reInitialize();                        //!< Reset all state: accumulator and previousTime
     void reInitializeExceptPersistentStates();  //!< Reset only non-persistent state: the accumulator
     DvAccumulationOutput update(const AccDataMsgF32Payload& accData);
 
    private:
     Eigen::Vector3f vehAccumDV_B{Eigen::Vector3f::Zero()};  //!< [m/s] running Delta-V accumulator (non-persistent)
     uint64_t previousTime{};                                //!< [ns] latest measTime ingested so far (persistent)
-    uint32_t dvInitialized{};  //!< [-] non-zero once at least one packet has been ingested (persistent)
 };
 
 #endif

--- a/algorithms/dvAccumulation/dvAccumulationAlgorithm.h
+++ b/algorithms/dvAccumulation/dvAccumulationAlgorithm.h
@@ -1,9 +1,6 @@
 #ifndef F32XMERA_DV_ACCUMULATION_ALGORITHM_H
 #define F32XMERA_DV_ACCUMULATION_ALGORITHM_H
 
-#include "dvAccumulationTypes.h"
-#include "msgPayloadDef/AccDataMsgF32Payload.h"
-
 #include <Eigen/Core>
 #include <cstdint>
 
@@ -13,15 +10,17 @@ struct DvAccumulationOutput {
     Eigen::Vector3f vehAccumDV_B{Eigen::Vector3f::Zero()};  //!< [m/s] accumulated Delta-V in body-frame components
 };
 
-/*! @brief Pure algorithm: integrates accelerometer packets into a body-frame Delta-V accumulator.
+/*! @brief Pure algorithm: integrates a body-frame acceleration sample into a body-frame Delta-V
+ *         accumulator.
  *
- * On each update() call the input snapshot is sorted by measTime; every packet with measTime
- * strictly greater than the previously-seen latest time is integrated via dt * accel and added
- * to the running accumulator.
+ * Each update() call carries one body-frame non-gravitational acceleration sample plus the
+ * module call time. The time step is dt = callTime - previousTime; the sample is integrated via
+ * dt * accel and added to the running accumulator. The first call after a reInitialize()
+ * (previousTime == 0) only latches the clock, so dt does not blow up against a zero baseline.
  *
  * dvAccumulation has no tunable parameters, so there is no Config. State splits into persistent
- * (previousTime — carried across a re-initialization so a continuously-running module ignores the
- * backlog already ingested) and non-persistent (vehAccumDV_B). previousTime == 0 doubles as the
+ * (previousTime — carried across a re-initialization so a continuously-running module keeps its
+ * time reference) and non-persistent (vehAccumDV_B). previousTime == 0 doubles as the
  * "time reference not yet set" marker for the first update() after a reInitialize().
  */
 class DvAccumulationAlgorithm final {
@@ -30,11 +29,12 @@ class DvAccumulationAlgorithm final {
 
     void reInitialize();                        //!< Reset all state: accumulator and previousTime
     void reInitializeExceptPersistentStates();  //!< Reset only non-persistent state: the accumulator
-    DvAccumulationOutput update(const AccDataMsgF32Payload& accData);
+    //! Integrate one body-frame acceleration sample at callTime (ns) into the accumulated Delta-V.
+    DvAccumulationOutput update(uint64_t callTime, const Eigen::Vector3f& rDDotNoGravity_BN_B);
 
    private:
     Eigen::Vector3f vehAccumDV_B{Eigen::Vector3f::Zero()};  //!< [m/s] running Delta-V accumulator (non-persistent)
-    uint64_t previousTime{};                                //!< [ns] latest measTime ingested so far (persistent)
+    uint64_t previousTime{};                                //!< [ns] latest callTime integrated so far (persistent)
 };
 
 #endif

--- a/algorithms/dvAccumulation/dvAccumulationAlgorithm_c.cpp
+++ b/algorithms/dvAccumulation/dvAccumulationAlgorithm_c.cpp
@@ -1,10 +1,7 @@
 #include "dvAccumulationAlgorithm_c.h"
 #include "dvAccumulationAlgorithm.h"
-#include "msgPayloadDef/AccDataMsgF32Payload.h"
 #include "utilities/fsw/eigenSupport.h"
 #include "utilities/fsw/opaqueHandle.h"
-
-uint32_t DvAccumulationAlgorithm_getMaxAccBufPkt(void) { return MAX_ACC_BUF_PKT; }
 
 DvAccumulationAlgorithmHandle* DvAccumulationAlgorithm_create(void) {
     return fsw::createHandle<::DvAccumulationAlgorithm, DvAccumulationAlgorithmHandle>();
@@ -23,8 +20,10 @@ void DvAccumulationAlgorithm_reInitializeExceptPersistentStates(DvAccumulationAl
 }
 
 DvAccumulationOutput_c DvAccumulationAlgorithm_update(DvAccumulationAlgorithmHandle* self,
-                                                      const AccDataMsgF32Payload* accData) {
-    const DvAccumulationOutput out = fsw::fromHandle<::DvAccumulationAlgorithm>(self)->update(*accData);
+                                                      uint64_t callTime,
+                                                      const Vector3f_c* rDDotNoGravity_BN_B) {
+    const Eigen::Vector3f accel_B = cArrayToEigenVector3(rDDotNoGravity_BN_B->data);
+    const DvAccumulationOutput out = fsw::fromHandle<::DvAccumulationAlgorithm>(self)->update(callTime, accel_B);
 
     DvAccumulationOutput_c result{};
     result.timeTag = out.timeTag;

--- a/algorithms/dvAccumulation/dvAccumulationAlgorithm_c.h
+++ b/algorithms/dvAccumulation/dvAccumulationAlgorithm_c.h
@@ -2,7 +2,6 @@
 #define F32XMERA_DV_ACCUMULATION_ALGORITHM_C_H
 
 #include "dvAccumulationTypes.h"
-#include "msgPayloadDef/AccDataMsgF32Payload.h"
 
 #include <stdint.h>
 
@@ -12,12 +11,6 @@ extern "C" {
 
 /*! @brief Opaque handle to the C++ DvAccumulationAlgorithm instance. */
 typedef struct DvAccumulationAlgorithmHandle DvAccumulationAlgorithmHandle;
-
-/*!
- * @brief Get the MAX_ACC_BUF_PKT constant for Ada elaboration-time validation.
- * @return The number of accelerometer packet slots per input snapshot.
- */
-uint32_t DvAccumulationAlgorithm_getMaxAccBufPkt(void);
 
 /*!
  * @brief Construct a new DvAccumulationAlgorithm.
@@ -35,29 +28,30 @@ DvAccumulationAlgorithmHandle* DvAccumulationAlgorithm_create(void);
 void DvAccumulationAlgorithm_destroy(DvAccumulationAlgorithmHandle* self);
 
 /*!
- * @brief Reset all state: the accumulator plus the persistent integration bookkeeping
- *        (previousTime, dvInitialized).
+ * @brief Reset all state: the accumulator plus the persistent time reference (previousTime).
  * @param self Pointer to the instance.
  */
 void DvAccumulationAlgorithm_reInitialize(DvAccumulationAlgorithmHandle* self);
 
 /*!
- * @brief Reset only the non-persistent accumulator, keeping previousTime and dvInitialized so a
- *        continuously-running module ignores the backlog already ingested.
+ * @brief Reset only the non-persistent accumulator, keeping previousTime so a continuously-running
+ *        module keeps its time reference.
  * @param self Pointer to the instance.
  */
 void DvAccumulationAlgorithm_reInitializeExceptPersistentStates(DvAccumulationAlgorithmHandle* self);
 
 /*!
- * @brief Integrate any packets newer than the previously-seen latest measTime into the running
- *        Delta-V accumulator and return the current accumulator plus the time-tag of the most
- *        recently ingested sample.
- * @param self    Pointer to the instance.
- * @param accData Input accelerometer-packet snapshot.
+ * @brief Integrate one body-frame acceleration sample over the step since the previous call into
+ *        the running Delta-V accumulator and return the current accumulator plus the time-tag of
+ *        the most recently ingested sample.
+ * @param self                 Pointer to the instance.
+ * @param callTime             Module call time (nanoseconds).
+ * @param rDDotNoGravity_BN_B  Body-frame non-gravitational acceleration (m/s^2).
  * @return DvAccumulationOutput_c  timeTag (seconds) plus body-frame Delta-V (m/s).
  */
 DvAccumulationOutput_c DvAccumulationAlgorithm_update(DvAccumulationAlgorithmHandle* self,
-                                                      const AccDataMsgF32Payload* accData);
+                                                      uint64_t callTime,
+                                                      const Vector3f_c* rDDotNoGravity_BN_B);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/algorithms/dvAccumulation/dvAccumulationF32.i
+++ b/algorithms/dvAccumulation/dvAccumulationF32.i
@@ -8,5 +8,4 @@
 %include "dvAccumulation.h"
 
 %include "msgPayloadDef/NavTransMsgF32Payload.h"
-%include "msgPayloadDef/AccDataMsgF32Payload.h"
-%include "msgPayloadDef/AccPktDataMsgF32Payload.h"
+%include "msgPayloadDef/IMUSensorBodyMsgF32Payload.h"


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2340
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This ticket changes the input to dvAccumulation. Since averageMimu already manages the ring buffer averaging of the acceleration data and mimuMajorityVote averages the 3 imu accelerations, dvAccumulation can use the output of mimuMajorityVote as it's input. This drastically simplifies dvAccumulation and it becomes a simple integrator.

## Verification
Tests were added to test the new functionality. 

## Documentation
Documenation was updated

## Future work
dvAccumulation will get another more detailed through the V&V ticket: [](https://lasp.colorado.edu/flares/browse/MAXGNC-2207). 
