### PR TITLE
Feature/2349 timeless sunline filter

### DIFF
--- a/algorithms/filteringCore/_tests/test_kalmanFilter.cpp
+++ b/algorithms/filteringCore/_tests/test_kalmanFilter.cpp
@@ -228,4 +228,113 @@ TEST(ApplySequentialRobust, FailedTimeUpdateShortCircuitsMeasurementAndClears) {
     EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 0.0);
 }
 
+// applyTimestepRobust tests: the filter steps by dt every call and folds every queued measurement in
+// at that step. The queue's timeOfLastMeasurement is repurposed as the elapsed span since the anchor.
+
+// Empty queue: one timeUpdate(dt), no measurement folded in, so the elapsed span accumulates by dt.
+TEST(ApplyTimestepRobust, EmptyQueueTimeUpdatesAndAccumulatesSpan) {
+    CallLog log;
+    RecordingFilter filter{&log};
+    measurement_queue<double, 4> q;
+
+    applyTimestepRobust(q, filter, 2.0);
+
+    ASSERT_EQ(log.entries.size(), 1u);
+    EXPECT_EQ(log.entries[0].first, CallLog::Kind::TimeUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[0].second, 2.0);
+    EXPECT_EQ(count(log, CallLog::Kind::Clear), 0);
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 2.0);  // nothing folded in → span kept
+}
+
+// One measurement: timeUpdate(dt) then measurementUpdate (no preceding timeUpdate(0) for the first),
+// and the anchor advances so the span resets to 0.
+TEST(ApplyTimestepRobust, SingleMeasurementFoldsInAndResetsSpan) {
+    CallLog log;
+    RecordingFilter filter{&log};
+    measurement_queue<double, 4> q;
+    q.enqueue(1.0, 0.5);
+
+    applyTimestepRobust(q, filter, 2.0);
+
+    ASSERT_EQ(log.entries.size(), 2u);
+    EXPECT_EQ(log.entries[0].first, CallLog::Kind::TimeUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[0].second, 2.0);
+    EXPECT_EQ(log.entries[1].first, CallLog::Kind::MeasurementUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[1].second, 0.5);
+    EXPECT_EQ(count(log, CallLog::Kind::Clear), 0);
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 0.0);
+}
+
+// Two measurements at one step: the first folds into the propagated sigma points; each subsequent
+// one is preceded by a timeUpdate(0) re-anchor. Measurements drain earliest-first.
+TEST(ApplyTimestepRobust, MultipleMeasurementsReanchorWithZeroTimeUpdate) {
+    CallLog log;
+    RecordingFilter filter{&log};
+    measurement_queue<double, 4> q;
+    q.enqueue(2.0, 0.7);  // enqueued out of order
+    q.enqueue(1.0, 0.3);
+
+    applyTimestepRobust(q, filter, 2.0);
+
+    // Expected: timeUpdate(2), meas(0.3), timeUpdate(0), meas(0.7)
+    ASSERT_EQ(log.entries.size(), 4u);
+    EXPECT_EQ(log.entries[0].first, CallLog::Kind::TimeUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[0].second, 2.0);
+    EXPECT_EQ(log.entries[1].first, CallLog::Kind::MeasurementUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[1].second, 0.3);
+    EXPECT_EQ(log.entries[2].first, CallLog::Kind::TimeUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[2].second, 0.0);
+    EXPECT_EQ(log.entries[3].first, CallLog::Kind::MeasurementUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[3].second, 0.7);
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 0.0);
+}
+
+// A failed timeUpdate clears and carries the elapsed span forward, so successive failures retry over a
+// longer interval (dt, 2dt, 3dt, …); a later good measurement resets the span to zero.
+TEST(ApplyTimestepRobust, FailedTimeUpdatesAccumulateSpanUntilSuccess) {
+    CallLog log;
+    RecordingFilter filter{&log};
+    measurement_queue<double, 4> q;
+    filter.timeUpdatesFail = true;
+
+    applyTimestepRobust(q, filter, 2.0);
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 2.0);
+    applyTimestepRobust(q, filter, 2.0);
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 4.0);
+    applyTimestepRobust(q, filter, 2.0);
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 6.0);
+
+    // Every failed call cleared and attempted a timeUpdate over the growing span.
+    EXPECT_EQ(count(log, CallLog::Kind::Clear), 3);
+    EXPECT_DOUBLE_EQ(log.entries[0].second, 2.0);
+    EXPECT_DOUBLE_EQ(log.entries[2].second, 4.0);
+    EXPECT_DOUBLE_EQ(log.entries[4].second, 6.0);
+
+    // Recover: the next call propagates over the full accumulated span + dt and folds a measurement in.
+    filter.timeUpdatesFail = false;
+    q.enqueue(1.0, 0.5);
+    applyTimestepRobust(q, filter, 2.0);
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 0.0);  // anchor advanced → span reset
+}
+
+// A failed measurementUpdate clears and, because nothing folded in, holds the anchor and carries the
+// span forward.
+TEST(ApplyTimestepRobust, FailedMeasurementClearsAndCarriesSpan) {
+    CallLog log;
+    RecordingFilter filter{&log};
+    filter.failOnNegativeMeasurement = true;
+    measurement_queue<double, 4> q;
+    q.enqueue(1.0, -1.0);  // bad: measurementUpdate reports invalid
+
+    applyTimestepRobust(q, filter, 2.0);
+
+    // timeUpdate(2) ok, meas(-1) fails → clear; nothing folded in → span carried forward at dt.
+    ASSERT_EQ(log.entries.size(), 3u);
+    EXPECT_EQ(log.entries[0].first, CallLog::Kind::TimeUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[0].second, 2.0);
+    EXPECT_EQ(log.entries[1].first, CallLog::Kind::MeasurementUpdate);
+    EXPECT_EQ(log.entries[2].first, CallLog::Kind::Clear);
+    EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 2.0);
+}
+
 }  // namespace filtering

--- a/algorithms/filteringCore/_tests/test_kalmanFilter_fuzz.cpp
+++ b/algorithms/filteringCore/_tests/test_kalmanFilter_fuzz.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: ISC
 // Copyright (c) 2026, Laboratory for Atmospheric and Space Physics, University of Colorado at Boulder
 
-// Property-based fuzz tests for filtering::applySequential and applySequentialRobust.
+// Property-based fuzz tests for filtering::applySequential, applySequentialRobust, and
+// applyTimestepRobust.
 
 #include <filteringCore/measurementQueue.h>
 #include <filteringCore/kalmanFilter.hpp>
@@ -156,5 +157,75 @@ FUZZ_TEST(ApplySequentialFuzz, fuzzApplySequentialRobustInvariants)
                  fuzztest::InRange(-1e4, 1e4),  // v2
                  fuzztest::InRange(0.0, 1e4),   // initialAnchor
                  fuzztest::InRange(0.0, 1e4));  // extraCallTime
+
+// applyTimestepRobust under a fuzzed measurement failure pattern (sign of each value selects
+// success/failure; timeUpdate always succeeds here). Regardless of the pattern:
+//   * the first call is a single timeUpdate over the full elapsed span (initialSpan + dt),
+//   * every other timeUpdate is a zero-dt re-anchor,
+//   * clear() fires exactly once per failed measurement, immediately after it, and
+//   * the elapsed span resets to 0 iff at least one measurement folded in, else keeps initialSpan + dt.
+void fuzzApplyTimestepRobustInvariants(double t0,
+                                       double t1,
+                                       double t2,
+                                       double v0,
+                                       double v1,
+                                       double v2,
+                                       double initialSpan,
+                                       double dt) {
+    CallLog log;
+    RecordingFilter filter{&log};
+    filter.failOnNegativeMeasurement = true;
+    measurement_queue<double, 4> q;
+    q.setTimeOfLastMeasurement(initialSpan);
+    q.enqueue(t0, double{v0});
+    q.enqueue(t1, double{v1});
+    q.enqueue(t2, double{v2});
+
+    double const step = initialSpan + dt;
+    applyTimestepRobust(q, filter, dt);
+
+    ASSERT_FALSE(log.entries.empty());
+    EXPECT_EQ(log.entries[0].first, CallLog::Kind::TimeUpdate);
+    EXPECT_DOUBLE_EQ(log.entries[0].second, step) << "first timeUpdate must span the full elapsed interval";
+
+    int measApplied = 0;
+    int clears = 0;
+    int failed = 0;
+    for (std::size_t i = 0; i < log.entries.size(); ++i) {
+        auto const& [kind, value] = log.entries[i];
+        if (kind == CallLog::Kind::TimeUpdate) {
+            EXPECT_GE(value, 0.0) << "negative dt";
+            if (i > 0) EXPECT_DOUBLE_EQ(value, 0.0) << "in-loop re-anchor must be a zero time update";
+        } else if (kind == CallLog::Kind::MeasurementUpdate) {
+            if (value >= 0.0) {
+                ++measApplied;
+            } else {
+                ++failed;
+            }
+        } else {  // Clear
+            ++clears;
+            ASSERT_GT(i, 0u);
+            EXPECT_EQ(log.entries[i - 1].first, CallLog::Kind::MeasurementUpdate)
+                << "clear must follow a measurement update";
+            EXPECT_LT(log.entries[i - 1].second, 0.0) << "clear must follow a failed (value < 0) measurement";
+        }
+    }
+    EXPECT_EQ(clears, failed) << "exactly one clear per failed measurement";
+
+    if (measApplied > 0) {
+        EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), 0.0) << "a folded-in measurement resets the span";
+    } else {
+        EXPECT_DOUBLE_EQ(q.getTimeOfLastMeasurement(), step) << "with nothing folded in the span is carried forward";
+    }
+}
+FUZZ_TEST(ApplySequentialFuzz, fuzzApplyTimestepRobustInvariants)
+    .WithDomains(fuzztest::InRange(-1e4, 1e4),  // t0
+                 fuzztest::InRange(-1e4, 1e4),  // t1
+                 fuzztest::InRange(-1e4, 1e4),  // t2
+                 fuzztest::InRange(-1e4, 1e4),  // v0 (sign selects success/failure)
+                 fuzztest::InRange(-1e4, 1e4),  // v1
+                 fuzztest::InRange(-1e4, 1e4),  // v2
+                 fuzztest::InRange(0.0, 1e4),   // initialSpan
+                 fuzztest::InRange(0.0, 1e4));  // dt
 
 }  // namespace filtering

--- a/algorithms/filteringCore/filteringCore.rst
+++ b/algorithms/filteringCore/filteringCore.rst
@@ -132,14 +132,24 @@ which the parent ``algorithms/`` include path resolves.
      it to its last good state. On a failed update it calls ``clear()`` and
      leaves the anchor in place, so a bad measurement can neither corrupt the
      estimate nor advance the timeline.
+   - ``applyTimestepRobust(queue, filter, dt)`` — the robust *dt-stepping*
+     scheduler, for filters that carry no absolute time. Same method contract as
+     ``applySequentialRobust`` (bool-returning updates plus ``clear()``). Instead
+     of a call time it steps by ``dt`` and folds every queued measurement in at
+     that one step; it repurposes the queue's ``timeOfLastMeasurement`` as the
+     elapsed span since the anchor, so measurement-free or failed cycles keep
+     accumulating and ``timeUpdate`` always propagates the full interval from the
+     fixed anchor. The span resets to zero once a measurement advances the anchor.
+     The first queued measurement folds into the propagated sigma points; each
+     later one is preceded by a ``timeUpdate(0)`` re-anchor.
 
    The upshot: the concept keeps the core open — any two update methods satisfy
    it — while the chosen scheduler drives the design of those methods. Pick
-   ``applySequentialRobust`` and you are obliged to make your updates report
-   validity and to implement ``clear()``; pick ``applySequential`` and plain
-   ``void`` updates suffice. Other scheduling styles (batch, iterated, ...) drop
-   in as further ``apply_*`` free templates, each imposing its own method
-   contract, without touching the queue.
+   ``applySequentialRobust`` / ``applyTimestepRobust`` and you are obliged to make
+   your updates report validity and to implement ``clear()``; pick
+   ``applySequential`` and plain ``void`` updates suffice. Other scheduling styles
+   (batch, iterated, ...) drop in as further ``apply_*`` free templates, each
+   imposing its own method contract, without touching the queue.
 
 ``srukf.hpp``
    The square-root uKF (van der Merwe & Wan, ICASSP 2001) in two layers:
@@ -206,15 +216,18 @@ Each concept is an interface in the core; a concrete type connects to it by
 ``SRuKF`` and the retained configuration, installs the dynamics
 functor onto the estimator's ``dynamics`` member in ``reset()``, satisfies
 ``SequentialFilter`` via public ``timeUpdate`` / ``measurementUpdate``, owns
-the ``measurement_queue<Measurement, BatchSize>``, exposes the single-call
-``update(currentSeconds, CssData, RateData)`` (which enqueues whichever
-readings are present and runs
-``applySequential(measurements, *this, currentSeconds)``), and packages the
+the ``measurement_queue<Measurement, BatchSize>``, exposes a settable/gettable
+``dt`` and the single-call ``update(CssData, RateData)`` (which enqueues
+whichever readings are present and runs
+``applyTimestepRobust(measurements, *this, dt)``), and packages the
 filter's state and covariance into the plain-data ``FilterStateOutput`` /
-``CssResidualsOutput`` / ``RateResidualsOutput``. If the filter needs to keep
-the estimate physically meaningful, it post-processes after the queue drains —
-sunline's ``regularize()`` renormalizes the heading to a unit vector and clamps
-the CSS bias to its configured bounds; the SRUKF itself stays agnostic to that.
+``CssResidualsOutput`` / ``RateResidualsOutput``. Sunline carries no absolute
+time: it steps by ``dt`` every call, so the queue's ``timeOfLastMeasurement``
+acts as the elapsed span since the anchor rather than an absolute time (see
+``applyTimestepRobust`` above). If the filter needs to keep the estimate
+physically meaningful, it post-processes after the queue drains — sunline's
+``regularize()`` renormalizes the heading to a unit vector and clamps the CSS
+bias to its configured bounds; the SRUKF itself stays agnostic to that.
 
 
 Time bookkeeping: queue ↔ SRUKF
@@ -270,6 +283,13 @@ On the next call, if a new measurement arrives at t=10, the scheduler issues
 forward from its preserved t=4 anchor, not 3 s past the previously-output
 t=7 value. Because the anchor was never compromised, no drift accumulates from
 the output-only propagation.
+
+The walkthrough above is ``applySequential``, which reads absolute measurement
+times against ``callTime``. ``applyTimestepRobust`` (used by sunline) keeps the
+same anchor discipline but carries no absolute time: it steps by ``dt`` and
+stores the *elapsed span since the anchor* in ``getTimeOfLastMeasurement()``, so
+a measurement-free call propagates ``span + dt`` from the fixed anchor and the
+span keeps growing until a measurement advances the anchor and resets it to 0.
 
 Why the pattern is generic
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -330,8 +350,9 @@ P2407, ``__cpp_lib_freestanding_variant``). The filter that knows its kinds name
    void applyMeasurement(CssMeasurement const&);
    void applyMeasurement(RateMeasurement const&);
 
-Because every kind shares the one queue timeline, ``applySequential``
-interleaves them in time order. The variant is over the input structs; each
+Because every kind shares the one queue, the scheduler folds them in together —
+``applySequential`` interleaves them in time order, while ``applyTimestepRobust``
+(sunline) folds them all in at the one time step. The variant is over the input structs; each
 ``applyMeasurement`` overload builds that kind's model (the
 ``Measurement<M, State>`` object) and calls ``srukf.measurementUpdate`` — the
 same input-struct-vs-model split a single-kind filter would use. Each overload also
@@ -390,16 +411,17 @@ xmera):
 
    SunlineFilterAlgorithm algo(cfg);     // owns the SRUKF + measurement_queue; construction seeds the filter
 
-   // Queue-driven path: hand the raw readings to one drive call. update() packs
-   // whichever readings are present (timeTag > 0), enqueues them, and runs
-   // applySequential(measurements, *this, currentSeconds) under the hood, then
-   // regularizes the state and returns a single bundled snapshot.
+   // Queue-driven path: set the fixed step, then hand the raw readings to one
+   // drive call. update() packs whichever readings are present (timeTag > 0),
+   // enqueues them, and runs applyTimestepRobust(measurements, *this, dt) under
+   // the hood, then regularizes the state and returns a single bundled snapshot.
+   algo.setDt(dt);
    CssData  css;  css.timeTag  = t;  css.cosValues = cosValues;
    RateData rate; rate.timeTag = t;  rate.rate     = omegaMeas;
-   SunlineFilterOutput out = algo.update(currentSeconds, css, rate);
+   SunlineFilterOutput out = algo.update(css, rate);
 
    // Direct-stepping path: call the SequentialFilter pair yourself (this is
-   // what applySequential calls under the hood).
+   // what applyTimestepRobust calls under the hood).
    algo.timeUpdate(dt);                            // predict
    algo.measurementUpdate(RateMeasurement{...});   // fold a measurement in directly
 

--- a/algorithms/filteringCore/kalmanFilter.hpp
+++ b/algorithms/filteringCore/kalmanFilter.hpp
@@ -83,6 +83,48 @@ void applySequentialRobust(measurement_queue<Measurement, Capacity>& queue, Filt
     queue.setTimeOfLastMeasurement(timeOfLastMeasurement);
 }
 
+/*! Robust filter update with no absolute time: the filter steps by `dt` every call and every queued
+ *  measurement is folded in as if taken at the end of that time update. There is no callTime; instead the
+ *  queue's `timeOfLastMeasurement` is repurposed as the elapsed span since the anchor (the last folded-in
+ *  measurement). Each call propagates over `step = getTimeOfLastMeasurement() + dt` from the SRuKF-style
+ *  anchor, so measurement-free (or failed) cycles keep accumulating and the state marches forward
+ *  cumulatively; the accumulator resets to zero only when a measurement advances the anchor.
+ *  Because timeUpdate and measurementUpdate detect bad updates, they must both return a bool (true on a
+ *  good update). The filter must also expose a clear() so internal state can be sanitized after a bad update.
+ *  The first queued measurement folds into the propagated sigma points from timeUpdate(step); each
+ *  subsequent measurement is preceded by a timeUpdate(0) to re-anchor the sigma points about the latest
+ *  posterior before it is folded in.
+ *  @param queue    [-] measurement queue (drained on return)
+ *  @param filter   [-] filter satisfying SequentialFilter
+ *  @param dt       [s] time step of the filter update
+ */
+template <class Filter, class Measurement, std::size_t Capacity>
+    requires SequentialFilter<Filter, Measurement>
+void applyTimestepRobust(measurement_queue<Measurement, Capacity>& queue, Filter& filter, double dt) {
+    if (double const step = queue.getTimeOfLastMeasurement() + dt; !filter.timeUpdate(step)) {
+        // Propagation failed: sanitize and carry the elapsed span forward so the retry propagates the full
+        // interval next call. Do not process measurements against a bad prediction.
+        filter.clear();
+        queue.setTimeOfLastMeasurement(step);
+    } else {
+        bool measurementApplied = false;
+        for (auto entry = queue.popEarliest(); entry.has_value(); entry = queue.popEarliest()) {
+            if (measurementApplied) {
+                filter.timeUpdate(0);  // re-anchor sigma points about the latest posterior (2nd+ measurement only)
+            }
+            auto& [_, measurement] = entry.value();
+            if (!filter.measurementUpdate(measurement)) {
+                filter.clear();
+            } else {
+                measurementApplied = true;
+            }
+        }
+        // A measurement advances the stateOfLastMeasurement, otherwise keep accumulating the
+        // elapsed span so a measurement-free step still propagates cumulatively from the fixed anchor.
+        queue.setTimeOfLastMeasurement(measurementApplied ? 0.0 : step);
+    }
+}
+
 }  // namespace filtering
 
 #endif

--- a/algorithms/sunlineFilter/_tests/sunlineFilterTestHelpers.hpp
+++ b/algorithms/sunlineFilter/_tests/sunlineFilterTestHelpers.hpp
@@ -176,7 +176,7 @@ inline std::optional<SunlineFilterConfig> tryFuzzConfig(Eigen::Vector3d const& s
 }
 
 // Drives one update() with the given (possibly non-finite) CSS cos-values and rate at a shared
-// measurement time, propagating dt to the output time.
+// measurement time, stepping the filter forward by dt.
 inline void driveUpdate(SunlineFilterAlgorithm& algo,
                         Eigen::Vector<double, MaxCss> const& cssCos,
                         Eigen::Vector3d const& rate,
@@ -187,7 +187,8 @@ inline void driveUpdate(SunlineFilterAlgorithm& algo,
     RateData r;
     r.timeTag = 1.0;
     r.rate = rate;
-    algo.update(1.0 + dt, css, r);
+    algo.setDt(dt);
+    algo.update(css, r);
 }
 
 // ---------------------------------------------------------------------------

--- a/algorithms/sunlineFilter/_tests/test_sunlineFilter.cpp
+++ b/algorithms/sunlineFilter/_tests/test_sunlineFilter.cpp
@@ -289,14 +289,15 @@ TEST(SunlineFilterAlgorithmMeasurements, InformativeMeasurementReducesResidual) 
 TEST(SunlineFilterAlgorithmMeasurements, RateDataFiresResidualOnlyWhenFresh) {
     SunlineFilterAlgorithm algo(rateOnlyConfig(makeState(Eigen::Vector3d(0, 0, 1), Eigen::Vector3d::Zero(), 1.0),
                                                diagCovariance(1E-2, 1E-1, 1E-2)));
+    algo.setDt(1.0);
 
-    SunlineFilterOutput const stale = algo.update(1.0, CssData{}, RateData{});
+    SunlineFilterOutput const stale = algo.update(CssData{}, RateData{});
     EXPECT_FALSE(stale.rateResiduals.valid);
 
     RateData rate;
     rate.timeTag = 2.0;
     rate.rate = Eigen::Vector3d(0.02, -0.01, 0.015);
-    SunlineFilterOutput const fresh = algo.update(2.0, CssData{}, rate);
+    SunlineFilterOutput const fresh = algo.update(CssData{}, rate);
     EXPECT_TRUE(fresh.rateResiduals.valid);
     EXPECT_TRUE(fresh.rateResiduals.observation.isApprox(rate.rate, 1E-12));
 }
@@ -305,8 +306,9 @@ TEST(SunlineFilterAlgorithmMeasurements, RateDataFiresResidualOnlyWhenFresh) {
 TEST(SunlineFilterAlgorithmMeasurements, CssDataFiresResidualOnlyWhenFresh) {
     SunlineFilterAlgorithm algo(threeCssConfig(
         makeState(Eigen::Vector3d(0, 0, 1), Eigen::Vector3d::Zero(), 1.0), diagCovariance(1E-2, 1E-2, 1E-1), 0.0));
+    algo.setDt(1.0);
 
-    SunlineFilterOutput const stale = algo.update(1.0, CssData{}, RateData{});
+    SunlineFilterOutput const stale = algo.update(CssData{}, RateData{});
     EXPECT_FALSE(stale.cssResiduals.valid);
 
     CssData css;
@@ -314,7 +316,7 @@ TEST(SunlineFilterAlgorithmMeasurements, CssDataFiresResidualOnlyWhenFresh) {
     css.cosValues(0) = 0.5;
     css.cosValues(1) = 0.5;
     css.cosValues(2) = 0.707;
-    SunlineFilterOutput const fresh = algo.update(2.0, css, RateData{});
+    SunlineFilterOutput const fresh = algo.update(css, RateData{});
     EXPECT_TRUE(fresh.cssResiduals.valid);
     EXPECT_EQ(fresh.cssResiduals.numberOfActiveCss, 3);
 }
@@ -335,12 +337,14 @@ TEST(SunlineFilterAlgorithmMeasurements, LargerMeasurementNoiseStdShrinksCovaria
     ConfigInputs sharpIn = base;
     sharpIn.gyroStd = 1E-3;
     SunlineFilterAlgorithm sharp(buildConfig(sharpIn));
-    sharp.update(1.0, CssData{}, rate);
+    sharp.setDt(1.0);
+    sharp.update(CssData{}, rate);
 
     ConfigInputs looseIn = base;
     looseIn.gyroStd = 1E-1;
     SunlineFilterAlgorithm loose(buildConfig(looseIn));
-    loose.update(1.0, CssData{}, rate);
+    loose.setDt(1.0);
+    loose.update(CssData{}, rate);
 
     EXPECT_LT(rateBlockTrace(sharp.getCovariance()), rateBlockTrace(loose.getCovariance()));
     EXPECT_LT(rateBlockTrace(loose.getCovariance()), rateBlockTrace(base.initialCovariance));
@@ -353,6 +357,7 @@ TEST(SunlineFilterAlgorithmUpdate, UpdateWithRateAndCssExposesBothResiduals) {
     Eigen::Vector3d const sHat0 = Eigen::Vector3d(0.0, 0.0, 1.0);
     SunlineFilterAlgorithm algo(
         threeCssConfig(makeState(sHat0, Eigen::Vector3d(0.01, 0.0, 0.0), 1.0), diagCovariance(1E-2, 1E-2, 1E-1), 0.0));
+    algo.setDt(1.0);
 
     CssData css;
     css.timeTag = 1.0;
@@ -364,7 +369,7 @@ TEST(SunlineFilterAlgorithmUpdate, UpdateWithRateAndCssExposesBothResiduals) {
     rate.timeTag = 1.0;
     rate.rate = Eigen::Vector3d(0.01, 0.0, 0.0);
 
-    SunlineFilterOutput const out = algo.update(2.0, css, rate);
+    SunlineFilterOutput const out = algo.update(css, rate);
 
     EXPECT_EQ(out.cssResiduals.numberOfActiveCss, 3);
 }
@@ -375,6 +380,7 @@ TEST(SunlineFilterAlgorithmUpdate, UpdateWithRateAndCssExposesBothResiduals) {
 TEST(SunlineFilterAlgorithmUpdate, CssBelowThresholdNotProcessed) {
     SunlineFilterAlgorithm algo(threeCssConfig(
         makeState(Eigen::Vector3d(0, 0, 1), Eigen::Vector3d(0.01, 0, 0), 1.0), diagCovariance(1E-2, 1E-2, 1E-1), 0.5));
+    algo.setDt(1.0);
 
     CssData css;
     css.timeTag = 1.0;
@@ -386,17 +392,18 @@ TEST(SunlineFilterAlgorithmUpdate, CssBelowThresholdNotProcessed) {
     rate.timeTag = 1.0;
     rate.rate = Eigen::Vector3d(0.01, 0.0, 0.0);
 
-    SunlineFilterOutput const out = algo.update(2.0, css, rate);
+    SunlineFilterOutput const out = algo.update(css, rate);
 
     EXPECT_EQ(out.cssResiduals.numberOfActiveCss, 0);
 }
 
-// Through the queue-driven update(), a bad CSS reading is rejected by applySequentialRobust
+// Through the queue-driven update(), a bad CSS reading is rejected by applyTimestepRobust
 // (which calls clear()) and the filter recovers: the residual is invalid, the state stays finite,
 // and a normal update right after is processed cleanly.
 TEST(SunlineFilterAlgorithmUpdate, BadMeasurementIsRejectedAndFilterRecovers) {
     SunlineFilterAlgorithm algo(threeCssConfig(
         makeState(Eigen::Vector3d(0, 0, 1), Eigen::Vector3d(0.01, 0, 0), 1.0), diagCovariance(1E-1, 1E-2, 1E-1), 0.0));
+    algo.setDt(1.0);
 
     // A good update first, to establish a finite anchor.
     CssData good;
@@ -404,7 +411,7 @@ TEST(SunlineFilterAlgorithmUpdate, BadMeasurementIsRejectedAndFilterRecovers) {
     good.cosValues(0) = 0.5;
     good.cosValues(1) = 0.5;
     good.cosValues(2) = 0.707;
-    algo.update(1.0, good, RateData{});
+    algo.update(good, RateData{});
 
     // A NaN CSS reading must not corrupt the filter.
     CssData bad;
@@ -412,7 +419,7 @@ TEST(SunlineFilterAlgorithmUpdate, BadMeasurementIsRejectedAndFilterRecovers) {
     bad.cosValues(0) = std::numeric_limits<double>::quiet_NaN();
     bad.cosValues(1) = 0.5;
     bad.cosValues(2) = 0.707;
-    SunlineFilterOutput const out = algo.update(2.0, bad, RateData{});
+    SunlineFilterOutput const out = algo.update(bad, RateData{});
 
     EXPECT_FALSE(out.cssResiduals.valid) << "bad measurement must not produce a valid residual";
     EXPECT_TRUE(algo.getState().raw().allFinite()) << "filter state must stay finite after a bad update";
@@ -425,30 +432,31 @@ TEST(SunlineFilterAlgorithmUpdate, BadMeasurementIsRejectedAndFilterRecovers) {
     recover.cosValues(0) = 0.5;
     recover.cosValues(1) = 0.5;
     recover.cosValues(2) = 0.707;
-    SunlineFilterOutput const recovered = algo.update(3.0, recover, RateData{});
+    SunlineFilterOutput const recovered = algo.update(recover, RateData{});
 
     EXPECT_TRUE(recovered.cssResiduals.valid) << "the post-recovery measurement must be applied";
     EXPECT_TRUE(recovered.cssResiduals.postFit.allFinite()) << "residuals must be finite after recovery";
     EXPECT_TRUE(algo.getState().raw().allFinite()) << "state must be finite after recovery";
 }
 
-// Each update() with empty measurements re-propagates from the unchanged anchor to
-// currentSeconds, so with process noise the covariance trace grows with currentSeconds.
+// Each measurement-free update() accumulates the elapsed span and re-propagates from the unchanged
+// anchor over a growing interval, so with process noise the covariance trace grows every call.
 TEST(SunlineFilterAlgorithmUpdate, WithoutMeasurementsGrowsCovarianceMonotonically) {
     Matrix7 const P0 = diagCovariance(1E-2, 1E-3, 1E-2);
     SunlineFilterAlgorithm algo(rateOnlyConfigWithProcessNoise(
         makeState(Eigen::Vector3d(0, 0, 1), Eigen::Vector3d::Zero(), 1.0), P0, Matrix7::Identity() * 1E-3));
+    algo.setDt(1.0);
 
-    algo.update(1.0, CssData{}, RateData{});
+    algo.update(CssData{}, RateData{});
     double const trace1 = algo.getCovariance().trace();
-    algo.update(4.0, CssData{}, RateData{});
-    double const trace4 = algo.getCovariance().trace();
-    algo.update(9.0, CssData{}, RateData{});
-    double const trace9 = algo.getCovariance().trace();
+    algo.update(CssData{}, RateData{});
+    double const trace2 = algo.getCovariance().trace();
+    algo.update(CssData{}, RateData{});
+    double const trace3 = algo.getCovariance().trace();
 
     EXPECT_GT(trace1, P0.trace());
-    EXPECT_GT(trace4, trace1);
-    EXPECT_GT(trace9, trace4);
+    EXPECT_GT(trace2, trace1);
+    EXPECT_GT(trace3, trace2);
 }
 
 TEST(SunlineFilterAlgorithmReInit, ReInitializePreservesEstimateReInitializeAllResetsIt) {
@@ -466,7 +474,8 @@ TEST(SunlineFilterAlgorithmReInit, ReInitializePreservesEstimateReInitializeAllR
     RateData rate;
     rate.timeTag = 1.0;
     rate.rate = Eigen::Vector3d(0.01, 0.0, 0.0);
-    algo.update(2.0, css, rate);
+    algo.setDt(1.0);
+    algo.update(css, rate);
 
     State const movedState = algo.getState();
     Matrix7 const movedCovariance = algo.getCovariance();
@@ -530,11 +539,12 @@ TEST(SunlineFilterAlgorithmRegression, ConvergesToConstantSunDirection) {
     }
     RateData const noRate;  // timeTag 0 -> not enqueued; pure CSS updates
 
+    algo.setDt(1.0);
     double t = 0.0;
     for (int step = 0; step < 40; ++step) {
         t += 1.0;
         css.timeTag = t;
-        algo.update(t, css, noRate);
+        algo.update(css, noRate);
     }
 
     Eigen::Vector3d const sEst = algo.getState().get<filtering::Position<3>>();

--- a/algorithms/sunlineFilter/_tests/test_sunlineFilter.py
+++ b/algorithms/sunlineFilter/_tests/test_sunlineFilter.py
@@ -55,6 +55,7 @@ def mrp_integration(t, x):
 
 
 def setup_filter_data(filter_object):
+    filter_object.dt = 1.0  # fixed filter time step, matches the 1 s task rate
     filter_object.alpha = 0.02
     filter_object.beta = 2.0
 
@@ -157,9 +158,14 @@ def state_propagation_flyby(show_plots=False):
 
     sim_time = 50
     time = np.linspace(0, sim_time, sim_time+1)
-    expected = np.zeros([len(time), 8])
-    expected[0, 1:] = initState
-    expected = rk4(sunline_dynamics, time, expected[0, 1:], normalizeState=True)
+    # The filter carries no absolute time and steps by dt on every call, so the sample logged at
+    # call i reflects the state one dt ahead. Build the truth one step longer and drop t=0 so that
+    # expected[i] is the state at t=(i+1)*dt, matching what the filter outputs at sample i.
+    truth_time = np.linspace(0, sim_time + 1, sim_time + 2)
+    truth = np.zeros([len(truth_time), 8])
+    truth[0, 1:] = initState
+    truth = rk4(sunline_dynamics, truth_time, truth[0, 1:], normalizeState=True)
+    expected = truth[1:]
 
     unit_test_sim.InitializeSimulation()
     unit_test_sim.ConfigureStopTime(macros.sec2nano(sim_time))

--- a/algorithms/sunlineFilter/sunlineFilter.cpp
+++ b/algorithms/sunlineFilter/sunlineFilter.cpp
@@ -42,6 +42,9 @@ void SunlineFilter::reset(uint64_t currentSimNanos) {
     if (!this->cssConfigInMsg.isLinked()) {
         throw std::invalid_argument("sunlineFilter.cssConfigInMsg wasn't connected.");
     }
+    if (this->dt <= 0.0) {
+        throw std::invalid_argument("sunlineFilter.dt must be set to a positive time step.");
+    }
 
     auto const cssConfig = this->cssConfigInMsg();
     uint32_t const numCss = cssConfig.nCSS;
@@ -70,6 +73,7 @@ void SunlineFilter::reset(uint64_t currentSimNanos) {
                                                     this->cssMeasurementNoiseStd,
                                                     this->gyroMeasurementNoiseStd);
     this->algorithm = std::make_unique<SunlineFilterAlgorithm>(config);
+    this->algorithm->setDt(this->dt);
     this->lastNavAttTimeTag = 0;
     this->lastCssTimeTag = 0;
 }
@@ -92,6 +96,20 @@ void SunlineFilter::reInitialize() {
     }
     this->algorithm->reInitialize();
 }
+
+/*! Pass-through to the algorithm's filter time step. The value is retained on the adapter so it can be set
+ *  before reset() (it seeds the algorithm when constructed) and forwarded live once the algorithm exists.
+ *  @return void
+ *  @param newDt [s] filter time step */
+void SunlineFilter::setDt(double newDt) {
+    this->dt = newDt;
+    if (this->algorithm) {
+        this->algorithm->setDt(newDt);
+    }
+}
+
+/*! @return the filter time step, from the live algorithm once constructed, otherwise the pending value */
+double SunlineFilter::getDt() const { return this->algorithm ? this->algorithm->getDt() : this->dt; }
 
 /*! Read NavAtt and CSS messages, call algorithm update, and
  *  write the output state and residuals.

--- a/algorithms/sunlineFilter/sunlineFilter.cpp
+++ b/algorithms/sunlineFilter/sunlineFilter.cpp
@@ -120,8 +120,6 @@ void SunlineFilter::updateState(uint64_t currentSimNanos) {
         throw XmeraLifecycleException("SunlineFilter reset() has not been called.");
     }
 
-    double const currentSeconds = static_cast<double>(currentSimNanos) * NANO2SEC;
-
     RateData rateData{};
     CssData cssData{};
 
@@ -141,7 +139,7 @@ void SunlineFilter::updateState(uint64_t currentSimNanos) {
         this->lastCssTimeTag = timeTag;
     }
 
-    SunlineFilterOutput const filterOutput = this->algorithm->update(currentSeconds, cssData, rateData);
+    SunlineFilterOutput const filterOutput = this->algorithm->update(cssData, rateData);
     this->writeOutputMessages(currentSimNanos, filterOutput);
 }
 

--- a/algorithms/sunlineFilter/sunlineFilter.h
+++ b/algorithms/sunlineFilter/sunlineFilter.h
@@ -29,8 +29,12 @@ class SunlineFilter : public SysModel {
     void reInitializeExceptPersistentStates();
     void reInitialize();
 
+    void setDt(double newDt);
+    double getDt() const;
+
     // Phase 1: public config properties -- set before reset(). The matrix/vector
     // properties are sized to their defaults (zero / identity) in the constructor.
+    double dt = 0.2;                       //!< [s] fixed filter time step applied every update (task period)
     double alpha = 0.0;                    //!< [-] sigma-point spread tunable
     double beta = 0.0;                     //!< [-] prior-knowledge tunable
     Eigen::MatrixXd processNoise;          //!< [-] N x N process noise Q (defaults to zero)

--- a/algorithms/sunlineFilter/sunlineFilter.rst
+++ b/algorithms/sunlineFilter/sunlineFilter.rst
@@ -128,6 +128,9 @@ Configuration parameters
     * - Property
       - Description
       - Valid range
+    * - dt
+      - fixed filter time step applied on every update (typically the task period)
+      - > 0
     * - alpha
       - sigma-point spread tunable
       - any

--- a/algorithms/sunlineFilter/sunlineFilterAlgorithm.cpp
+++ b/algorithms/sunlineFilter/sunlineFilterAlgorithm.cpp
@@ -104,6 +104,12 @@ void SunlineFilterAlgorithm::reInitialize() {
 
 /*! Main entrypoint. Enqueues whichever measurements are present, empties
  *  the queue through the SRuKF, then sanitizes the state.
+/*! Set the fixed time step applied on every update() call.
+ *  @param newDt [s] filter time step */
+void SunlineFilterAlgorithm::setDt(double newDt) { this->dt = newDt; }
+
+/*! @return the fixed time step applied on every update() call */
+double SunlineFilterAlgorithm::getDt() const { return this->dt; }
  *  @return Snapshot of post-update filter state and residuals.
  *  @param currentSeconds [s] simulation time the filter is advancing to
  *  @param cssData        [-] CSS array reading + time tag

--- a/algorithms/sunlineFilter/sunlineFilterAlgorithm.cpp
+++ b/algorithms/sunlineFilter/sunlineFilterAlgorithm.cpp
@@ -102,21 +102,20 @@ void SunlineFilterAlgorithm::reInitialize() {
     this->srukf.reset();
 }
 
-/*! Main entrypoint. Enqueues whichever measurements are present, empties
- *  the queue through the SRuKF, then sanitizes the state.
 /*! Set the fixed time step applied on every update() call.
  *  @param newDt [s] filter time step */
 void SunlineFilterAlgorithm::setDt(double newDt) { this->dt = newDt; }
 
 /*! @return the fixed time step applied on every update() call */
 double SunlineFilterAlgorithm::getDt() const { return this->dt; }
+
+/*! Main entrypoint. Enqueues whichever measurements are present, steps the filter forward by the
+ *  configured dt through the SRuKF folding every queued measurement in at that step, then sanitizes
+ *  the state. No absolute time enters the filter.
  *  @return Snapshot of post-update filter state and residuals.
- *  @param currentSeconds [s] simulation time the filter is advancing to
- *  @param cssData        [-] CSS array reading + time tag
- *  @param rateData       [-] gyro reading + time tag */
-SunlineFilterOutput SunlineFilterAlgorithm::update(double currentSeconds,
-                                                   CssData const& cssData,
-                                                   RateData const& rateData) {
+ *  @param cssData  [-] CSS array reading + time tag
+ *  @param rateData [-] gyro reading + time tag */
+SunlineFilterOutput SunlineFilterAlgorithm::update(CssData const& cssData, RateData const& rateData) {
     this->lastCssResiduals.valid = false;
     this->lastRateResiduals.valid = false;
 
@@ -126,7 +125,7 @@ SunlineFilterOutput SunlineFilterAlgorithm::update(double currentSeconds,
     if (rateData.timeTag > 0) {
         this->measurements.enqueue(rateData.timeTag, this->packRateMeasurement(rateData));
     }
-    applySequentialRobust(this->measurements, *this, currentSeconds);
+    applyTimestepRobust(this->measurements, *this, this->dt);
     this->srukf.setState(this->regularize(this->srukf.getState()));
     this->srukf.setStateLastMeasurement(this->regularize(this->srukf.getStateAtLastMeasurement()));
 
@@ -157,7 +156,7 @@ void SunlineFilterAlgorithm::clear() {
 }
 
 /*! Apply a CSS measurement and record its residuals. The SRuKF returns the residuals only on a
- *  good update; an unsuccessful update yields no value and returns false to applySequential.
+ *  good update; an unsuccessful update yields no value and returns false to applyTimestepRobust.
  *  @return true iff the update was applied (state/covariance finite)
  *  @param measurement [-] packed CSS measurement (cosValues, H, noise) */
 bool SunlineFilterAlgorithm::applyMeasurement(CssMeasurement const& measurement) {

--- a/algorithms/sunlineFilter/sunlineFilterAlgorithm.h
+++ b/algorithms/sunlineFilter/sunlineFilterAlgorithm.h
@@ -222,9 +222,10 @@ class SunlineFilterAlgorithm {
 
     void setConfig(SunlineFilterConfig const& config);
 
-    SunlineFilterOutput update(double currentSeconds, CssData const& cssData, RateData const& rateData);
     void setDt(double newDt);
     double getDt() const;
+
+    SunlineFilterOutput update(CssData const& cssData, RateData const& rateData);
 
     void reInitializeExceptPersistentStates();
     void reInitialize();

--- a/algorithms/sunlineFilter/sunlineFilterAlgorithm.h
+++ b/algorithms/sunlineFilter/sunlineFilterAlgorithm.h
@@ -223,6 +223,8 @@ class SunlineFilterAlgorithm {
     void setConfig(SunlineFilterConfig const& config);
 
     SunlineFilterOutput update(double currentSeconds, CssData const& cssData, RateData const& rateData);
+    void setDt(double newDt);
+    double getDt() const;
 
     void reInitializeExceptPersistentStates();
     void reInitialize();
@@ -246,6 +248,7 @@ class SunlineFilterAlgorithm {
     State regularize(State const& state) const;
 
     SunlineFilterConfig cfg;  //!< validated configuration, supplied at construction / setConfig()
+    double dt = 0.2;          //!< [s] fixed time step applied on every update() call
     SRuKF<State, SunlineDynamics> srukf;
     filtering::measurement_queue<Measurement, BatchSize> measurements;
 

--- a/algorithms/sunlineFilter/sunlineFilterAlgorithm_c.cpp
+++ b/algorithms/sunlineFilter/sunlineFilterAlgorithm_c.cpp
@@ -120,8 +120,15 @@ void SunlineFilterAlgorithm_setConfig(SunlineFilterAlgorithmHandle* self, const 
     fsw::fromHandle<::SunlineFilterAlgorithm>(self)->setConfig(configFromC(*config));
 }
 
+void SunlineFilterAlgorithm_setDt(SunlineFilterAlgorithmHandle* self, const double dt) {
+    fsw::fromHandle<::SunlineFilterAlgorithm>(self)->setDt(dt);
+}
+
+double SunlineFilterAlgorithm_getDt(const SunlineFilterAlgorithmHandle* self) {
+    return fsw::fromHandle<const ::SunlineFilterAlgorithm>(self)->getDt();
+}
+
 SunlineFilterOutput_c SunlineFilterAlgorithm_update(SunlineFilterAlgorithmHandle* self,
-                                                    const double currentSeconds,
                                                     const SunlineCssData_c* cssData,
                                                     const SunlineRateData_c* rateData) {
     CssData cssDataCpp{};
@@ -134,8 +141,7 @@ SunlineFilterOutput_c SunlineFilterAlgorithm_update(SunlineFilterAlgorithmHandle
     rateDataCpp.timeTag = rateData->timeTag;
     rateDataCpp.rate << rateData->rate[0], rateData->rate[1], rateData->rate[2];
 
-    const SunlineFilterOutput out =
-        fsw::fromHandle<::SunlineFilterAlgorithm>(self)->update(currentSeconds, cssDataCpp, rateDataCpp);
+    const SunlineFilterOutput out = fsw::fromHandle<::SunlineFilterAlgorithm>(self)->update(cssDataCpp, rateDataCpp);
     return outputToC(out);
 }
 

--- a/algorithms/sunlineFilter/sunlineFilterAlgorithm_c.h
+++ b/algorithms/sunlineFilter/sunlineFilterAlgorithm_c.h
@@ -52,20 +52,33 @@ void SunlineFilterAlgorithm_destroy(SunlineFilterAlgorithmHandle* self);
 void SunlineFilterAlgorithm_setConfig(SunlineFilterAlgorithmHandle* self, const SunlineFilterConfig_c* config);
 
 /**
- * @brief Advance the filter to currentSeconds using the supplied measurements.
+ * @brief Set the fixed time step applied on every update() call.
+ * @param self Pointer to the instance.
+ * @param dt   [s] filter time step.
+ */
+void SunlineFilterAlgorithm_setDt(SunlineFilterAlgorithmHandle* self, double dt);
+
+/**
+ * @brief Get the fixed time step applied on every update() call.
+ * @param self Pointer to the instance.
+ * @return [s] the filter time step.
+ */
+double SunlineFilterAlgorithm_getDt(const SunlineFilterAlgorithmHandle* self);
+
+/**
+ * @brief Step the filter forward by its configured dt using the supplied measurements.
  *
- * A measurement whose timeTag does not advance beyond the last consumed reading
- * is ignored by the filter; the caller signals "no new reading" by leaving the
- * corresponding struct's timeTag unchanged.
+ * The filter tracks no absolute time; it advances by the dt set via SunlineFilterAlgorithm_setDt and
+ * folds every supplied measurement in at that step. A measurement whose timeTag does not advance beyond
+ * the last consumed reading is ignored; the caller signals "no new reading" by leaving the corresponding
+ * struct's timeTag unchanged (<= 0).
  *
  * @param self           Pointer to the instance.
- * @param currentSeconds [s] time the filter is advancing to.
  * @param cssData        Pointer to the CSS array reading.
  * @param rateData       Pointer to the gyro rate reading.
  * @return SunlineFilterOutput_c  Post-update filter state and per-kind residuals.
  */
 SunlineFilterOutput_c SunlineFilterAlgorithm_update(SunlineFilterAlgorithmHandle* self,
-                                                    double currentSeconds,
                                                     const SunlineCssData_c* cssData,
                                                     const SunlineRateData_c* rateData);
 


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2349
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
Make the sunline filter not use time.
First add a new way to apply measurement.
Add setters an getters for the dt
Then we can remove time from the algorithm. 

## Verification
The tests and the algorithms don't need to change too much, but they were updated. 

## Documentation
Documentation was updated

## Future work
None
