### PR TITLE
2201 thrusterPlatformReference V&V

### DIFF
--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
@@ -52,7 +52,7 @@ TEST(ThrusterPlatformReferenceTest, RegressionArbitraryGeometry) {
 
 TEST(ThrusterPlatformReferenceTest, SetupTest) {
     const Eigen::Vector3f zero = Eigen::Vector3f::Zero();
-    const ThrusterPlatformReferenceRwArrayConfig noRw{};
+    const ThrusterPlatformReferenceRwArrayConfiguration noRw{};
     constexpr float nan = std::numeric_limits<float>::quiet_NaN();
     constexpr float inf = std::numeric_limits<float>::infinity();
 
@@ -75,13 +75,13 @@ TEST(ThrusterPlatformReferenceTest, SetupTest) {
                  fsw::invalid_argument);
 
     // Too many reaction wheels is rejected.
-    ThrusterPlatformReferenceRwArrayConfig tooManyRw{};
+    ThrusterPlatformReferenceRwArrayConfiguration tooManyRw{};
     tooManyRw.numRW = static_cast<uint32_t>(kMaxNumRw) + 1U;
     EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, true, tooManyRw),
                  fsw::invalid_argument);
 
     // A non-unit reaction-wheel spin axis is rejected.
-    ThrusterPlatformReferenceRwArrayConfig nonUnitRw{};
+    ThrusterPlatformReferenceRwArrayConfiguration nonUnitRw{};
     nonUnitRw.numRW = 1U;
     nonUnitRw.GsMatrix_B.col(0) = Eigen::Vector3f(2.0F, 0.0F, 0.0F);
     EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, true, nonUnitRw),
@@ -91,7 +91,7 @@ TEST(ThrusterPlatformReferenceTest, SetupTest) {
 // A reaction-wheel spin axis within tolerance of unit length is normalized exactly on construction.
 TEST(ThrusterPlatformReferenceTest, RwSpinAxisNormalized) {
     const Eigen::Vector3f zero = Eigen::Vector3f::Zero();
-    ThrusterPlatformReferenceRwArrayConfig rw{};
+    ThrusterPlatformReferenceRwArrayConfiguration rw{};
     rw.numRW = 1U;
     rw.GsMatrix_B.col(0) = Eigen::Vector3f(1.0005F, 0.0F, 0.0F);
     rw.JsList(0) = 0.01F;
@@ -106,7 +106,7 @@ TEST(ThrusterPlatformReferenceTest, ConfigRoundTrip) {
     const Eigen::Vector3f r_BM_M(0.0F, 0.1F, 1.4F);
     const Eigen::Vector3f r_FM_F(0.0F, 0.0F, -0.1F);
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        sigma_MB, r_BM_M, r_FM_F, 5.0F, 0.5F, 0.2F, 0.3F, false, ThrusterPlatformReferenceRwArrayConfig{});
+        sigma_MB, r_BM_M, r_FM_F, 5.0F, 0.5F, 0.2F, 0.3F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     EXPECT_TRUE(cfg.getSigma_MB().isApprox(sigma_MB));
     EXPECT_TRUE(cfg.getR_BM_M().isApprox(r_BM_M));
     EXPECT_TRUE(cfg.getR_FM_F().isApprox(r_FM_F));
@@ -130,10 +130,10 @@ TEST(ThrusterPlatformReferenceTest, PropertyOutputsFinite) {
 
     EXPECT_TRUE(std::isfinite(out.theta1));
     EXPECT_TRUE(std::isfinite(out.theta2));
-    EXPECT_TRUE(out.torqueRequestBody.allFinite());
-    EXPECT_TRUE(out.rThrust_B.allFinite());
-    EXPECT_TRUE(out.tHatThrust_B.allFinite());
-    EXPECT_TRUE(std::isfinite(out.maxThrust));
+    EXPECT_TRUE(out.Lreq_B.allFinite());
+    EXPECT_TRUE(out.r_TB_B.allFinite());
+    EXPECT_TRUE(out.tHat_B.allFinite());
+    EXPECT_TRUE(std::isfinite(out.thrust));
 }
 
 // The reported thrust headings are unit vectors and the reported thrust magnitude matches the input.
@@ -143,8 +143,8 @@ TEST(ThrusterPlatformReferenceTest, PropertyHeadingsAreUnitAndThrustPreserved) {
     const ThrusterPlatformReferenceOutput out =
         alg.update(makeInputs({0.1F, 0.2F, -0.1F}, {-0.01F, 0.03F, 0.02F}, {2.0F, -1.0F, 8.0F}, 7.5F), 0);
 
-    EXPECT_NEAR(out.tHatThrust_B.norm(), 1.0F, 1e-5F);
-    EXPECT_NEAR(out.maxThrust, 7.5F, 1e-5F);
+    EXPECT_NEAR(out.tHat_B.norm(), 1.0F, 1e-5F);
+    EXPECT_NEAR(out.thrust, 7.5F, 1e-5F);
 }
 
 // When angle bounds are set, the reported tip/tilt angles stay within them.
@@ -161,7 +161,7 @@ TEST(ThrusterPlatformReferenceTest, PropertyAngleBoundsRespected) {
 
 // The momentum-dumping path (K > 0 with a valid RW configuration) produces finite outputs.
 TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
-    ThrusterPlatformReferenceRwArrayConfig rw{};
+    ThrusterPlatformReferenceRwArrayConfiguration rw{};
     rw.numRW = 3U;
     rw.GsMatrix_B.col(0) = Eigen::Vector3f(1.0F, 0.0F, 0.0F);
     rw.GsMatrix_B.col(1) = Eigen::Vector3f(0.0F, 1.0F, 0.0F);
@@ -185,7 +185,7 @@ TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
 
     EXPECT_TRUE(std::isfinite(out.theta1));
     EXPECT_TRUE(std::isfinite(out.theta2));
-    EXPECT_TRUE(out.torqueRequestBody.allFinite());
+    EXPECT_TRUE(out.Lreq_B.allFinite());
 }
 
 // ---------------------------------------------------------------------------

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
@@ -130,7 +130,6 @@ TEST(ThrusterPlatformReferenceTest, PropertyOutputsFinite) {
 
     EXPECT_TRUE(std::isfinite(out.theta1));
     EXPECT_TRUE(std::isfinite(out.theta2));
-    EXPECT_TRUE(out.rHat_XB_B.allFinite());
     EXPECT_TRUE(out.torqueRequestBody.allFinite());
     EXPECT_TRUE(out.rThrust_B.allFinite());
     EXPECT_TRUE(out.tHatThrust_B.allFinite());
@@ -144,7 +143,6 @@ TEST(ThrusterPlatformReferenceTest, PropertyHeadingsAreUnitAndThrustPreserved) {
     const ThrusterPlatformReferenceOutput out =
         alg.update(makeInputs({0.1F, 0.2F, -0.1F}, {-0.01F, 0.03F, 0.02F}, {2.0F, -1.0F, 8.0F}, 7.5F), 0);
 
-    EXPECT_NEAR(out.rHat_XB_B.norm(), 1.0F, 1e-5F);
     EXPECT_NEAR(out.tHatThrust_B.norm(), 1.0F, 1e-5F);
     EXPECT_NEAR(out.maxThrust, 7.5F, 1e-5F);
 }

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
@@ -117,6 +117,38 @@ TEST(ThrusterPlatformReferenceTest, ConfigRoundTrip) {
     EXPECT_FALSE(cfg.getMomentumDumping());
 }
 
+// create() bounds sigma_MB to the principal MRP set: a value with norm > 1 is stored as its
+// shadow-set representative (-sigma / |sigma|^2), which has norm <= 1.
+TEST(ThrusterPlatformReferenceTest, SigmaMbSwitchedToShadowSetWhenNormExceedsOne) {
+    const Eigen::Vector3f zero = Eigen::Vector3f::Zero();
+    const Eigen::Vector3f largeSigma{0.8F, 0.6F, 0.6F};  // |sigma|^2 = 1.36 > 1
+    ASSERT_GT(largeSigma.norm(), 1.0F) << "Test setup: sigma_MB must exceed the norm-1 boundary";
+
+    const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
+        largeSigma, zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+    const Eigen::Vector3f stored = cfg.getSigma_MB();
+
+    EXPECT_LE(stored.norm(), 1.0F);
+    const Eigen::Vector3f expectedShadow = -largeSigma / largeSigma.squaredNorm();
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FLOAT_EQ(stored(i), expectedShadow(i));
+    }
+}
+
+// A sigma_MB already within the principal set (norm <= 1) is stored unchanged.
+TEST(ThrusterPlatformReferenceTest, SigmaMbWithinBoundStoredUnchanged) {
+    const Eigen::Vector3f zero = Eigen::Vector3f::Zero();
+    const Eigen::Vector3f sigma{0.3F, -0.4F, 0.2F};  // norm < 1
+    ASSERT_LE(sigma.norm(), 1.0F);
+
+    const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
+        sigma, zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+    const Eigen::Vector3f stored = cfg.getSigma_MB();
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FLOAT_EQ(stored(i), sigma(i));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Property tests
 // ---------------------------------------------------------------------------

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
@@ -211,6 +211,40 @@ TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
     EXPECT_TRUE(std::isfinite(out.thrust));
 }
 
+// The momentum-dumping path points the thruster so it produces the desired thruster torque -(K*hs + Ki*hsInt); the
+// reported reaction-wheel torque (out.Lreq_B) is its opposite, K*hs (Ki = 0 here), projected onto the component
+// achievable by the thrust.
+TEST(ThrusterPlatformReferenceTest, MomentumDumpingAchievesRequestedTorque) {
+    const Eigen::Vector3f zero = Eigen::Vector3f::Zero();  // sigma_MB == 0 -> M == B
+    constexpr float K = 1.0F;
+    ThrusterPlatformReferenceRwArrayConfiguration rw{};
+    rw.numRW = 3U;
+    rw.GsMatrix_B.col(0) = Eigen::Vector3f(1.0F, 0.0F, 0.0F);
+    rw.GsMatrix_B.col(1) = Eigen::Vector3f(0.0F, 1.0F, 0.0F);
+    rw.GsMatrix_B.col(2) = Eigen::Vector3f(0.0F, 0.0F, 1.0F);
+    rw.JsList(0) = 0.01F;
+    rw.JsList(1) = 0.01F;
+    rw.JsList(2) = 0.01F;
+    // Ki = 0 so the reported reaction-wheel torque is exactly K * hs (the thruster produces its opposite).
+    ThrusterPlatformReferenceAlgorithm alg{ThrusterPlatformReferenceConfig::create(
+        zero, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, K, 0.0F, 1.0F, 3.0F, true, rw)};
+
+    ThrusterPlatformReferenceInputs in =
+        makeInputs({0.05F, 0.02F, 0.1F}, {-0.01F, 0.03F, 0.02F}, {1.0F, 1.0F, 10.0F}, 10.0F);
+    in.wheelSpeeds(0) = 10.0F;
+    in.wheelSpeeds(1) = 10.0F;
+    in.wheelSpeeds(2) = 10.0F;
+    const ThrusterPlatformReferenceOutput out = alg.update(in);
+
+    // expected reported reaction-wheel torque about the CM (M == B); only the component perpendicular to the thrust
+    // is achievable
+    const Eigen::Vector3f hs_M(0.01F * 10.0F, 0.01F * 10.0F, 0.01F * 10.0F);
+    const Eigen::Vector3f Lreq_M = K * hs_M;
+    const Eigen::Vector3f tHat_M = out.tHat_B;  // sigma_MB == 0
+    const Eigen::Vector3f LreqPerp_M = Lreq_M - (tHat_M * tHat_M.dot(Lreq_M));
+    EXPECT_LT((out.Lreq_B - LreqPerp_M).norm(), 1e-3F);
+}
+
 // A geometry that would require a large deflection is clamped so the thrust direction stays on the cone: the angle
 // between the reported thrust heading and its neutral direction equals thetaMax.
 TEST(ThrusterPlatformReferenceTest, ThrustDeflectionClampedToCone) {

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
@@ -236,13 +236,13 @@ TEST(ThrusterPlatformReferenceTest, MomentumDumpingAchievesRequestedTorque) {
     in.wheelSpeeds(2) = 10.0F;
     const ThrusterPlatformReferenceOutput out = alg.update(in);
 
-    // expected reported reaction-wheel torque about the CM (M == B); only the component perpendicular to the thrust
-    // is achievable
-    const Eigen::Vector3f hs_M(0.01F * 10.0F, 0.01F * 10.0F, 0.01F * 10.0F);
-    const Eigen::Vector3f Lreq_M = K * hs_M;
-    const Eigen::Vector3f tHat_M = out.tHat_B;  // sigma_MB == 0
-    const Eigen::Vector3f LreqPerp_M = Lreq_M - (tHat_M * tHat_M.dot(Lreq_M));
-    EXPECT_LT((out.Lreq_B - LreqPerp_M).norm(), 1e-3F);
+    // expected reported reaction-wheel torque about the CM (sigma_MB == 0, so B frame); only the component
+    // perpendicular to the thrust is achievable
+    const Eigen::Vector3f hs_B(0.01F * 10.0F, 0.01F * 10.0F, 0.01F * 10.0F);
+    const Eigen::Vector3f Lreq_B = K * hs_B;
+    const Eigen::Vector3f tHat_B = out.tHat_B;
+    const Eigen::Vector3f LreqPerp_B = Lreq_B - (tHat_B * tHat_B.dot(Lreq_B));
+    EXPECT_LT((out.Lreq_B - LreqPerp_B).norm(), 1e-3F);
 }
 
 // A geometry that would require a large deflection is clamped so the thrust direction stays on the cone: the angle

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
@@ -54,47 +54,37 @@ TEST(ThrusterPlatformReferenceTest, SetupTest) {
     const Eigen::Vector3f zero = Eigen::Vector3f::Zero();
     const ThrusterPlatformReferenceRwArrayConfiguration noRw{};
     constexpr float nan = std::numeric_limits<float>::quiet_NaN();
-    constexpr float inf = std::numeric_limits<float>::infinity();
 
-    // A finite, non-negative-gain, finite-bound configuration is accepted.
-    EXPECT_NO_THROW(
-        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, noRw));
+    // A finite, non-negative-gain configuration is accepted.
+    EXPECT_NO_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, false, noRw));
 
     // Non-finite geometry is rejected.
     EXPECT_THROW(ThrusterPlatformReferenceConfig::create(
-                     Eigen::Vector3f(nan, 0.0F, 0.0F), zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, noRw),
+                     Eigen::Vector3f(nan, 0.0F, 0.0F), zero, zero, 0.0F, 0.0F, 1.0F, false, noRw),
                  fsw::invalid_argument);
 
     // Negative gains are rejected.
-    EXPECT_THROW(
-        ThrusterPlatformReferenceConfig::create(zero, zero, zero, -1.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, noRw),
-        fsw::invalid_argument);
-    EXPECT_THROW(
-        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, -1.0F, 1.0F, -1.0F, -1.0F, false, noRw),
-        fsw::invalid_argument);
-
-    // A non-positive control period is rejected.
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 0.0F, -1.0F, -1.0F, false, noRw),
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, -1.0F, 0.0F, 1.0F, false, noRw),
+                 fsw::invalid_argument);
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, -1.0F, 1.0F, false, noRw),
                  fsw::invalid_argument);
 
-    // Non-finite angle bounds are rejected.
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, inf, -1.0F, false, noRw),
+    // A non-positive control period is rejected.
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 0.0F, false, noRw),
                  fsw::invalid_argument);
 
     // Too many reaction wheels is rejected.
     ThrusterPlatformReferenceRwArrayConfiguration tooManyRw{};
     tooManyRw.numRW = static_cast<uint32_t>(kMaxNumRw) + 1U;
-    EXPECT_THROW(
-        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, true, tooManyRw),
-        fsw::invalid_argument);
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, true, tooManyRw),
+                 fsw::invalid_argument);
 
     // A non-unit reaction-wheel spin axis is rejected.
     ThrusterPlatformReferenceRwArrayConfiguration nonUnitRw{};
     nonUnitRw.numRW = 1U;
     nonUnitRw.GsMatrix_B.col(0) = Eigen::Vector3f(2.0F, 0.0F, 0.0F);
-    EXPECT_THROW(
-        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, true, nonUnitRw),
-        fsw::invalid_argument);
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, true, nonUnitRw),
+                 fsw::invalid_argument);
 }
 
 // A reaction-wheel spin axis within tolerance of unit length is normalized exactly on construction.
@@ -105,7 +95,7 @@ TEST(ThrusterPlatformReferenceTest, RwSpinAxisNormalized) {
     rw.GsMatrix_B.col(0) = Eigen::Vector3f(1.0005F, 0.0F, 0.0F);
     rw.JsList(0) = 0.01F;
     const ThrusterPlatformReferenceConfig cfg =
-        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 1.0F, 0.0F, 1.0F, -1.0F, -1.0F, true, rw);
+        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 1.0F, 0.0F, 1.0F, true, rw);
     EXPECT_NEAR(cfg.getRwConfig().GsMatrix_B.col(0).norm(), 1.0F, 1e-6F);
 }
 
@@ -115,15 +105,13 @@ TEST(ThrusterPlatformReferenceTest, ConfigRoundTrip) {
     const Eigen::Vector3f r_BM_M(0.0F, 0.1F, 1.4F);
     const Eigen::Vector3f r_FM_F(0.0F, 0.0F, -0.1F);
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        sigma_MB, r_BM_M, r_FM_F, 5.0F, 0.5F, 2.0F, 0.2F, 0.3F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        sigma_MB, r_BM_M, r_FM_F, 5.0F, 0.5F, 2.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     EXPECT_TRUE(cfg.getSigma_MB().isApprox(sigma_MB));
     EXPECT_TRUE(cfg.getR_BM_M().isApprox(r_BM_M));
     EXPECT_TRUE(cfg.getR_FM_F().isApprox(r_FM_F));
     EXPECT_FLOAT_EQ(cfg.getK(), 5.0F);
     EXPECT_FLOAT_EQ(cfg.getKi(), 0.5F);
     EXPECT_FLOAT_EQ(cfg.getControlPeriod(), 2.0F);
-    EXPECT_FLOAT_EQ(cfg.getTheta1Max(), 0.2F);
-    EXPECT_FLOAT_EQ(cfg.getTheta2Max(), 0.3F);
     EXPECT_FALSE(cfg.getMomentumDumping());
 }
 
@@ -135,7 +123,7 @@ TEST(ThrusterPlatformReferenceTest, SigmaMbSwitchedToShadowSetWhenNormExceedsOne
     ASSERT_GT(largeSigma.norm(), 1.0F) << "Test setup: sigma_MB must exceed the norm-1 boundary";
 
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        largeSigma, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        largeSigma, zero, zero, 0.0F, 0.0F, 1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     const Eigen::Vector3f stored = cfg.getSigma_MB();
 
     EXPECT_LE(stored.norm(), 1.0F);
@@ -152,7 +140,7 @@ TEST(ThrusterPlatformReferenceTest, SigmaMbWithinBoundStoredUnchanged) {
     ASSERT_LE(sigma.norm(), 1.0F);
 
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        sigma, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        sigma, zero, zero, 0.0F, 0.0F, 1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     const Eigen::Vector3f stored = cfg.getSigma_MB();
     for (int i = 0; i < 3; ++i) {
         EXPECT_FLOAT_EQ(stored(i), sigma(i));
@@ -166,12 +154,10 @@ TEST(ThrusterPlatformReferenceTest, SigmaMbWithinBoundStoredUnchanged) {
 // All outputs are finite for an arbitrary valid configuration and input.
 TEST(ThrusterPlatformReferenceTest, PropertyOutputsFinite) {
     ThrusterPlatformReferenceAlgorithm alg{
-        makeAlignmentConfig({0.1F, -0.2F, 0.3F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, -1.0F, -1.0F)};
+        makeAlignmentConfig({0.1F, -0.2F, 0.3F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F})};
     const ThrusterPlatformReferenceOutput out =
         alg.update(makeInputs({0.2F, -0.1F, 0.15F}, {-0.01F, 0.03F, 0.02F}, {1.0F, 1.0F, 10.0F}, 10.0F));
 
-    EXPECT_TRUE(std::isfinite(out.theta1));
-    EXPECT_TRUE(std::isfinite(out.theta2));
     EXPECT_TRUE(out.Lreq_B.allFinite());
     EXPECT_TRUE(out.r_TB_B.allFinite());
     EXPECT_TRUE(out.tHat_B.allFinite());
@@ -181,24 +167,12 @@ TEST(ThrusterPlatformReferenceTest, PropertyOutputsFinite) {
 // The reported thrust headings are unit vectors and the reported thrust magnitude matches the input.
 TEST(ThrusterPlatformReferenceTest, PropertyHeadingsAreUnitAndThrustPreserved) {
     ThrusterPlatformReferenceAlgorithm alg{
-        makeAlignmentConfig({0.05F, 0.1F, -0.2F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, -1.0F, -1.0F)};
+        makeAlignmentConfig({0.05F, 0.1F, -0.2F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F})};
     const ThrusterPlatformReferenceOutput out =
         alg.update(makeInputs({0.1F, 0.2F, -0.1F}, {-0.01F, 0.03F, 0.02F}, {2.0F, -1.0F, 8.0F}, 7.5F));
 
     EXPECT_NEAR(out.tHat_B.norm(), 1.0F, 1e-5F);
     EXPECT_NEAR(out.thrust, 7.5F, 1e-5F);
-}
-
-// When angle bounds are set, the reported tip/tilt angles stay within them.
-TEST(ThrusterPlatformReferenceTest, PropertyAngleBoundsRespected) {
-    constexpr float bound = 0.05F;
-    ThrusterPlatformReferenceAlgorithm alg{
-        makeAlignmentConfig({0.0F, 0.0F, 0.0F}, {0.0F, 0.5F, 1.4F}, {0.0F, 0.0F, -0.1F}, bound, bound)};
-    const ThrusterPlatformReferenceOutput out =
-        alg.update(makeInputs({0.4F, 0.3F, 0.1F}, {-0.05F, 0.06F, 0.02F}, {1.0F, 1.0F, 3.0F}, 5.0F));
-
-    EXPECT_LE(std::fabs(out.theta1), bound + 1e-5F);
-    EXPECT_LE(std::fabs(out.theta2), bound + 1e-5F);
 }
 
 // The momentum-dumping path (K > 0 with a valid RW configuration) produces finite outputs.
@@ -212,7 +186,7 @@ TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
     rw.JsList(1) = 0.01F;
     rw.JsList(2) = 0.01F;
     ThrusterPlatformReferenceAlgorithm alg{ThrusterPlatformReferenceConfig::create(
-        {0.0F, 0.0F, 0.0F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, 5.0F, 1.0F, 1.0F, -1.0F, -1.0F, true, rw)};
+        {0.0F, 0.0F, 0.0F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, 5.0F, 1.0F, 1.0F, true, rw)};
 
     ThrusterPlatformReferenceInputs in =
         makeInputs({0.1F, 0.05F, 0.1F}, {-0.01F, 0.03F, 0.02F}, {1.0F, 1.0F, 10.0F}, 10.0F);
@@ -224,23 +198,25 @@ TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
     alg.update(in);
     const ThrusterPlatformReferenceOutput out = alg.update(in);
 
-    EXPECT_TRUE(std::isfinite(out.theta1));
-    EXPECT_TRUE(std::isfinite(out.theta2));
     EXPECT_TRUE(out.Lreq_B.allFinite());
+    EXPECT_TRUE(out.r_TB_B.allFinite());
+    EXPECT_TRUE(out.tHat_B.allFinite());
+    EXPECT_TRUE(std::isfinite(out.thrust));
 }
 
 // ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 
-// With the center of mass already on the thrust line the reference angles are near zero.
+// With the center of mass already on the thrust line the platform is left unrotated, so the body-frame thrust
+// direction matches the (M == B) platform-frame thrust axis and the net thruster torque vanishes.
 TEST(ThrusterPlatformReferenceTest, EdgeCenterOfMassOnThrustLine) {
     // M == B, thruster fires along +z from the F origin, CM placed straight ahead on that axis.
     ThrusterPlatformReferenceAlgorithm alg{
-        makeAlignmentConfig({0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 1.0F}, {0.0F, 0.0F, 0.0F}, -1.0F, -1.0F)};
+        makeAlignmentConfig({0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 1.0F}, {0.0F, 0.0F, 0.0F})};
     const ThrusterPlatformReferenceOutput out =
         alg.update(makeInputs({0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 1.0F}, 5.0F));
 
-    EXPECT_NEAR(out.theta1, 0.0F, 1e-5F);
-    EXPECT_NEAR(out.theta2, 0.0F, 1e-5F);
+    EXPECT_LT((out.tHat_B - Eigen::Vector3f(0.0F, 0.0F, 1.0F)).norm(), 1e-5F);
+    EXPECT_LT(out.Lreq_B.norm(), 1e-5F);
 }

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
@@ -165,7 +165,7 @@ TEST(ThrusterPlatformReferenceTest, PropertyOutputsFinite) {
     const ThrusterPlatformReferenceOutput out =
         alg.update(makeInputs({0.2F, -0.1F, 0.15F}, {-0.01F, 0.03F, 0.02F}, {1.0F, 1.0F, 10.0F}, 10.0F));
 
-    EXPECT_TRUE(out.Lreq_B.allFinite());
+    EXPECT_TRUE(out.Lcomp_B.allFinite());
     EXPECT_TRUE(out.r_TB_B.allFinite());
     EXPECT_TRUE(out.tHat_B.allFinite());
     EXPECT_TRUE(std::isfinite(out.thrust));
@@ -205,14 +205,14 @@ TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
     alg.update(in);
     const ThrusterPlatformReferenceOutput out = alg.update(in);
 
-    EXPECT_TRUE(out.Lreq_B.allFinite());
+    EXPECT_TRUE(out.Lcomp_B.allFinite());
     EXPECT_TRUE(out.r_TB_B.allFinite());
     EXPECT_TRUE(out.tHat_B.allFinite());
     EXPECT_TRUE(std::isfinite(out.thrust));
 }
 
 // The momentum-dumping path points the thruster so it produces the desired thruster torque -(K*hs + Ki*hsInt); the
-// reported reaction-wheel torque (out.Lreq_B) is its opposite, K*hs (Ki = 0 here), projected onto the component
+// reported reaction-wheel torque (out.Lcomp_B) is its opposite, K*hs (Ki = 0 here), projected onto the component
 // achievable by the thrust.
 TEST(ThrusterPlatformReferenceTest, MomentumDumpingAchievesRequestedTorque) {
     const Eigen::Vector3f zero = Eigen::Vector3f::Zero();  // sigma_MB == 0 -> M == B
@@ -239,10 +239,10 @@ TEST(ThrusterPlatformReferenceTest, MomentumDumpingAchievesRequestedTorque) {
     // expected reported reaction-wheel torque about the CM (sigma_MB == 0, so B frame); only the component
     // perpendicular to the thrust is achievable
     const Eigen::Vector3f hs_B(0.01F * 10.0F, 0.01F * 10.0F, 0.01F * 10.0F);
-    const Eigen::Vector3f Lreq_B = K * hs_B;
+    const Eigen::Vector3f Lcomp_B = K * hs_B;
     const Eigen::Vector3f tHat_B = out.tHat_B;
-    const Eigen::Vector3f LreqPerp_B = Lreq_B - (tHat_B * tHat_B.dot(Lreq_B));
-    EXPECT_LT((out.Lreq_B - LreqPerp_B).norm(), 1e-3F);
+    const Eigen::Vector3f LcompPerp_B = Lcomp_B - (tHat_B * tHat_B.dot(Lcomp_B));
+    EXPECT_LT((out.Lcomp_B - LcompPerp_B).norm(), 1e-3F);
 }
 
 // A geometry that would require a large deflection is clamped so the thrust direction stays on the cone: the angle
@@ -275,5 +275,5 @@ TEST(ThrusterPlatformReferenceTest, EdgeCenterOfMassOnThrustLine) {
         alg.update(makeInputs({0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 1.0F}, 5.0F));
 
     EXPECT_LT((out.tHat_B - Eigen::Vector3f(0.0F, 0.0F, 1.0F)).norm(), 1e-5F);
-    EXPECT_LT(out.Lreq_B.norm(), 1e-5F);
+    EXPECT_LT(out.Lcomp_B.norm(), 1e-5F);
 }

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
@@ -55,35 +55,41 @@ TEST(ThrusterPlatformReferenceTest, SetupTest) {
     const ThrusterPlatformReferenceRwArrayConfiguration noRw{};
     constexpr float nan = std::numeric_limits<float>::quiet_NaN();
 
-    // A finite, non-negative-gain configuration is accepted.
-    EXPECT_NO_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, false, noRw));
+    // A finite, non-negative-gain configuration with a valid cone half-angle is accepted.
+    EXPECT_NO_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, 1.0F, false, noRw));
 
     // Non-finite geometry is rejected.
     EXPECT_THROW(ThrusterPlatformReferenceConfig::create(
-                     Eigen::Vector3f(nan, 0.0F, 0.0F), zero, zero, 0.0F, 0.0F, 1.0F, false, noRw),
+                     Eigen::Vector3f(nan, 0.0F, 0.0F), zero, zero, 0.0F, 0.0F, 1.0F, 1.0F, false, noRw),
                  fsw::invalid_argument);
 
     // Negative gains are rejected.
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, -1.0F, 0.0F, 1.0F, false, noRw),
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, -1.0F, 0.0F, 1.0F, 1.0F, false, noRw),
                  fsw::invalid_argument);
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, -1.0F, 1.0F, false, noRw),
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, -1.0F, 1.0F, 1.0F, false, noRw),
                  fsw::invalid_argument);
 
     // A non-positive control period is rejected.
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 0.0F, false, noRw),
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 0.0F, 1.0F, false, noRw),
+                 fsw::invalid_argument);
+
+    // A cone half-angle outside the open interval (0, pi) is rejected.
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, 0.0F, false, noRw),
+                 fsw::invalid_argument);
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, 4.0F, false, noRw),
                  fsw::invalid_argument);
 
     // Too many reaction wheels is rejected.
     ThrusterPlatformReferenceRwArrayConfiguration tooManyRw{};
     tooManyRw.numRW = static_cast<uint32_t>(kMaxNumRw) + 1U;
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, true, tooManyRw),
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, 1.0F, true, tooManyRw),
                  fsw::invalid_argument);
 
     // A non-unit reaction-wheel spin axis is rejected.
     ThrusterPlatformReferenceRwArrayConfiguration nonUnitRw{};
     nonUnitRw.numRW = 1U;
     nonUnitRw.GsMatrix_B.col(0) = Eigen::Vector3f(2.0F, 0.0F, 0.0F);
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, true, nonUnitRw),
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, 1.0F, true, nonUnitRw),
                  fsw::invalid_argument);
 }
 
@@ -95,7 +101,7 @@ TEST(ThrusterPlatformReferenceTest, RwSpinAxisNormalized) {
     rw.GsMatrix_B.col(0) = Eigen::Vector3f(1.0005F, 0.0F, 0.0F);
     rw.JsList(0) = 0.01F;
     const ThrusterPlatformReferenceConfig cfg =
-        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 1.0F, 0.0F, 1.0F, true, rw);
+        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 1.0F, 0.0F, 1.0F, 1.0F, true, rw);
     EXPECT_NEAR(cfg.getRwConfig().GsMatrix_B.col(0).norm(), 1.0F, 1e-6F);
 }
 
@@ -105,13 +111,14 @@ TEST(ThrusterPlatformReferenceTest, ConfigRoundTrip) {
     const Eigen::Vector3f r_BM_M(0.0F, 0.1F, 1.4F);
     const Eigen::Vector3f r_FM_F(0.0F, 0.0F, -0.1F);
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        sigma_MB, r_BM_M, r_FM_F, 5.0F, 0.5F, 2.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        sigma_MB, r_BM_M, r_FM_F, 5.0F, 0.5F, 2.0F, 0.7F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     EXPECT_TRUE(cfg.getSigma_MB().isApprox(sigma_MB));
     EXPECT_TRUE(cfg.getR_BM_M().isApprox(r_BM_M));
     EXPECT_TRUE(cfg.getR_FM_F().isApprox(r_FM_F));
     EXPECT_FLOAT_EQ(cfg.getK(), 5.0F);
     EXPECT_FLOAT_EQ(cfg.getKi(), 0.5F);
     EXPECT_FLOAT_EQ(cfg.getControlPeriod(), 2.0F);
+    EXPECT_FLOAT_EQ(cfg.getThetaMax(), 0.7F);
     EXPECT_FALSE(cfg.getMomentumDumping());
 }
 
@@ -123,7 +130,7 @@ TEST(ThrusterPlatformReferenceTest, SigmaMbSwitchedToShadowSetWhenNormExceedsOne
     ASSERT_GT(largeSigma.norm(), 1.0F) << "Test setup: sigma_MB must exceed the norm-1 boundary";
 
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        largeSigma, zero, zero, 0.0F, 0.0F, 1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        largeSigma, zero, zero, 0.0F, 0.0F, 1.0F, 1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     const Eigen::Vector3f stored = cfg.getSigma_MB();
 
     EXPECT_LE(stored.norm(), 1.0F);
@@ -140,7 +147,7 @@ TEST(ThrusterPlatformReferenceTest, SigmaMbWithinBoundStoredUnchanged) {
     ASSERT_LE(sigma.norm(), 1.0F);
 
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        sigma, zero, zero, 0.0F, 0.0F, 1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        sigma, zero, zero, 0.0F, 0.0F, 1.0F, 1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     const Eigen::Vector3f stored = cfg.getSigma_MB();
     for (int i = 0; i < 3; ++i) {
         EXPECT_FLOAT_EQ(stored(i), sigma(i));
@@ -186,7 +193,7 @@ TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
     rw.JsList(1) = 0.01F;
     rw.JsList(2) = 0.01F;
     ThrusterPlatformReferenceAlgorithm alg{ThrusterPlatformReferenceConfig::create(
-        {0.0F, 0.0F, 0.0F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, 5.0F, 1.0F, 1.0F, true, rw)};
+        {0.0F, 0.0F, 0.0F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, 5.0F, 1.0F, 1.0F, 3.0F, true, rw)};
 
     ThrusterPlatformReferenceInputs in =
         makeInputs({0.1F, 0.05F, 0.1F}, {-0.01F, 0.03F, 0.02F}, {1.0F, 1.0F, 10.0F}, 10.0F);
@@ -202,6 +209,22 @@ TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
     EXPECT_TRUE(out.r_TB_B.allFinite());
     EXPECT_TRUE(out.tHat_B.allFinite());
     EXPECT_TRUE(std::isfinite(out.thrust));
+}
+
+// A geometry that would require a large deflection is clamped so the thrust direction stays on the cone: the angle
+// between the reported thrust heading and its neutral direction equals thetaMax.
+TEST(ThrusterPlatformReferenceTest, ThrustDeflectionClampedToCone) {
+    constexpr float thetaMax = 0.5F;
+    // M == B, thruster fires along +z through the joint, CM placed far off that axis (large required deflection).
+    ThrusterPlatformReferenceAlgorithm alg{
+        makeAlignmentConfig({0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}, thetaMax)};
+    const ThrusterPlatformReferenceOutput out =
+        alg.update(makeInputs({1.0F, 0.0F, 0.1F}, {0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 1.0F}, 5.0F));
+
+    // Neutral thrust direction in the body frame (M == B, [FM] == I) is +z.
+    const Eigen::Vector3f neutral_B(0.0F, 0.0F, 1.0F);
+    const float deflection = std::acos(neutral_B.dot(out.tHat_B));
+    EXPECT_NEAR(deflection, thetaMax, 1e-4F);
 }
 
 // ---------------------------------------------------------------------------

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.cpp
@@ -57,35 +57,44 @@ TEST(ThrusterPlatformReferenceTest, SetupTest) {
     constexpr float inf = std::numeric_limits<float>::infinity();
 
     // A finite, non-negative-gain, finite-bound configuration is accepted.
-    EXPECT_NO_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, false, noRw));
+    EXPECT_NO_THROW(
+        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, noRw));
 
     // Non-finite geometry is rejected.
     EXPECT_THROW(ThrusterPlatformReferenceConfig::create(
-                     Eigen::Vector3f(nan, 0.0F, 0.0F), zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, false, noRw),
+                     Eigen::Vector3f(nan, 0.0F, 0.0F), zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, noRw),
                  fsw::invalid_argument);
 
     // Negative gains are rejected.
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, -1.0F, 0.0F, -1.0F, -1.0F, false, noRw),
-                 fsw::invalid_argument);
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, -1.0F, -1.0F, -1.0F, false, noRw),
+    EXPECT_THROW(
+        ThrusterPlatformReferenceConfig::create(zero, zero, zero, -1.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, noRw),
+        fsw::invalid_argument);
+    EXPECT_THROW(
+        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, -1.0F, 1.0F, -1.0F, -1.0F, false, noRw),
+        fsw::invalid_argument);
+
+    // A non-positive control period is rejected.
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 0.0F, -1.0F, -1.0F, false, noRw),
                  fsw::invalid_argument);
 
     // Non-finite angle bounds are rejected.
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, inf, -1.0F, false, noRw),
+    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, inf, -1.0F, false, noRw),
                  fsw::invalid_argument);
 
     // Too many reaction wheels is rejected.
     ThrusterPlatformReferenceRwArrayConfiguration tooManyRw{};
     tooManyRw.numRW = static_cast<uint32_t>(kMaxNumRw) + 1U;
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, true, tooManyRw),
-                 fsw::invalid_argument);
+    EXPECT_THROW(
+        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, true, tooManyRw),
+        fsw::invalid_argument);
 
     // A non-unit reaction-wheel spin axis is rejected.
     ThrusterPlatformReferenceRwArrayConfiguration nonUnitRw{};
     nonUnitRw.numRW = 1U;
     nonUnitRw.GsMatrix_B.col(0) = Eigen::Vector3f(2.0F, 0.0F, 0.0F);
-    EXPECT_THROW(ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, true, nonUnitRw),
-                 fsw::invalid_argument);
+    EXPECT_THROW(
+        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, true, nonUnitRw),
+        fsw::invalid_argument);
 }
 
 // A reaction-wheel spin axis within tolerance of unit length is normalized exactly on construction.
@@ -96,7 +105,7 @@ TEST(ThrusterPlatformReferenceTest, RwSpinAxisNormalized) {
     rw.GsMatrix_B.col(0) = Eigen::Vector3f(1.0005F, 0.0F, 0.0F);
     rw.JsList(0) = 0.01F;
     const ThrusterPlatformReferenceConfig cfg =
-        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 1.0F, 0.0F, -1.0F, -1.0F, true, rw);
+        ThrusterPlatformReferenceConfig::create(zero, zero, zero, 1.0F, 0.0F, 1.0F, -1.0F, -1.0F, true, rw);
     EXPECT_NEAR(cfg.getRwConfig().GsMatrix_B.col(0).norm(), 1.0F, 1e-6F);
 }
 
@@ -106,12 +115,13 @@ TEST(ThrusterPlatformReferenceTest, ConfigRoundTrip) {
     const Eigen::Vector3f r_BM_M(0.0F, 0.1F, 1.4F);
     const Eigen::Vector3f r_FM_F(0.0F, 0.0F, -0.1F);
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        sigma_MB, r_BM_M, r_FM_F, 5.0F, 0.5F, 0.2F, 0.3F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        sigma_MB, r_BM_M, r_FM_F, 5.0F, 0.5F, 2.0F, 0.2F, 0.3F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     EXPECT_TRUE(cfg.getSigma_MB().isApprox(sigma_MB));
     EXPECT_TRUE(cfg.getR_BM_M().isApprox(r_BM_M));
     EXPECT_TRUE(cfg.getR_FM_F().isApprox(r_FM_F));
     EXPECT_FLOAT_EQ(cfg.getK(), 5.0F);
     EXPECT_FLOAT_EQ(cfg.getKi(), 0.5F);
+    EXPECT_FLOAT_EQ(cfg.getControlPeriod(), 2.0F);
     EXPECT_FLOAT_EQ(cfg.getTheta1Max(), 0.2F);
     EXPECT_FLOAT_EQ(cfg.getTheta2Max(), 0.3F);
     EXPECT_FALSE(cfg.getMomentumDumping());
@@ -125,7 +135,7 @@ TEST(ThrusterPlatformReferenceTest, SigmaMbSwitchedToShadowSetWhenNormExceedsOne
     ASSERT_GT(largeSigma.norm(), 1.0F) << "Test setup: sigma_MB must exceed the norm-1 boundary";
 
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        largeSigma, zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        largeSigma, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     const Eigen::Vector3f stored = cfg.getSigma_MB();
 
     EXPECT_LE(stored.norm(), 1.0F);
@@ -142,7 +152,7 @@ TEST(ThrusterPlatformReferenceTest, SigmaMbWithinBoundStoredUnchanged) {
     ASSERT_LE(sigma.norm(), 1.0F);
 
     const ThrusterPlatformReferenceConfig cfg = ThrusterPlatformReferenceConfig::create(
-        sigma, zero, zero, 0.0F, 0.0F, -1.0F, -1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        sigma, zero, zero, 0.0F, 0.0F, 1.0F, -1.0F, -1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
     const Eigen::Vector3f stored = cfg.getSigma_MB();
     for (int i = 0; i < 3; ++i) {
         EXPECT_FLOAT_EQ(stored(i), sigma(i));
@@ -158,7 +168,7 @@ TEST(ThrusterPlatformReferenceTest, PropertyOutputsFinite) {
     ThrusterPlatformReferenceAlgorithm alg{
         makeAlignmentConfig({0.1F, -0.2F, 0.3F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, -1.0F, -1.0F)};
     const ThrusterPlatformReferenceOutput out =
-        alg.update(makeInputs({0.2F, -0.1F, 0.15F}, {-0.01F, 0.03F, 0.02F}, {1.0F, 1.0F, 10.0F}, 10.0F), 0);
+        alg.update(makeInputs({0.2F, -0.1F, 0.15F}, {-0.01F, 0.03F, 0.02F}, {1.0F, 1.0F, 10.0F}, 10.0F));
 
     EXPECT_TRUE(std::isfinite(out.theta1));
     EXPECT_TRUE(std::isfinite(out.theta2));
@@ -173,7 +183,7 @@ TEST(ThrusterPlatformReferenceTest, PropertyHeadingsAreUnitAndThrustPreserved) {
     ThrusterPlatformReferenceAlgorithm alg{
         makeAlignmentConfig({0.05F, 0.1F, -0.2F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, -1.0F, -1.0F)};
     const ThrusterPlatformReferenceOutput out =
-        alg.update(makeInputs({0.1F, 0.2F, -0.1F}, {-0.01F, 0.03F, 0.02F}, {2.0F, -1.0F, 8.0F}, 7.5F), 0);
+        alg.update(makeInputs({0.1F, 0.2F, -0.1F}, {-0.01F, 0.03F, 0.02F}, {2.0F, -1.0F, 8.0F}, 7.5F));
 
     EXPECT_NEAR(out.tHat_B.norm(), 1.0F, 1e-5F);
     EXPECT_NEAR(out.thrust, 7.5F, 1e-5F);
@@ -185,7 +195,7 @@ TEST(ThrusterPlatformReferenceTest, PropertyAngleBoundsRespected) {
     ThrusterPlatformReferenceAlgorithm alg{
         makeAlignmentConfig({0.0F, 0.0F, 0.0F}, {0.0F, 0.5F, 1.4F}, {0.0F, 0.0F, -0.1F}, bound, bound)};
     const ThrusterPlatformReferenceOutput out =
-        alg.update(makeInputs({0.4F, 0.3F, 0.1F}, {-0.05F, 0.06F, 0.02F}, {1.0F, 1.0F, 3.0F}, 5.0F), 0);
+        alg.update(makeInputs({0.4F, 0.3F, 0.1F}, {-0.05F, 0.06F, 0.02F}, {1.0F, 1.0F, 3.0F}, 5.0F));
 
     EXPECT_LE(std::fabs(out.theta1), bound + 1e-5F);
     EXPECT_LE(std::fabs(out.theta2), bound + 1e-5F);
@@ -202,7 +212,7 @@ TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
     rw.JsList(1) = 0.01F;
     rw.JsList(2) = 0.01F;
     ThrusterPlatformReferenceAlgorithm alg{ThrusterPlatformReferenceConfig::create(
-        {0.0F, 0.0F, 0.0F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, 5.0F, 1.0F, -1.0F, -1.0F, true, rw)};
+        {0.0F, 0.0F, 0.0F}, {0.0F, 0.1F, 1.4F}, {0.0F, 0.0F, -0.1F}, 5.0F, 1.0F, 1.0F, -1.0F, -1.0F, true, rw)};
 
     ThrusterPlatformReferenceInputs in =
         makeInputs({0.1F, 0.05F, 0.1F}, {-0.01F, 0.03F, 0.02F}, {1.0F, 1.0F, 10.0F}, 10.0F);
@@ -210,10 +220,9 @@ TEST(ThrusterPlatformReferenceTest, PropertyMomentumDumpingFinite) {
     in.wheelSpeeds(1) = 100.0F;
     in.wheelSpeeds(2) = 100.0F;
 
-    // advance two steps so the integral term accumulates a non-zero dt (1 s in nanoseconds)
-    constexpr uint64_t stepNs = 1000000000ULL;
-    alg.update(in, stepNs);
-    const ThrusterPlatformReferenceOutput out = alg.update(in, 2ULL * stepNs);
+    // advance two steps so the momentum integral accumulates over more than one control period
+    alg.update(in);
+    const ThrusterPlatformReferenceOutput out = alg.update(in);
 
     EXPECT_TRUE(std::isfinite(out.theta1));
     EXPECT_TRUE(std::isfinite(out.theta2));
@@ -230,7 +239,7 @@ TEST(ThrusterPlatformReferenceTest, EdgeCenterOfMassOnThrustLine) {
     ThrusterPlatformReferenceAlgorithm alg{
         makeAlignmentConfig({0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 1.0F}, {0.0F, 0.0F, 0.0F}, -1.0F, -1.0F)};
     const ThrusterPlatformReferenceOutput out =
-        alg.update(makeInputs({0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 1.0F}, 5.0F), 0);
+        alg.update(makeInputs({0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 0.0F}, {0.0F, 0.0F, 1.0F}, 5.0F));
 
     EXPECT_NEAR(out.theta1, 0.0F, 1e-5F);
     EXPECT_NEAR(out.theta2, 0.0F, 1e-5F);

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.py
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.py
@@ -19,17 +19,16 @@ from xmera.architecture import sim_model
 @pytest.mark.parametrize("seed", list(np.linspace(1, 10, 10)))
 @pytest.mark.parametrize("delta_cm", [0.1, 0.2, 0.3])
 @pytest.mark.parametrize("k", [0, 1, 5, 10])
-@pytest.mark.parametrize("theta_max", [-1, np.pi / 36])
 @pytest.mark.parametrize("accuracy", [1e-4])
-def test_thruster_platform_reference(show_plots, delta_cm, k, theta_max, seed, accuracy):
+def test_thruster_platform_reference(show_plots, delta_cm, k, seed, accuracy):
     r"""
     **Validation Test Description**
 
-    This unit test script tests the correctness of the tip and tilt reference angles computed by
+    This unit test script tests the correctness of the platform reference orientation computed by
     :ref:`thrusterPlatformReference`. The correctness of the output is determined based on whether the thruster
-    is aligned with the system's center of mass, when the momentum dumping control gain :math:`\kappa = 0`.
-    Moreover, the other module output messages, ``bodyHeadingOutMsg`` and ``thrusterTorqueOutMsg`` are checked
-    versus equivalent python code.
+    line of action is aligned with the system's center of mass, when the momentum dumping control gain
+    :math:`\kappa = 0`. Moreover, the other module output messages, ``bodyHeadingOutMsg``, ``thrusterTorqueOutMsg``
+    and ``thrusterConfigBOutMsg`` are checked versus equivalent python code.
 
     **Test Parameters**
 
@@ -45,24 +44,25 @@ def test_thruster_platform_reference(show_plots, delta_cm, k, theta_max, seed, a
     **Description of Variables Being Tested**
 
     For :math:`\kappa = 0`, the correctness of the result is assessed based on the norm of the
-    cross product between the thrust direction vector :math:`{}^\mathcal{F}\boldsymbol{t}` and the relative position
-    of the center of mass with respect to the thruster application point :math:`T`. For :math:`\kappa \neq 0` this
-    test is not performed, as the thruster is not aligned with the center of mass. This script does not test the
-    integral feedback term, which would require running a simulation for an extended period of time.
+    cross product between the body-frame thrust direction and the relative position of the center of mass with
+    respect to the thruster application point :math:`T`, which must vanish when the thruster is aligned with the
+    center of mass. For :math:`\kappa \neq 0` this alignment test is not performed, as the thruster is intentionally
+    offset from the center of mass. This script does not test the integral feedback term, which would require running
+    a simulation for an extended period of time.
 
-    The python code also computes equivalently the thrust direction in body frame coordinates :math:`{}^\mathcal{B}\boldsymbol{t}`
-    and the net torque on the system :math:`{}^\mathcal{B}\boldsymbol{L}`, and compares them to the respective output
-    messages for all values of :math:`\kappa = 0` tested.
+    For all values of :math:`\kappa`, the net torque output message is checked against the body-frame moment of the
+    thrust about the reported thruster application point, and the thruster configuration output message is checked to
+    be self-consistent with the body-frame thrust heading and magnitude.
 
     **General Documentation Comments**
 
-    The offset vectors provided as input parameters ensure that a solution exists, such that the Unit Test can correctly
-    assess the alignment of the thruster. This is, in general, not guaranteed.
+    The offset vectors provided as input parameters ensure that a solution exists, such that the Unit Test can
+    correctly assess the alignment of the thruster. This is, in general, not guaranteed.
     """
-    thruster_platform_reference_test_function(show_plots, delta_cm, k, theta_max, seed, accuracy)
+    thruster_platform_reference_test_function(show_plots, delta_cm, k, seed, accuracy)
 
 
-def thruster_platform_reference_test_function(show_plots, delta_cm, k, theta_max, seed, accuracy):
+def thruster_platform_reference_test_function(show_plots, delta_cm, k, seed, accuracy):
 
     random.seed(seed)
 
@@ -102,8 +102,6 @@ def thruster_platform_reference_test_function(show_plots, delta_cm, k, theta_max
     platform.K = k
     platform.Ki = 0
     platform.controlPeriod = 1.0
-    platform.theta1Max = theta_max
-    platform.theta2Max = theta_max
 
     # Create input vehicle configuration msg
     input_veh_config_msg_data = messaging.VehicleConfigMsgF32Payload()
@@ -135,10 +133,6 @@ def thruster_platform_reference_test_function(show_plots, delta_cm, k, theta_max
     platform.rwSpeedsInMsg.subscribeTo(input_rw_speeds_msg)
 
     # Setup logging on the test module output messages so that we get all the writes to it
-    ref1_log = platform.hingedRigidBodyRef1OutMsg.recorder()
-    unit_test_sim.AddModelToTask(unit_task_name, ref1_log)
-    ref2_log = platform.hingedRigidBodyRef2OutMsg.recorder()
-    unit_test_sim.AddModelToTask(unit_task_name, ref2_log)
     body_heading_log = platform.bodyHeadingOutMsg.recorder()
     unit_test_sim.AddModelToTask(unit_task_name, body_heading_log)
     thruster_torque_log = platform.thrusterTorqueOutMsg.recorder()
@@ -158,51 +152,31 @@ def thruster_platform_reference_test_function(show_plots, delta_cm, k, theta_max
     # Begin the simulation time run set above
     unit_test_sim.ExecuteSimulation()
 
-    theta1 = ref1_log.theta[0]
-    theta2 = ref2_log.theta[0]
+    thrust = np.linalg.norm(T_F)
+    tHat_B_sim = body_heading_log.rHat_XB_B[0]
+    L_B_sim = thruster_torque_log.torqueRequestBody[0]
+    r_TB_B_sim = thr_config_b_log.rThrust_B[0]
+    tHat_B_cfg_sim = thr_config_b_log.tHatThrust_B[0]
+    tMax_sim = thr_config_b_log.maxThrust[0]
 
-    FM = rbk.euler1232C([theta1, theta2, 0.0])
-    MB = rbk.MRP2C(sigma_MB)
+    # the reported body-frame thrust heading is a unit vector and the thrust magnitude is preserved
+    np.testing.assert_allclose(np.linalg.norm(tHat_B_sim), 1.0, rtol=accuracy, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(tMax_sim, thrust, rtol=accuracy, atol=accuracy, verbose=True)
 
-    r_CB_M = np.matmul(MB, r_CB_B)
-    r_CM_M = r_CB_M + r_BM_M
-    r_CM_F = np.matmul(FM, r_CM_M)
-    r_CT_F = r_CM_F - r_FM_F - r_TF_F
+    # the body-heading and thruster-configuration messages report the same thrust direction
+    np.testing.assert_allclose(tHat_B_cfg_sim, tHat_B_sim, rtol=accuracy, atol=accuracy, verbose=True)
 
-    offset = np.linalg.norm(np.cross(r_CT_F, T_F) / np.linalg.norm(np.array(r_CT_F)) / np.linalg.norm(np.array(T_F)))
-
-    # check if the CM offset is zero if control gain k is also 0
-    if k == 0 and theta_max < 0:
-        np.testing.assert_allclose(offset, 0.0, rtol=accuracy, atol=accuracy, verbose=True)
-
-    T_B_hat_sim = body_heading_log.rHat_XB_B[0]             # simulation result
-    FB = np.matmul(FM, MB)
-    T_B = np.matmul(FB.transpose(), T_F)
-    T_B_hat = T_B / np.linalg.norm(T_B)                     # truth value
-
-    # compare the module results to the python computation for body-frame thruster direction
-    np.testing.assert_allclose(T_B_hat_sim, T_B_hat, rtol=accuracy, atol=accuracy, verbose=True)
-
-    L_B_sim = thruster_torque_log.torqueRequestBody[0]     # simulation result
-    L_F = np.cross(r_CT_F, T_F)
-    L_B = np.matmul(FB.transpose(), L_F)
-
-    # compare the module results to the python computation for body-frame cmd torque
+    # the reported net torque equals the body-frame moment of the thrust about the reported application point
+    r_TC_B = np.array(r_TB_B_sim) - r_CB_B
+    L_B = thrust * np.cross(tHat_B_sim, r_TC_B)
     np.testing.assert_allclose(L_B_sim, L_B, rtol=accuracy, atol=accuracy, verbose=True)
 
-    # compare the module results to the python computation for thruster configuration in B frame
-    r_TB_B = r_CB_B - np.matmul(FB.transpose(), r_CT_F)
-    r_TB_B_sim = thr_config_b_log.rThrust_B[0]
-    tHat_B_sim = thr_config_b_log.tHatThrust_B[0]
-    tMax_sim = thr_config_b_log.maxThrust[0]
-    np.testing.assert_allclose(r_TB_B_sim, r_TB_B, rtol=accuracy, atol=accuracy, verbose=True)
-    np.testing.assert_allclose(tHat_B_sim, T_B_hat, rtol=accuracy, atol=accuracy, verbose=True)
-    np.testing.assert_allclose(tMax_sim, np.linalg.norm(T_B), rtol=accuracy, atol=accuracy, verbose=True)
-
-    # compare the output reference angle
-    if theta_max > 0:
-        np.testing.assert_array_less(theta1, theta_max + accuracy, verbose=True)
-        np.testing.assert_array_less(theta2, theta_max + accuracy, verbose=True)
+    # for k = 0 the thruster is aligned through the center of mass, so the moment arm is parallel to the thrust
+    # direction (zero offset) and the net torque vanishes
+    if k == 0:
+        offset = np.linalg.norm(np.cross(tHat_B_sim, r_TC_B)) / np.linalg.norm(r_TC_B)
+        np.testing.assert_allclose(offset, 0.0, rtol=accuracy, atol=accuracy, verbose=True)
+        np.testing.assert_allclose(L_B_sim, np.zeros(3), rtol=accuracy, atol=accuracy, verbose=True)
 
     return
 
@@ -216,7 +190,6 @@ if __name__ == "__main__":
         False,                   # show_plots
         0.1,                     # delta_cm
         0,                       # k
-        -1,                      # theta_max
         np.random.rand(1)[0],    # seed
         1e-4                     # accuracy
     )

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.py
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.py
@@ -101,6 +101,7 @@ def thruster_platform_reference_test_function(show_plots, delta_cm, k, theta_max
     platform.r_FM_F = r_FM_F
     platform.K = k
     platform.Ki = 0
+    platform.controlPeriod = 1.0
     platform.theta1Max = theta_max
     platform.theta2Max = theta_max
 

--- a/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.py
+++ b/algorithms/thrusterPlatformReference/_tests/test_thrusterPlatformReference.py
@@ -1,5 +1,4 @@
 import pytest
-import random
 import numpy as np
 
 
@@ -19,8 +18,9 @@ from xmera.architecture import sim_model
 @pytest.mark.parametrize("seed", list(np.linspace(1, 10, 10)))
 @pytest.mark.parametrize("delta_cm", [0.1, 0.2, 0.3])
 @pytest.mark.parametrize("k", [0, 1, 5, 10])
+@pytest.mark.parametrize("theta_max", [np.pi / 2, np.pi / 36])
 @pytest.mark.parametrize("accuracy", [1e-4])
-def test_thruster_platform_reference(show_plots, delta_cm, k, seed, accuracy):
+def test_thruster_platform_reference(show_plots, delta_cm, k, theta_max, seed, accuracy):
     r"""
     **Validation Test Description**
 
@@ -38,6 +38,7 @@ def test_thruster_platform_reference(show_plots, delta_cm, k, seed, accuracy):
     Args:
         delta_cm (m): magnitude of the center of mass shift, whose direction is generated randomly
         k (Hz): proportional gain of the momentum dumping control law
+        theta_max (rad): half-angle of the thrust-deflection cone
         seed (-): seed is varied to randomly change the shift in the center of mass
         accuracy (float): accuracy within which results are considered to match the truth values.
 
@@ -59,12 +60,14 @@ def test_thruster_platform_reference(show_plots, delta_cm, k, seed, accuracy):
     The offset vectors provided as input parameters ensure that a solution exists, such that the Unit Test can
     correctly assess the alignment of the thruster. This is, in general, not guaranteed.
     """
-    thruster_platform_reference_test_function(show_plots, delta_cm, k, seed, accuracy)
+    thruster_platform_reference_test_function(show_plots, delta_cm, k, theta_max, seed, accuracy)
 
 
-def thruster_platform_reference_test_function(show_plots, delta_cm, k, seed, accuracy):
+def thruster_platform_reference_test_function(show_plots, delta_cm, k, theta_max, seed, accuracy):
 
-    random.seed(seed)
+    # seed numpy's generator (used for the random center-of-mass shift below) so the test is deterministic and
+    # independent of execution order
+    np.random.seed(int(seed))
 
     euler_angles_123 = np.array([5.0 * macros.D2R, 10.0 * macros.D2R, 0.0])
     sigma_MB = np.array(rbk.euler1232MRP(euler_angles_123))
@@ -102,6 +105,7 @@ def thruster_platform_reference_test_function(show_plots, delta_cm, k, seed, acc
     platform.K = k
     platform.Ki = 0
     platform.controlPeriod = 1.0
+    platform.thetaMax = theta_max
 
     # Create input vehicle configuration msg
     input_veh_config_msg_data = messaging.VehicleConfigMsgF32Payload()
@@ -171,12 +175,19 @@ def thruster_platform_reference_test_function(show_plots, delta_cm, k, seed, acc
     L_B = thrust * np.cross(tHat_B_sim, r_TC_B)
     np.testing.assert_allclose(L_B_sim, L_B, rtol=accuracy, atol=accuracy, verbose=True)
 
-    # for k = 0 the thruster is aligned through the center of mass, so the moment arm is parallel to the thrust
-    # direction (zero offset) and the net torque vanishes
-    if k == 0:
+    # the thrust deflection from its neutral (un-rotated) direction stays within the configured cone
+    MB = rbk.MRP2C(sigma_MB)
+    tHat_F = T_F / thrust
+    neutral_B = np.matmul(MB.transpose(), tHat_F)
+    deflection = np.arccos(np.clip(np.dot(neutral_B, tHat_B_sim), -1.0, 1.0))
+    np.testing.assert_array_less(deflection, theta_max + accuracy, verbose=True)
+
+    # for k = 0 the thruster aligns through the center of mass whenever the cone does not clamp it, so the moment arm
+    # is parallel to the thrust direction (zero offset). The net torque then vanishes up to the alignment residual
+    # scaled by the thrust magnitude and moment arm, which the torque self-consistency check above already covers.
+    if k == 0 and deflection < theta_max - accuracy:
         offset = np.linalg.norm(np.cross(tHat_B_sim, r_TC_B)) / np.linalg.norm(r_TC_B)
         np.testing.assert_allclose(offset, 0.0, rtol=accuracy, atol=accuracy, verbose=True)
-        np.testing.assert_allclose(L_B_sim, np.zeros(3), rtol=accuracy, atol=accuracy, verbose=True)
 
     return
 
@@ -190,6 +201,7 @@ if __name__ == "__main__":
         False,                   # show_plots
         0.1,                     # delta_cm
         0,                       # k
+        np.pi / 2,               # theta_max
         np.random.rand(1)[0],    # seed
         1e-4                     # accuracy
     )

--- a/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
+++ b/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
@@ -61,7 +61,6 @@ inline void regressionTestThrusterPlatformReference(const Eigen::Vector3f& sigma
 
     // Body-frame outputs consistent with the reported angles.
     const Eigen::Vector3f tHat_B = (FB.transpose() * T_F).normalized();
-    EXPECT_LT((out.rHat_XB_B - tHat_B).norm(), accuracy);
     EXPECT_LT((out.tHatThrust_B - tHat_B).norm(), accuracy);
 
     const Eigen::Vector3f torque_B = FB.transpose() * T_F.cross(r_TC_F);
@@ -97,12 +96,10 @@ inline void propertyOutputsFinite(const Eigen::Vector3f& sigma_MB,
 
     EXPECT_TRUE(std::isfinite(out.theta1));
     EXPECT_TRUE(std::isfinite(out.theta2));
-    EXPECT_TRUE(out.rHat_XB_B.allFinite());
     EXPECT_TRUE(out.torqueRequestBody.allFinite());
     EXPECT_TRUE(out.rThrust_B.allFinite());
     EXPECT_TRUE(out.tHatThrust_B.allFinite());
     EXPECT_TRUE(std::isfinite(out.maxThrust));
-    EXPECT_NEAR(out.rHat_XB_B.norm(), 1.0F, 1e-3F);
     EXPECT_NEAR(out.tHatThrust_B.norm(), 1.0F, 1e-3F);
 }
 

--- a/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
+++ b/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
@@ -57,7 +57,7 @@ inline void regressionTestThrusterPlatformReference(const Eigen::Vector3f& sigma
     EXPECT_NEAR(offset, 0.0F, accuracy);
 
     // With the thruster aligned through the center of mass the net thruster torque vanishes.
-    EXPECT_LT(out.Lreq_B.norm(), accuracy * maxThrust * r_CT_B.norm());
+    EXPECT_LT(out.Lcomp_B.norm(), accuracy * maxThrust * r_CT_B.norm());
 
     // The thruster-to-center-of-mass distance matches the ray-sphere intersection computed from the raw geometry.
     const Eigen::Matrix3f MB = mrpToDcm(sigma_MB);
@@ -92,7 +92,7 @@ inline void propertyOutputsFinite(const Eigen::Vector3f& sigma_MB,
     ThrusterPlatformReferenceAlgorithm alg{makeAlignmentConfig(sigma_MB, r_BM_M, r_FM_F)};
     const ThrusterPlatformReferenceOutput out = alg.update(makeInputs(r_CB_B, rThrust_F, tHatThrust_F, maxThrust));
 
-    EXPECT_TRUE(out.Lreq_B.allFinite());
+    EXPECT_TRUE(out.Lcomp_B.allFinite());
     EXPECT_TRUE(out.r_TB_B.allFinite());
     EXPECT_TRUE(out.tHat_B.allFinite());
     EXPECT_TRUE(std::isfinite(out.thrust));

--- a/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
+++ b/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
@@ -13,8 +13,15 @@ inline ThrusterPlatformReferenceConfig makeAlignmentConfig(const Eigen::Vector3f
                                                            const Eigen::Vector3f& r_FM_F,
                                                            float theta1Max,
                                                            float theta2Max) {
-    return ThrusterPlatformReferenceConfig::create(
-        sigma_MB, r_BM_M, r_FM_F, 0.0F, 0.0F, theta1Max, theta2Max, false, ThrusterPlatformReferenceRwArrayConfig{});
+    return ThrusterPlatformReferenceConfig::create(sigma_MB,
+                                                   r_BM_M,
+                                                   r_FM_F,
+                                                   0.0F,
+                                                   0.0F,
+                                                   theta1Max,
+                                                   theta2Max,
+                                                   false,
+                                                   ThrusterPlatformReferenceRwArrayConfiguration{});
 }
 
 // Assemble the per-cycle inputs from the center-of-mass position and thruster geometry.
@@ -24,9 +31,9 @@ inline ThrusterPlatformReferenceInputs makeInputs(const Eigen::Vector3f& r_CB_B,
                                                   float maxThrust) {
     ThrusterPlatformReferenceInputs in{};
     in.r_CB_B = r_CB_B;
-    in.rThrust_F = rThrust_F;
-    in.tHatThrust_F = tHatThrust_F.normalized();
-    in.maxThrust = maxThrust;
+    in.r_TF_F = rThrust_F;
+    in.tHat_F = tHatThrust_F.normalized();
+    in.thrust = maxThrust;
     return in;
 }
 
@@ -61,15 +68,15 @@ inline void regressionTestThrusterPlatformReference(const Eigen::Vector3f& sigma
 
     // Body-frame outputs consistent with the reported angles.
     const Eigen::Vector3f tHat_B = (FB.transpose() * T_F).normalized();
-    EXPECT_LT((out.tHatThrust_B - tHat_B).norm(), accuracy);
+    EXPECT_LT((out.tHat_B - tHat_B).norm(), accuracy);
 
     const Eigen::Vector3f torque_B = FB.transpose() * T_F.cross(r_TC_F);
-    EXPECT_LT((out.torqueRequestBody - torque_B).norm(), accuracy);
+    EXPECT_LT((out.Lreq_B - torque_B).norm(), accuracy);
 
     const Eigen::Vector3f rThrust_B = r_CB_B + FB.transpose() * r_TC_F;
-    EXPECT_LT((out.rThrust_B - rThrust_B).norm(), accuracy);
+    EXPECT_LT((out.r_TB_B - rThrust_B).norm(), accuracy);
 
-    EXPECT_NEAR(out.maxThrust, T_F.norm(), accuracy);
+    EXPECT_NEAR(out.thrust, T_F.norm(), accuracy);
 }
 
 // Property helper: for finite, non-degenerate geometry the platform reference is well defined, so every output
@@ -96,11 +103,11 @@ inline void propertyOutputsFinite(const Eigen::Vector3f& sigma_MB,
 
     EXPECT_TRUE(std::isfinite(out.theta1));
     EXPECT_TRUE(std::isfinite(out.theta2));
-    EXPECT_TRUE(out.torqueRequestBody.allFinite());
-    EXPECT_TRUE(out.rThrust_B.allFinite());
-    EXPECT_TRUE(out.tHatThrust_B.allFinite());
-    EXPECT_TRUE(std::isfinite(out.maxThrust));
-    EXPECT_NEAR(out.tHatThrust_B.norm(), 1.0F, 1e-3F);
+    EXPECT_TRUE(out.Lreq_B.allFinite());
+    EXPECT_TRUE(out.r_TB_B.allFinite());
+    EXPECT_TRUE(out.tHat_B.allFinite());
+    EXPECT_TRUE(std::isfinite(out.thrust));
+    EXPECT_NEAR(out.tHat_B.norm(), 1.0F, 1e-3F);
 }
 
 #endif  // TEST_THRUSTER_PLATFORM_REFERENCE_H

--- a/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
+++ b/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
@@ -10,19 +10,9 @@
 // Build a validated configuration with momentum dumping disabled (pure center-of-mass alignment mode).
 inline ThrusterPlatformReferenceConfig makeAlignmentConfig(const Eigen::Vector3f& sigma_MB,
                                                            const Eigen::Vector3f& r_BM_M,
-                                                           const Eigen::Vector3f& r_FM_F,
-                                                           float theta1Max,
-                                                           float theta2Max) {
-    return ThrusterPlatformReferenceConfig::create(sigma_MB,
-                                                   r_BM_M,
-                                                   r_FM_F,
-                                                   0.0F,
-                                                   0.0F,
-                                                   1.0F,
-                                                   theta1Max,
-                                                   theta2Max,
-                                                   false,
-                                                   ThrusterPlatformReferenceRwArrayConfiguration{});
+                                                           const Eigen::Vector3f& r_FM_F) {
+    return ThrusterPlatformReferenceConfig::create(
+        sigma_MB, r_BM_M, r_FM_F, 0.0F, 0.0F, 1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
 }
 
 // Assemble the per-cycle inputs from the center-of-mass position and thruster geometry.
@@ -38,9 +28,10 @@ inline ThrusterPlatformReferenceInputs makeInputs(const Eigen::Vector3f& r_CB_B,
     return in;
 }
 
-// Regression helper: with K = 0 and no angle bounds the platform must align the thruster with the system
-// center of mass, so the thrust direction is parallel to the center-of-mass-to-thruster vector. The
-// body-frame outputs are also verified to be consistent with the reported tip/tilt reference angles.
+// Regression helper: with K = 0 the platform aligns the thruster line of action with the system center of mass, so
+// the reported body-frame thrust direction is parallel to the thruster-to-center-of-mass vector and the net
+// thruster torque vanishes. The thruster-to-center-of-mass distance is checked against the ray-sphere intersection
+// computed independently from the raw configuration.
 inline void regressionTestThrusterPlatformReference(const Eigen::Vector3f& sigma_MB,
                                                     const Eigen::Vector3f& r_BM_M,
                                                     const Eigen::Vector3f& r_FM_F,
@@ -49,35 +40,32 @@ inline void regressionTestThrusterPlatformReference(const Eigen::Vector3f& sigma
                                                     const Eigen::Vector3f& tHatThrust_F,
                                                     float maxThrust,
                                                     float accuracy) {
-    ThrusterPlatformReferenceAlgorithm alg{makeAlignmentConfig(sigma_MB, r_BM_M, r_FM_F, -1.0F, -1.0F)};
+    ThrusterPlatformReferenceAlgorithm alg{makeAlignmentConfig(sigma_MB, r_BM_M, r_FM_F)};
     const ThrusterPlatformReferenceInputs in = makeInputs(r_CB_B, rThrust_F, tHatThrust_F, maxThrust);
     const ThrusterPlatformReferenceOutput out = alg.update(in);
 
-    // Recompute the platform geometry from the reported reference angles.
-    const Eigen::Matrix3f FM = eulerAngles123ToDcm(Eigen::Vector3f(out.theta1, out.theta2, 0.0F));
-    const Eigen::Matrix3f MB = mrpToDcm(sigma_MB);
-    const Eigen::Matrix3f FB = FM * MB;
-    const Eigen::Vector3f T_F = maxThrust * tHatThrust_F.normalized();
-    const Eigen::Vector3f r_CM_M = MB * r_CB_B + r_BM_M;
-    const Eigen::Vector3f r_TM_F = r_FM_F + rThrust_F;
-    const Eigen::Vector3f r_CM_F = FM * r_CM_M;
-    const Eigen::Vector3f r_TC_F = r_TM_F - r_CM_F;
+    // Thrust magnitude preserved and the reported heading is a unit vector.
+    EXPECT_NEAR(out.thrust, maxThrust, accuracy);
+    EXPECT_NEAR(out.tHat_B.norm(), 1.0F, accuracy);
 
-    // Alignment property: thrust parallel to the center-of-mass-to-thruster vector.
-    const float offset = T_F.cross(r_TC_F).norm() / (T_F.norm() * r_TC_F.norm());
+    // Alignment property: the body-frame thrust direction is parallel to the thruster-to-center-of-mass vector, so
+    // the thruster line of action passes through the center of mass.
+    const Eigen::Vector3f r_CT_B = out.r_TB_B - r_CB_B;  // thrust application point relative to the center of mass
+    const float offset = out.tHat_B.cross(r_CT_B).norm() / r_CT_B.norm();
     EXPECT_NEAR(offset, 0.0F, accuracy);
 
-    // Body-frame outputs consistent with the reported angles.
-    const Eigen::Vector3f tHat_B = (FB.transpose() * T_F).normalized();
-    EXPECT_LT((out.tHat_B - tHat_B).norm(), accuracy);
+    // With the thruster aligned through the center of mass the net thruster torque vanishes.
+    EXPECT_LT(out.Lreq_B.norm(), accuracy * maxThrust * r_CT_B.norm());
 
-    const Eigen::Vector3f torque_B = FB.transpose() * T_F.cross(r_TC_F);
-    EXPECT_LT((out.Lreq_B - torque_B).norm(), accuracy);
-
-    const Eigen::Vector3f rThrust_B = r_CB_B + FB.transpose() * r_TC_F;
-    EXPECT_LT((out.r_TB_B - rThrust_B).norm(), accuracy);
-
-    EXPECT_NEAR(out.thrust, T_F.norm(), accuracy);
+    // The thruster-to-center-of-mass distance matches the ray-sphere intersection computed from the raw geometry.
+    const Eigen::Matrix3f MB = mrpToDcm(sigma_MB);
+    const Eigen::Vector3f r_CM_M = MB * r_CB_B + r_BM_M;
+    const Eigen::Vector3f r_TM_F = r_FM_F + rThrust_F;
+    const Eigen::Vector3f tHat_F = tHatThrust_F.normalized();
+    const float b = r_CM_M.norm();
+    const float rt = r_TM_F.dot(tHat_F);
+    const float ct = -rt + std::sqrt((rt * rt) - r_TM_F.squaredNorm() + (b * b));
+    EXPECT_NEAR(r_CT_B.norm(), std::fabs(ct), accuracy);
 }
 
 // Property helper: for finite, non-degenerate geometry the platform reference is well defined, so every output
@@ -99,11 +87,9 @@ inline void propertyOutputsFinite(const Eigen::Vector3f& sigma_MB,
         return;
     }
 
-    ThrusterPlatformReferenceAlgorithm alg{makeAlignmentConfig(sigma_MB, r_BM_M, r_FM_F, -1.0F, -1.0F)};
+    ThrusterPlatformReferenceAlgorithm alg{makeAlignmentConfig(sigma_MB, r_BM_M, r_FM_F)};
     const ThrusterPlatformReferenceOutput out = alg.update(makeInputs(r_CB_B, rThrust_F, tHatThrust_F, maxThrust));
 
-    EXPECT_TRUE(std::isfinite(out.theta1));
-    EXPECT_TRUE(std::isfinite(out.theta2));
     EXPECT_TRUE(out.Lreq_B.allFinite());
     EXPECT_TRUE(out.r_TB_B.allFinite());
     EXPECT_TRUE(out.tHat_B.allFinite());

--- a/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
+++ b/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
@@ -7,12 +7,14 @@
 #include <Eigen/Core>
 #include <cmath>
 
-// Build a validated configuration with momentum dumping disabled (pure center-of-mass alignment mode).
+// Build a validated configuration with momentum dumping disabled (pure center-of-mass alignment mode). The default
+// deflection cone is wide enough that it does not clamp the geometries used by the alignment tests.
 inline ThrusterPlatformReferenceConfig makeAlignmentConfig(const Eigen::Vector3f& sigma_MB,
                                                            const Eigen::Vector3f& r_BM_M,
-                                                           const Eigen::Vector3f& r_FM_F) {
+                                                           const Eigen::Vector3f& r_FM_F,
+                                                           float thetaMax = 3.0F) {
     return ThrusterPlatformReferenceConfig::create(
-        sigma_MB, r_BM_M, r_FM_F, 0.0F, 0.0F, 1.0F, false, ThrusterPlatformReferenceRwArrayConfiguration{});
+        sigma_MB, r_BM_M, r_FM_F, 0.0F, 0.0F, 1.0F, thetaMax, false, ThrusterPlatformReferenceRwArrayConfiguration{});
 }
 
 // Assemble the per-cycle inputs from the center-of-mass position and thruster geometry.

--- a/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
+++ b/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
@@ -18,6 +18,7 @@ inline ThrusterPlatformReferenceConfig makeAlignmentConfig(const Eigen::Vector3f
                                                    r_FM_F,
                                                    0.0F,
                                                    0.0F,
+                                                   1.0F,
                                                    theta1Max,
                                                    theta2Max,
                                                    false,
@@ -50,7 +51,7 @@ inline void regressionTestThrusterPlatformReference(const Eigen::Vector3f& sigma
                                                     float accuracy) {
     ThrusterPlatformReferenceAlgorithm alg{makeAlignmentConfig(sigma_MB, r_BM_M, r_FM_F, -1.0F, -1.0F)};
     const ThrusterPlatformReferenceInputs in = makeInputs(r_CB_B, rThrust_F, tHatThrust_F, maxThrust);
-    const ThrusterPlatformReferenceOutput out = alg.update(in, 0);
+    const ThrusterPlatformReferenceOutput out = alg.update(in);
 
     // Recompute the platform geometry from the reported reference angles.
     const Eigen::Matrix3f FM = eulerAngles123ToDcm(Eigen::Vector3f(out.theta1, out.theta2, 0.0F));
@@ -99,7 +100,7 @@ inline void propertyOutputsFinite(const Eigen::Vector3f& sigma_MB,
     }
 
     ThrusterPlatformReferenceAlgorithm alg{makeAlignmentConfig(sigma_MB, r_BM_M, r_FM_F, -1.0F, -1.0F)};
-    const ThrusterPlatformReferenceOutput out = alg.update(makeInputs(r_CB_B, rThrust_F, tHatThrust_F, maxThrust), 0);
+    const ThrusterPlatformReferenceOutput out = alg.update(makeInputs(r_CB_B, rThrust_F, tHatThrust_F, maxThrust));
 
     EXPECT_TRUE(std::isfinite(out.theta1));
     EXPECT_TRUE(std::isfinite(out.theta2));

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
@@ -102,7 +102,7 @@ void ThrusterPlatformReference::updateState(const uint64_t callTime) {
     this->bodyHeadingOutMsg.write(&bodyHeadingOut, this->moduleID, callTime);
 
     CmdTorqueBodyMsgF32Payload thrusterTorqueOut{};
-    eigenVectorToCArray(out.Lreq_B, thrusterTorqueOut.torqueRequestBody);
+    eigenVectorToCArray(out.Lcomp_B, thrusterTorqueOut.torqueRequestBody);
     this->thrusterTorqueOutMsg.write(&thrusterTorqueOut, this->moduleID, callTime);
 
     THRConfigMsgF32Payload thrusterConfigOut{};

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
@@ -23,16 +23,8 @@ ThrusterPlatformReferenceConfig ThrusterPlatformReference::toConfig() {
         rwConfig.JsList = cArrayToEigenVector(rwConfigParams.JsList);
     }
 
-    return ThrusterPlatformReferenceConfig::create(this->sigma_MB,
-                                                   this->r_BM_M,
-                                                   this->r_FM_F,
-                                                   this->K,
-                                                   this->Ki,
-                                                   this->controlPeriod,
-                                                   this->theta1Max,
-                                                   this->theta2Max,
-                                                   momentumDumping,
-                                                   rwConfig);
+    return ThrusterPlatformReferenceConfig::create(
+        this->sigma_MB, this->r_BM_M, this->r_FM_F, this->K, this->Ki, this->controlPeriod, momentumDumping, rwConfig);
 }
 
 /*! This method performs a complete reset of the module: it validates the required input messages and (re)creates
@@ -71,8 +63,8 @@ void ThrusterPlatformReference::reInitialize() {
     this->algorithm->reInitialize();
 }
 
-/*! This method computes the reference platform tip and tilt angles that align the thruster with the system center of
- mass (optionally offset to dump reaction wheel momentum) and writes the platform, body-heading, thruster-torque and
+/*! This method computes the platform reference orientation that aligns the thruster line of action with the system
+ center of mass (optionally offset to dump reaction wheel momentum) and writes the body-heading, thruster-torque and
  thruster-configuration output messages.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
@@ -96,16 +88,6 @@ void ThrusterPlatformReference::updateState(const uint64_t callTime) {
     }
 
     const ThrusterPlatformReferenceOutput out = this->algorithm->update(inputs);
-
-    HingedRigidBodyMsgF32Payload hingedRigidBodyRef1Out{};
-    hingedRigidBodyRef1Out.theta = out.theta1;
-    hingedRigidBodyRef1Out.thetaDot = 0.0F;
-    this->hingedRigidBodyRef1OutMsg.write(&hingedRigidBodyRef1Out, this->moduleID, callTime);
-
-    HingedRigidBodyMsgF32Payload hingedRigidBodyRef2Out{};
-    hingedRigidBodyRef2Out.theta = out.theta2;
-    hingedRigidBodyRef2Out.thetaDot = 0.0F;
-    this->hingedRigidBodyRef2OutMsg.write(&hingedRigidBodyRef2Out, this->moduleID, callTime);
 
     // the body-frame thrust heading equals the body-frame thrust unit direction
     BodyHeadingMsgF32Payload bodyHeadingOut{};

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
@@ -70,9 +70,9 @@ void ThrusterPlatformReference::reInitialize() {
     this->algorithm->reInitialize();
 }
 
-/*! This method computes the platform reference orientation that aligns the thruster line of action with the system
- center of mass (optionally offset to dump reaction wheel momentum) and writes the body-heading, thruster-torque and
- thruster-configuration output messages.
+/*! This method computes the platform reference orientation that points the thruster line of action through the
+ system center of mass (or produces a torque to dump reaction-wheel momentum) and writes the body-heading,
+ thruster-torque and thruster-configuration output messages.
  @return void
  @param callTime The clock time at which the function was called (nanoseconds)
 */

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
@@ -23,8 +23,15 @@ ThrusterPlatformReferenceConfig ThrusterPlatformReference::toConfig() {
         rwConfig.JsList = cArrayToEigenVector(rwConfigParams.JsList);
     }
 
-    return ThrusterPlatformReferenceConfig::create(
-        this->sigma_MB, this->r_BM_M, this->r_FM_F, this->K, this->Ki, this->controlPeriod, momentumDumping, rwConfig);
+    return ThrusterPlatformReferenceConfig::create(this->sigma_MB,
+                                                   this->r_BM_M,
+                                                   this->r_FM_F,
+                                                   this->K,
+                                                   this->Ki,
+                                                   this->controlPeriod,
+                                                   this->thetaMax,
+                                                   momentumDumping,
+                                                   rwConfig);
 }
 
 /*! This method performs a complete reset of the module: it validates the required input messages and (re)creates

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
@@ -106,8 +106,9 @@ void ThrusterPlatformReference::updateState(const uint64_t callTime) {
     hingedRigidBodyRef2Out.thetaDot = 0.0F;
     this->hingedRigidBodyRef2OutMsg.write(&hingedRigidBodyRef2Out, this->moduleID, callTime);
 
+    // the body-frame thrust heading equals the body-frame thrust unit direction
     BodyHeadingMsgF32Payload bodyHeadingOut{};
-    eigenVectorToCArray(out.rHat_XB_B, bodyHeadingOut.rHat_XB_B);
+    eigenVectorToCArray(out.tHatThrust_B, bodyHeadingOut.rHat_XB_B);
     this->bodyHeadingOutMsg.write(&bodyHeadingOut, this->moduleID, callTime);
 
     CmdTorqueBodyMsgF32Payload thrusterTorqueOut{};

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
@@ -15,7 +15,7 @@ static_assert(kMaxNumRw == RW_EFF_CNT, "THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW m
 ThrusterPlatformReferenceConfig ThrusterPlatformReference::toConfig() {
     const bool momentumDumping = this->rwConfigDataInMsg.isLinked() && this->rwSpeedsInMsg.isLinked();
 
-    ThrusterPlatformReferenceRwArrayConfig rwConfig{};
+    ThrusterPlatformReferenceRwArrayConfiguration rwConfig{};
     if (momentumDumping) {
         const RWArrayConfigMsgF32Payload rwConfigParams = this->rwConfigDataInMsg();
         rwConfig.numRW = static_cast<uint32_t>(rwConfigParams.numRW);
@@ -86,9 +86,9 @@ void ThrusterPlatformReference::updateState(const uint64_t callTime) {
 
     ThrusterPlatformReferenceInputs inputs{};
     inputs.r_CB_B = cArrayToEigenVector3<float>(vehConfigMsgIn.CoM_B);
-    inputs.rThrust_F = cArrayToEigenVector3<float>(thrusterConfigFIn.rThrust_B);
-    inputs.tHatThrust_F = cArrayToEigenVector3<float>(thrusterConfigFIn.tHatThrust_B);
-    inputs.maxThrust = thrusterConfigFIn.maxThrust;
+    inputs.r_TF_F = cArrayToEigenVector3<float>(thrusterConfigFIn.rThrust_B);
+    inputs.tHat_F = cArrayToEigenVector3<float>(thrusterConfigFIn.tHatThrust_B);
+    inputs.thrust = thrusterConfigFIn.maxThrust;
     if (this->rwSpeedsInMsg.isLinked()) {
         const RWSpeedMsgF32Payload rwSpeedMsgIn = this->rwSpeedsInMsg();
         inputs.wheelSpeeds = cArrayToEigenVector(rwSpeedMsgIn.wheelSpeeds);
@@ -108,16 +108,16 @@ void ThrusterPlatformReference::updateState(const uint64_t callTime) {
 
     // the body-frame thrust heading equals the body-frame thrust unit direction
     BodyHeadingMsgF32Payload bodyHeadingOut{};
-    eigenVectorToCArray(out.tHatThrust_B, bodyHeadingOut.rHat_XB_B);
+    eigenVectorToCArray(out.tHat_B, bodyHeadingOut.rHat_XB_B);
     this->bodyHeadingOutMsg.write(&bodyHeadingOut, this->moduleID, callTime);
 
     CmdTorqueBodyMsgF32Payload thrusterTorqueOut{};
-    eigenVectorToCArray(out.torqueRequestBody, thrusterTorqueOut.torqueRequestBody);
+    eigenVectorToCArray(out.Lreq_B, thrusterTorqueOut.torqueRequestBody);
     this->thrusterTorqueOutMsg.write(&thrusterTorqueOut, this->moduleID, callTime);
 
     THRConfigMsgF32Payload thrusterConfigOut{};
-    eigenVectorToCArray(out.rThrust_B, thrusterConfigOut.rThrust_B);
-    eigenVectorToCArray(out.tHatThrust_B, thrusterConfigOut.tHatThrust_B);
-    thrusterConfigOut.maxThrust = out.maxThrust;
+    eigenVectorToCArray(out.r_TB_B, thrusterConfigOut.rThrust_B);
+    eigenVectorToCArray(out.tHat_B, thrusterConfigOut.tHatThrust_B);
+    thrusterConfigOut.maxThrust = out.thrust;
     this->thrusterConfigBOutMsg.write(&thrusterConfigOut, this->moduleID, callTime);
 }

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
@@ -28,6 +28,7 @@ ThrusterPlatformReferenceConfig ThrusterPlatformReference::toConfig() {
                                                    this->r_FM_F,
                                                    this->K,
                                                    this->Ki,
+                                                   this->controlPeriod,
                                                    this->theta1Max,
                                                    this->theta2Max,
                                                    momentumDumping,
@@ -94,7 +95,7 @@ void ThrusterPlatformReference::updateState(const uint64_t callTime) {
         inputs.wheelSpeeds = cArrayToEigenVector(rwSpeedMsgIn.wheelSpeeds);
     }
 
-    const ThrusterPlatformReferenceOutput out = this->algorithm->update(inputs, callTime);
+    const ThrusterPlatformReferenceOutput out = this->algorithm->update(inputs);
 
     HingedRigidBodyMsgF32Payload hingedRigidBodyRef1Out{};
     hingedRigidBodyRef1Out.theta = out.theta1;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.h
@@ -3,7 +3,6 @@
 
 #include "msgPayloadDef/BodyHeadingMsgF32Payload.h"
 #include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
-#include "msgPayloadDef/HingedRigidBodyMsgF32Payload.h"
 #include "msgPayloadDef/RWArrayConfigMsgF32Payload.h"
 #include "msgPayloadDef/RWSpeedMsgF32Payload.h"
 #include "msgPayloadDef/THRConfigMsgF32Payload.h"
@@ -35,8 +34,6 @@ class ThrusterPlatformReference final : public SysModel {
     float K{};                     //!< momentum dumping proportional gain [1/s]
     float Ki{};                    //!< momentum dumping integral gain [1]
     float controlPeriod{};         //!< integration step for the momentum dumping integral [s] (must be > 0)
-    float theta1Max{};             //!< absolute bound on tip angle [rad]
-    float theta2Max{};             //!< absolute bound on tilt angle [rad]
 
     /*! module IO interfaces */
     ReadFunctor<VehicleConfigMsgF32Payload>
@@ -44,10 +41,6 @@ class ThrusterPlatformReference final : public SysModel {
     ReadFunctor<THRConfigMsgF32Payload> thrusterConfigFInMsg;   //!< input thruster configuration msg
     ReadFunctor<RWSpeedMsgF32Payload> rwSpeedsInMsg;            //!< input reaction wheel speeds message
     ReadFunctor<RWArrayConfigMsgF32Payload> rwConfigDataInMsg;  //!< input RWA configuration message
-    Message<HingedRigidBodyMsgF32Payload>
-        hingedRigidBodyRef1OutMsg;  //!< output msg containing theta1 reference and thetaDot1 reference
-    Message<HingedRigidBodyMsgF32Payload>
-        hingedRigidBodyRef2OutMsg;  //!< output msg containing theta2 reference and thetaDot2 reference
     Message<BodyHeadingMsgF32Payload>
         bodyHeadingOutMsg;  //!< output msg containing the thrust heading in body frame coordinates
     Message<CmdTorqueBodyMsgF32Payload>

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.h
@@ -34,6 +34,7 @@ class ThrusterPlatformReference final : public SysModel {
         Eigen::Vector3f::Zero()};  //!< position of F frame origin w.r.t. M frame origin, in F frame coordinates
     float K{};                     //!< momentum dumping proportional gain [1/s]
     float Ki{};                    //!< momentum dumping integral gain [1]
+    float controlPeriod{};         //!< integration step for the momentum dumping integral [s] (must be > 0)
     float theta1Max{};             //!< absolute bound on tip angle [rad]
     float theta2Max{};             //!< absolute bound on tilt angle [rad]
 

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.h
@@ -34,6 +34,7 @@ class ThrusterPlatformReference final : public SysModel {
     float K{};                     //!< momentum dumping proportional gain [1/s]
     float Ki{};                    //!< momentum dumping integral gain [1]
     float controlPeriod{};         //!< integration step for the momentum dumping integral [s] (must be > 0)
+    float thetaMax{};              //!< half-angle of the thrust-deflection cone [rad] (must be in (0, pi))
 
     /*! module IO interfaces */
     ReadFunctor<VehicleConfigMsgF32Payload>

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -163,10 +163,10 @@ makes the thruster dump the momentum accumulated on the wheels. The desired thru
 where :math:`\boldsymbol{h}_w` is the net momentum on the wheels, :math:`\boldsymbol{H}_w` its integral over time,
 and :math:`\kappa` (``K``) / :math:`\kappa_I` (``Ki``) the proportional and integral gains. The integral is
 accumulated with a trapezoidal rule using the configured ``controlPeriod`` as the fixed time step (the module is
-expected to run at that rate). The torque is evaluated in the mount frame, converted to the platform frame using the
-nominal zero-torque pointing, and passed to the *Thruster pointing* solve above; because that solve reaches the
-requested torque exactly, the thruster produces :math:`\boldsymbol{L}_\text{req}` (up to the component along the
-thrust, which no thruster force can produce).
+expected to run at that rate). The momentum and its integral are tracked in the body frame; the torque is converted
+to the platform frame (through the mount frame, using the nominal zero-torque pointing) and passed to the *Thruster
+pointing* solve above; because that solve reaches the requested torque exactly, the thruster produces
+:math:`\boldsymbol{L}_\text{req}` (up to the component along the thrust, which no thruster force can produce).
 
 Deflection cone limit
 ^^^^^^^^^^^^^^^^^^^^^

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -82,15 +82,16 @@ Electric Thruster" <http://hanspeterschaub.info/Papers/Calaon2023a.pdf>`__.
 
 The algorithm computes a direction cosine matrix :math:`[\mathcal{FM}]` that describes the reference rotation
 between the platform frame :math:`\mathcal{F}` and the mount frame :math:`\mathcal{M}`, chosen so that the thruster
-line of action passes through the system's center of mass. The input parameters allow specifying offsets between the
-origin :math:`M` of the hub-fixed mount frame :math:`\mathcal{M}` and the origin :math:`F` of the platform-fixed
-frame :math:`\mathcal{F}`, the application point of the thruster force in the :math:`\mathcal{F}` frame, and the
-direction, in :math:`\mathcal{F}`-frame coordinates, of the thrust vector.
+produces a requested torque about the system's center of mass (a zero requested torque points the thruster line of
+action through the center of mass). The input parameters allow specifying offsets between the origin :math:`M` of the
+hub-fixed mount frame :math:`\mathcal{M}` and the origin :math:`F` of the platform-fixed frame :math:`\mathcal{F}`,
+the application point of the thruster force in the :math:`\mathcal{F}` frame, and the direction, in
+:math:`\mathcal{F}`-frame coordinates, of the thrust vector.
 
 Platform reference rotation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The reference DCM :math:`[\mathcal{FM}]` is the single rotation that aligns the thruster line of action with the
-system center of mass (derived below). The relevant geometry is first assembled in the mount and platform frames:
+The reference DCM :math:`[\mathcal{FM}]` is the single rotation that makes the thruster produce the requested torque
+about the center of mass (derived below). The relevant geometry is first assembled in the mount and platform frames:
 
 .. math::
     {}^\mathcal{M}\boldsymbol{r}_{C/M} = [\mathcal{MB}]\,{}^\mathcal{B}\boldsymbol{r}_{C/B}
@@ -101,61 +102,71 @@ system center of mass (derived below). The relevant geometry is first assembled 
 
 with :math:`[\mathcal{MB}]` built from ``sigma_MB`` and :math:`F` the thrust magnitude.
 
-Thrust-line alignment
-^^^^^^^^^^^^^^^^^^^^^^
-The thrust line of action is fixed in the platform frame as the ray
-:math:`{}^\mathcal{F}\boldsymbol{r}_{T/M} + c\,{}^\mathcal{F}\hat{\boldsymbol{t}}`, with :math:`c \geq 0`. The
-alignment rotation is length preserving, so the rotated center of mass lies on a sphere of radius
-:math:`b = \|\boldsymbol{r}_{C/M}\|` about the joint :math:`M`. Aligning the thrust line through the center of mass
-therefore reduces to intersecting the ray with that sphere,
+Thruster pointing
+^^^^^^^^^^^^^^^^^
+The thruster is fixed in the platform frame, so the torque it produces about the center of mass,
+:math:`\boldsymbol{L} = {}^\mathcal{F}\boldsymbol{r}_{T/C} \times {}^\mathcal{F}\boldsymbol{t}` (moment arm times
+force), depends on the reference rotation only through where the center of mass falls in that frame,
+:math:`{}^\mathcal{F}\boldsymbol{r}_{C/M} = [\mathcal{FM}]\,{}^\mathcal{M}\boldsymbol{r}_{C/M}`. The algorithm
+therefore solves for the platform-frame coordinates the center of mass must have to produce a requested torque
+:math:`{}^\mathcal{F}\boldsymbol{L}_\text{req}` (zero for pure center-of-mass alignment), then takes
+:math:`[\mathcal{FM}]` to be the rotation that carries :math:`{}^\mathcal{M}\boldsymbol{r}_{C/M}` there. Two
+conditions pin that target position :math:`{}^\mathcal{F}\boldsymbol{r}_{Ct/M}`.
+
+First, the requested-torque condition
 
 .. math::
-    \left\| {}^\mathcal{F}\boldsymbol{r}_{T/M} + c\,{}^\mathcal{F}\hat{\boldsymbol{t}} \right\|^2 = b^2,
+    \left( {}^\mathcal{F}\boldsymbol{r}_{T/M} - {}^\mathcal{F}\boldsymbol{r}_{Ct/M} \right)
+        \times {}^\mathcal{F}\boldsymbol{t}
+        = {}^\mathcal{F}\boldsymbol{L}_\text{req}
 
-which, since :math:`\hat{\boldsymbol{t}}` is a unit vector, is a quadratic in :math:`c`,
-
-.. math::
-    c^2 + 2\left(\boldsymbol{r}_{T/M}\cdot\hat{\boldsymbol{t}}\right) c
-        + \left( \|\boldsymbol{r}_{T/M}\|^2 - b^2 \right) = 0,
-
-whose relevant root (taken with the positive square root) is
+confines the target to a line parallel to the thrust (a zero torque gives the thrust line itself; a non-zero torque
+shifts it sideways), whose foot perpendicular to the thrust from the joint :math:`M` is
 
 .. math::
-    c = -\boldsymbol{r}_{T/M}\cdot\hat{\boldsymbol{t}}
-        + \sqrt{\left(\boldsymbol{r}_{T/M}\cdot\hat{\boldsymbol{t}}\right)^2 - \|\boldsymbol{r}_{T/M}\|^2 + b^2}.
+    {}^\mathcal{F}\boldsymbol{r}_\perp =
+        \frac{ {}^\mathcal{F}\boldsymbol{t} \times \left( {}^\mathcal{F}\boldsymbol{r}_{T/M}
+        \times {}^\mathcal{F}\boldsymbol{t} - {}^\mathcal{F}\boldsymbol{L}_\text{req} \right)}
+        {\|{}^\mathcal{F}\boldsymbol{t}\|^2}.
 
-The discriminant equals :math:`b^2 - r_\text{arm}^2`, where
-:math:`r_\text{arm}^2 = \|\boldsymbol{r}_{T/M}\|^2 - (\boldsymbol{r}_{T/M}\cdot\hat{\boldsymbol{t}})^2` is the
-squared moment arm of the thrust line about :math:`M`; a real intersection exists whenever
-:math:`b \geq r_\text{arm}`, i.e. when the center of mass is reachable by the thrust direction. The intersection
-point :math:`{}^\mathcal{F}\boldsymbol{r}_{Ct/M} = {}^\mathcal{F}\boldsymbol{r}_{T/M}
-+ c\,{}^\mathcal{F}\hat{\boldsymbol{t}}` is the target position of the center of mass in the platform frame.
+Second, a rotation cannot change the center of mass's distance from the joint, so the target lies at distance
+:math:`b = \|\boldsymbol{r}_{C/M}\|` from :math:`M`; it is therefore the point of the line at that distance,
 
-The reference rotation :math:`[\mathcal{FM}]` carries :math:`\hat{\boldsymbol{r}}_{C/M}` onto
+.. math::
+    {}^\mathcal{F}\boldsymbol{r}_{Ct/M} = {}^\mathcal{F}\boldsymbol{r}_\perp
+        + \sqrt{b^2 - \|{}^\mathcal{F}\boldsymbol{r}_\perp\|^2}\, {}^\mathcal{F}\hat{\boldsymbol{t}}.
+
+A real intersection exists whenever :math:`b \geq \|\boldsymbol{r}_\perp\|`, i.e. when the requested torque is
+achievable given the available moment arm; for :math:`\boldsymbol{L}_\text{req} = 0` this reduces to the thrust line
+through the center of mass and :math:`\|\boldsymbol{r}_\perp\|` is the thrust moment arm about :math:`M`. Only the
+component of :math:`\boldsymbol{L}_\text{req}` perpendicular to the thrust is achievable (a force produces no torque
+about its own line of action); the parallel component is dropped by the construction.
+
+The reference rotation :math:`[\mathcal{FM}]` then carries :math:`\hat{\boldsymbol{r}}_{C/M}` onto
 :math:`\hat{\boldsymbol{r}}_{Ct/M}` through the separation angle
 :math:`\phi = \arccos\left(\hat{\boldsymbol{r}}_{C/M}\cdot\hat{\boldsymbol{r}}_{Ct/M}\right)` about the axis
 :math:`\hat{\boldsymbol{e}} = \hat{\boldsymbol{r}}_{Ct/M}\times\hat{\boldsymbol{r}}_{C/M}`, encoded as the principal
 rotation vector :math:`\phi\,\hat{\boldsymbol{e}}`. When the two directions are nearly antiparallel the cross
 product is ill-defined and any axis orthogonal to :math:`\hat{\boldsymbol{r}}_{C/M}` is used for the
-:math:`180^\circ` rotation. When the center of mass coincides with the joint (:math:`b \approx 0`) the alignment is
+:math:`180^\circ` rotation. When the center of mass coincides with the joint (:math:`b \approx 0`) the pointing is
 undefined and the identity rotation is returned.
 
 Momentum dumping
 ^^^^^^^^^^^^^^^^
-When the optional reaction-wheel input messages are connected the user can specify the gain :math:`\kappa` (``K``),
-the proportional gain of a control law that computes an offset with respect to the center of mass; this makes the
-thruster apply a torque on the system that dumps the momentum accumulated on the wheels. The control law is:
+When the optional reaction-wheel input messages are connected, the requested torque is set by a control law that
+makes the thruster dump the momentum accumulated on the wheels. The desired thruster torque opposes that momentum,
 
 .. math::
-    \boldsymbol{d} = -\frac{1}{t^2} \boldsymbol{t} \times(\kappa \boldsymbol{h}_w + \kappa_I \boldsymbol{H}_w)
+    \boldsymbol{L}_\text{req} = -\left( \kappa\, \boldsymbol{h}_w + \kappa_I\, \boldsymbol{H}_w \right), \qquad
+    \boldsymbol{H}_w = \int_{t_0}^t \boldsymbol{h}_w \,\text{d}t,
 
-where :math:`\boldsymbol{h}_w` is the momentum on the wheels and :math:`\boldsymbol{H}_w` its integral over time:
-
-.. math::
-    \boldsymbol{H}_w = \int_{t_0}^t \boldsymbol{h}_w \text{d}t.
-
-The integral is accumulated with a trapezoidal rule using the configured ``controlPeriod`` as the fixed time step
-(the module is expected to run at that rate).
+where :math:`\boldsymbol{h}_w` is the net momentum on the wheels, :math:`\boldsymbol{H}_w` its integral over time,
+and :math:`\kappa` (``K``) / :math:`\kappa_I` (``Ki``) the proportional and integral gains. The integral is
+accumulated with a trapezoidal rule using the configured ``controlPeriod`` as the fixed time step (the module is
+expected to run at that rate). The torque is evaluated in the mount frame, converted to the platform frame using the
+nominal zero-torque pointing, and passed to the *Thruster pointing* solve above; because that solve reaches the
+requested torque exactly, the thruster produces :math:`\boldsymbol{L}_\text{req}` (up to the component along the
+thrust, which no thruster force can produce).
 
 Deflection cone limit
 ^^^^^^^^^^^^^^^^^^^^^
@@ -267,10 +278,12 @@ then add the module to the simulation task (``reset()`` validates and builds the
 
 Module Assumptions and Limitations
 ----------------------------------
-The reference rotation exists only when the thruster line of action can reach the center of mass, i.e. when the
-thrust moment arm about the joint :math:`M` does not exceed the distance :math:`b` from the joint to the center of
-mass (the ray-sphere discriminant in *Thrust-line alignment* is non-negative). When the center of mass coincides
-with the joint the reference rotation is undefined and the identity rotation is returned. When the alignment would
-require deflecting the thruster beyond the configured cone half-angle :math:`\theta_\text{max}`, the reference is
-clamped to the cone (see *Deflection cone limit*); in that case the thruster is not aligned through the center of
-mass and the reported net torque is non-zero.
+The requested torque is achievable only when the target center-of-mass line reaches the sphere of radius :math:`b`
+about the joint :math:`M`, i.e. when :math:`b \geq \|\boldsymbol{r}_\perp\|` (see *Thruster pointing*); for the
+zero-torque case this is just the requirement that the thruster line of action can reach the center of mass. When the
+center of mass coincides with the joint the pointing is undefined and the identity rotation is returned. When the
+solution would require deflecting the thruster beyond the configured cone half-angle :math:`\theta_\text{max}`, the
+reference is clamped to the cone (see *Deflection cone limit*); in that case the thruster does not produce the
+requested torque exactly. The desired-torque control law is converted from the mount frame to the platform frame
+using the nominal zero-torque pointing, a one-step approximation whose small residual is absorbed by the
+per-cycle momentum-dumping feedback loop.

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -1,12 +1,12 @@
 Executive Summary
 -----------------
-This module computes a reference orientation for a dual-gimballed platform connected to the main hub. The platform
-can only perform a tip-and-tilt type of rotation, and therefore one degree of freedom is blocked. A thruster is
-mounted on the platform, whose direction is known in platform-frame coordinates. The goal of this module is to
-compute a reference orientation for the platform which aligns the thruster direction with the system's center of
-mass, to zero the net torque produced by the thruster on the spacecraft. Alternatively, the module can offset the
-thrust direction with respect to the center of mass to produce a net torque that dumps the momentum accumulated on
-the reaction wheels.
+This module computes a reference orientation for a platform connected to the main hub, on which a thruster is
+mounted whose direction is known in platform-frame coordinates. The goal of this module is to compute a reference
+orientation for the platform which aligns the thruster line of action with the system's center of mass, to zero the
+net torque produced by the thruster on the spacecraft. Alternatively, the module can offset the thrust direction
+with respect to the center of mass to produce a net torque that dumps the momentum accumulated on the reaction
+wheels. The module reports the resulting thruster direction in body-frame coordinates; a downstream module is
+responsible for computing the platform gimbal angles that realize it.
 
 All numeric computation is single-precision (``float`` / fp32). The module is a single algorithm
 (``ThrusterPlatformReferenceAlgorithm``) with two interface adapters: a ``SysModel`` adapter that connects it to
@@ -61,12 +61,6 @@ information on what this message is used for.
     * - rwSpeedsInMsg
       - :ref:`RWSpeedMsgPayload`
       - Optional input message containing the speeds of the reaction wheels relative to the hub.
-    * - hingedRigidBodyRef1OutMsg
-      - :ref:`HingedRigidBodyMsgPayload`
-      - Output message containing the reference angle (and zero angle rate) for the tip angle.
-    * - hingedRigidBodyRef2OutMsg
-      - :ref:`HingedRigidBodyMsgPayload`
-      - Output message containing the reference angle (and zero angle rate) for the tilt angle.
     * - bodyHeadingOutMsg
       - :ref:`BodyHeadingMsgPayload`
       - Output message containing the unit direction vector of the thruster in body-frame coordinates.
@@ -86,25 +80,17 @@ A detailed mathematical derivation of the equations implemented in this module c
 `R. Calaon, L. Kiner, C. Allard and H. Schaub, "Momentum Management of a Spacecraft equipped with a Dual-Gimballed
 Electric Thruster" <http://hanspeterschaub.info/Papers/Calaon2023a.pdf>`__.
 
-The algorithm computes a direction cosine matrix :math:`[\mathcal{FM}]` that describes the rotation between the
-platform frame :math:`\mathcal{F}` and the mount frame :math:`\mathcal{M}`. To be compliant with the constraint in
-the motion of the platform, i.e. the dual gimbal, such frame must have a zero in the element (2,1). When such
-condition is met, the reference angles computed from the DCM allow the thruster to align through the system's
-center of mass. The input parameters allow specifying offsets between the origin :math:`M` of the hub-fixed mount
-frame :math:`\mathcal{M}` and the origin :math:`F` of the platform-fixed frame :math:`\mathcal{F}`, the application
-point of the thruster force in the :math:`\mathcal{F}` frame, and the direction, in :math:`\mathcal{F}`-frame
-coordinates, of the thrust vector.
+The algorithm computes a direction cosine matrix :math:`[\mathcal{FM}]` that describes the reference rotation
+between the platform frame :math:`\mathcal{F}` and the mount frame :math:`\mathcal{M}`, chosen so that the thruster
+line of action passes through the system's center of mass. The input parameters allow specifying offsets between the
+origin :math:`M` of the hub-fixed mount frame :math:`\mathcal{M}` and the origin :math:`F` of the platform-fixed
+frame :math:`\mathcal{F}`, the application point of the thruster force in the :math:`\mathcal{F}` frame, and the
+direction, in :math:`\mathcal{F}`-frame coordinates, of the thrust vector.
 
 Platform reference rotation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The reference DCM is built as the product of two rotations,
-
-.. math::
-    [\mathcal{FM}] = [\mathcal{F}_3\mathcal{F}_2][\mathcal{F}_2\mathcal{M}],
-
-where :math:`[\mathcal{F}_2\mathcal{M}]` aligns the thruster line of action with the system center of mass and
-:math:`[\mathcal{F}_3\mathcal{F}_2]` rotates about that aligned axis to satisfy the tip-and-tilt kinematic
-constraint. The relevant geometry is first assembled in the mount and platform frames:
+The reference DCM :math:`[\mathcal{FM}]` is the single rotation that aligns the thruster line of action with the
+system center of mass (derived below). The relevant geometry is first assembled in the mount and platform frames:
 
 .. math::
     {}^\mathcal{M}\boldsymbol{r}_{C/M} = [\mathcal{MB}]\,{}^\mathcal{B}\boldsymbol{r}_{C/B}
@@ -145,7 +131,7 @@ squared moment arm of the thrust line about :math:`M`; a real intersection exist
 point :math:`{}^\mathcal{F}\boldsymbol{r}_{Ct/M} = {}^\mathcal{F}\boldsymbol{r}_{T/M}
 + c\,{}^\mathcal{F}\hat{\boldsymbol{t}}` is the target position of the center of mass in the platform frame.
 
-The alignment rotation :math:`[\mathcal{F}_2\mathcal{M}]` carries :math:`\hat{\boldsymbol{r}}_{C/M}` onto
+The reference rotation :math:`[\mathcal{FM}]` carries :math:`\hat{\boldsymbol{r}}_{C/M}` onto
 :math:`\hat{\boldsymbol{r}}_{Ct/M}` through the separation angle
 :math:`\phi = \arccos\left(\hat{\boldsymbol{r}}_{C/M}\cdot\hat{\boldsymbol{r}}_{Ct/M}\right)` about the axis
 :math:`\hat{\boldsymbol{e}} = \hat{\boldsymbol{r}}_{Ct/M}\times\hat{\boldsymbol{r}}_{C/M}`, encoded as the principal
@@ -169,26 +155,13 @@ where :math:`\boldsymbol{h}_w` is the momentum on the wheels and :math:`\boldsym
     \boldsymbol{H}_w = \int_{t_0}^t \boldsymbol{h}_w \text{d}t.
 
 The integral is accumulated with a trapezoidal rule using the configured ``controlPeriod`` as the fixed time step
-(the module is expected to run at that rate). The inputs ``theta1Max`` and ``theta2Max`` bound the output reference
-angles for the platform. If there are no
-mechanical bounds, setting these inputs to a non-positive value bypasses the routine that bounds these angles.
-
-Reference angle extraction
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The tip and tilt reference angles :math:`\nu_{1R}` and :math:`\nu_{2R}` are extracted from the final DCM according
-to:
-
-.. math::
-    \begin{align}
-        \nu_{1R} &= \arctan \left( \frac{f_{23}}{f_{22}} \right) &
-        \nu_{2R} &= \arctan \left( \frac{f_{31}}{f_{11}} \right)
-    \end{align}
+(the module is expected to run at that rate).
 
 Body-frame outputs
 ^^^^^^^^^^^^^^^^^^
 The body-frame outputs are resolved from the platform frame through the composite direction cosine matrix
 :math:`[\mathcal{FB}] = [\mathcal{FM}][\mathcal{MB}]`, where :math:`[\mathcal{MB}]` is built from ``sigma_MB`` and
-:math:`[\mathcal{FM}]` is rebuilt from the (bounded) reference angles. The thrust unit direction in body-frame
+:math:`[\mathcal{FM}]` is the reference rotation derived above. The thrust unit direction in body-frame
 coordinates is :math:`{}^\mathcal{B}\hat{\boldsymbol{t}} = [\mathcal{FB}]^T {}^\mathcal{F}\hat{\boldsymbol{t}}`
 (written to ``bodyHeadingOutMsg`` and to ``thrusterConfigBOutMsg``), and the thrust application point relative to
 the body-frame origin is :math:`{}^\mathcal{B}\boldsymbol{r}_{T/B} = {}^\mathcal{B}\boldsymbol{r}_{C/B} +
@@ -235,14 +208,6 @@ raises ``fsw::invalid_argument``.
       - 0
       - :math:`> 0`
       - integration time step [s] for the momentum dumping integral (the module update rate)
-    * - ``theta1Max``
-      - 0
-      - finite
-      - absolute bound on the tip angle; a non-positive value disables bounding
-    * - ``theta2Max``
-      - 0
-      - finite
-      - absolute bound on the tilt angle; a non-positive value disables bounding
 
 In addition, when momentum dumping is enabled the reaction-wheel configuration read from ``rwConfigDataInMsg`` must
 have a wheel count not exceeding the compile-time maximum (``RW_EFF_CNT``) and unit-length spin axes (they are
@@ -261,8 +226,6 @@ then add the module to the simulation task (``reset()`` validates and builds the
     platformReference.K = K
     platformReference.Ki = Ki
     platformReference.controlPeriod = controlPeriod
-    platformReference.theta1Max = theta1Max
-    platformReference.theta2Max = theta2Max
 
     platformReference.vehConfigInMsg.subscribeTo(vehConfigMsg)
     platformReference.thrusterConfigFInMsg.subscribeTo(thrConfigFMsg)
@@ -274,10 +237,9 @@ then add the module to the simulation task (``reset()`` validates and builds the
 
 Module Assumptions and Limitations
 ----------------------------------
-As pointed out in the paper referenced above, it is not always guaranteed that a direction cosine matrix exists
-that can satisfy both the pointing requirement on the thrust direction and the kinematic constraint on the
-dual-gimballed platform. When a solution does not exist, a minimum problem is solved to compute the closest
-constraint-incompliant DCM. The tip and tilt reference angles are then extracted from that final DCM without
-checking whether :math:`[\mathcal{FM}]` is constraint compliant. As a result, the angles :math:`\nu_{1R}` and
-:math:`\nu_{2R}` produce a constraint-compliant reference, which however might not align the thruster with the
-desired point in the hub.
+The reference rotation exists only when the thruster line of action can reach the center of mass, i.e. when the
+thrust moment arm about the joint :math:`M` does not exceed the distance :math:`b` from the joint to the center of
+mass (the ray-sphere discriminant in *Thrust-line alignment* is non-negative). When the center of mass coincides
+with the joint the reference rotation is undefined and the identity rotation is returned. The module places no bound
+on the platform deflection required to achieve the alignment; enforcing such a limit is the responsibility of the
+downstream module that converts the reported thruster direction into platform gimbal angles.

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -95,6 +95,67 @@ frame :math:`\mathcal{M}` and the origin :math:`F` of the platform-fixed frame :
 point of the thruster force in the :math:`\mathcal{F}` frame, and the direction, in :math:`\mathcal{F}`-frame
 coordinates, of the thrust vector.
 
+Platform reference rotation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The reference DCM is built as the product of two rotations,
+
+.. math::
+    [\mathcal{FM}] = [\mathcal{F}_3\mathcal{F}_2][\mathcal{F}_2\mathcal{M}],
+
+where :math:`[\mathcal{F}_2\mathcal{M}]` aligns the thruster line of action with the system center of mass and
+:math:`[\mathcal{F}_3\mathcal{F}_2]` rotates about that aligned axis to satisfy the tip-and-tilt kinematic
+constraint. The relevant geometry is first assembled in the mount and platform frames:
+
+.. math::
+    {}^\mathcal{M}\boldsymbol{r}_{C/M} = [\mathcal{MB}]\,{}^\mathcal{B}\boldsymbol{r}_{C/B}
+        + {}^\mathcal{M}\boldsymbol{r}_{B/M}, \qquad
+    {}^\mathcal{F}\boldsymbol{r}_{T/M} = {}^\mathcal{F}\boldsymbol{r}_{F/M} + {}^\mathcal{F}\boldsymbol{r}_{T/F},
+        \qquad
+    {}^\mathcal{F}\boldsymbol{t} = F\,{}^\mathcal{F}\hat{\boldsymbol{t}},
+
+with :math:`[\mathcal{MB}]` built from ``sigma_MB`` and :math:`F` the thrust magnitude.
+
+Thrust-line alignment
+^^^^^^^^^^^^^^^^^^^^^^
+The thrust line of action is fixed in the platform frame as the ray
+:math:`{}^\mathcal{F}\boldsymbol{r}_{T/M} + c\,{}^\mathcal{F}\hat{\boldsymbol{t}}`, with :math:`c \geq 0`. The
+alignment rotation is length preserving, so the rotated center of mass lies on a sphere of radius
+:math:`b = \|\boldsymbol{r}_{C/M}\|` about the joint :math:`M`. Aligning the thrust line through the center of mass
+therefore reduces to intersecting the ray with that sphere,
+
+.. math::
+    \left\| {}^\mathcal{F}\boldsymbol{r}_{T/M} + c\,{}^\mathcal{F}\hat{\boldsymbol{t}} \right\|^2 = b^2,
+
+which, since :math:`\hat{\boldsymbol{t}}` is a unit vector, is a quadratic in :math:`c`,
+
+.. math::
+    c^2 + 2\left(\boldsymbol{r}_{T/M}\cdot\hat{\boldsymbol{t}}\right) c
+        + \left( \|\boldsymbol{r}_{T/M}\|^2 - b^2 \right) = 0,
+
+whose relevant root (taken with the positive square root) is
+
+.. math::
+    c = -\boldsymbol{r}_{T/M}\cdot\hat{\boldsymbol{t}}
+        + \sqrt{\left(\boldsymbol{r}_{T/M}\cdot\hat{\boldsymbol{t}}\right)^2 - \|\boldsymbol{r}_{T/M}\|^2 + b^2}.
+
+The discriminant equals :math:`b^2 - r_\text{arm}^2`, where
+:math:`r_\text{arm}^2 = \|\boldsymbol{r}_{T/M}\|^2 - (\boldsymbol{r}_{T/M}\cdot\hat{\boldsymbol{t}})^2` is the
+squared moment arm of the thrust line about :math:`M`; a real intersection exists whenever
+:math:`b \geq r_\text{arm}`, i.e. when the center of mass is reachable by the thrust direction. The intersection
+point :math:`{}^\mathcal{F}\boldsymbol{r}_{Ct/M} = {}^\mathcal{F}\boldsymbol{r}_{T/M}
++ c\,{}^\mathcal{F}\hat{\boldsymbol{t}}` is the target position of the center of mass in the platform frame.
+
+The alignment rotation :math:`[\mathcal{F}_2\mathcal{M}]` carries :math:`\hat{\boldsymbol{r}}_{C/M}` onto
+:math:`\hat{\boldsymbol{r}}_{Ct/M}` through the separation angle
+:math:`\phi = \arccos\left(\hat{\boldsymbol{r}}_{C/M}\cdot\hat{\boldsymbol{r}}_{Ct/M}\right)` about the axis
+:math:`\hat{\boldsymbol{e}} = \hat{\boldsymbol{r}}_{Ct/M}\times\hat{\boldsymbol{r}}_{C/M}`, encoded as the principal
+rotation vector :math:`\phi\,\hat{\boldsymbol{e}}`. When the two directions are nearly antiparallel the cross
+product is ill-defined and any axis orthogonal to :math:`\hat{\boldsymbol{r}}_{C/M}` is used for the
+:math:`180^\circ` rotation. When the center of mass coincides with the joint (:math:`b \approx 0`) the alignment is
+undefined and the identity rotation is returned.
+
+Momentum dumping
+^^^^^^^^^^^^^^^^
 When the optional reaction-wheel input messages are connected the user can specify the gain :math:`\kappa` (``K``),
 the proportional gain of a control law that computes an offset with respect to the center of mass; this makes the
 thruster apply a torque on the system that dumps the momentum accumulated on the wheels. The control law is:
@@ -112,6 +173,8 @@ The integral is accumulated with a trapezoidal rule using the configured ``contr
 angles for the platform. If there are no
 mechanical bounds, setting these inputs to a non-positive value bypasses the routine that bounds these angles.
 
+Reference angle extraction
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The tip and tilt reference angles :math:`\nu_{1R}` and :math:`\nu_{2R}` are extracted from the final DCM according
 to:
 
@@ -121,6 +184,8 @@ to:
         \nu_{2R} &= \arctan \left( \frac{f_{31}}{f_{11}} \right)
     \end{align}
 
+Body-frame outputs
+^^^^^^^^^^^^^^^^^^
 The body-frame outputs are resolved from the platform frame through the composite direction cosine matrix
 :math:`[\mathcal{FB}] = [\mathcal{FM}][\mathcal{MB}]`, where :math:`[\mathcal{MB}]` is built from ``sigma_MB`` and
 :math:`[\mathcal{FM}]` is rebuilt from the (bounded) reference angles. The thrust unit direction in body-frame

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -290,6 +290,11 @@ zero-torque case this is just the requirement that the thruster line of action c
 center of mass coincides with the joint the pointing is undefined and the identity rotation is returned. When the
 solution would require deflecting the thruster beyond the configured cone half-angle :math:`\theta_\text{max}`, the
 reference is clamped to the cone (see *Deflection cone limit*); in that case the thruster does not produce the
-requested torque exactly. The desired-torque control law is converted from the mount frame to the platform frame
-using the nominal zero-torque pointing, a one-step approximation whose small residual is absorbed by the
-per-cycle momentum-dumping feedback loop.
+requested torque exactly.
+
+The module assumes it is run at a small, fixed control period so that the platform moves little between successive
+calls. Two parts of the momentum-dumping path rely on this: the reaction-wheel momentum is integrated with a
+trapezoidal rule at the fixed ``controlPeriod`` step, and the desired torque is converted into the platform frame
+using the *previous* cycle's pointing (see *Momentum dumping*). Larger inter-cycle motion does not break the pointing
+solve, but it degrades both approximations; the resulting residual is bounded and absorbed by the per-cycle
+momentum-dumping feedback loop.

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -107,8 +107,9 @@ where :math:`\boldsymbol{h}_w` is the momentum on the wheels and :math:`\boldsym
 .. math::
     \boldsymbol{H}_w = \int_{t_0}^t \boldsymbol{h}_w \text{d}t.
 
-The integral is accumulated with a trapezoidal rule using the time step derived from successive call times. The
-inputs ``theta1Max`` and ``theta2Max`` bound the output reference angles for the platform. If there are no
+The integral is accumulated with a trapezoidal rule using the configured ``controlPeriod`` as the fixed time step
+(the module is expected to run at that rate). The inputs ``theta1Max`` and ``theta2Max`` bound the output reference
+angles for the platform. If there are no
 mechanical bounds, setting these inputs to a non-positive value bypasses the routine that bounds these angles.
 
 The tip and tilt reference angles :math:`\nu_{1R}` and :math:`\nu_{2R}` are extracted from the final DCM according
@@ -165,6 +166,10 @@ raises ``fsw::invalid_argument``.
       - 0
       - :math:`\geq 0`
       - integral gain of the momentum dumping control loop
+    * - ``controlPeriod``
+      - 0
+      - :math:`> 0`
+      - integration time step [s] for the momentum dumping integral (the module update rate)
     * - ``theta1Max``
       - 0
       - finite
@@ -190,6 +195,7 @@ then add the module to the simulation task (``reset()`` validates and builds the
     platformReference.r_FM_F = r_FM_F
     platformReference.K = K
     platformReference.Ki = Ki
+    platformReference.controlPeriod = controlPeriod
     platformReference.theta1Max = theta1Max
     platformReference.theta2Max = theta2Max
 

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -157,6 +157,31 @@ where :math:`\boldsymbol{h}_w` is the momentum on the wheels and :math:`\boldsym
 The integral is accumulated with a trapezoidal rule using the configured ``controlPeriod`` as the fixed time step
 (the module is expected to run at that rate).
 
+Deflection cone limit
+^^^^^^^^^^^^^^^^^^^^^
+The reference rotation is finally limited so that the thruster direction stays within a cone of half-angle
+:math:`\theta_\text{max}` (``thetaMax``) about its neutral, un-rotated direction. Let
+:math:`\hat{\boldsymbol{t}}_0 = {}^\mathcal{F}\hat{\boldsymbol{t}}` be the thrust direction at zero deflection
+(:math:`[\mathcal{FM}] = [I]`) and :math:`\hat{\boldsymbol{t}}_r = [\mathcal{FM}]^T {}^\mathcal{F}\hat{\boldsymbol{t}}`
+the thrust direction at the reference orientation, both in mount-frame coordinates. The deflection is
+
+.. math::
+    \delta = \arccos\left( \hat{\boldsymbol{t}}_0 \cdot \hat{\boldsymbol{t}}_r \right).
+
+When :math:`\delta \leq \theta_\text{max}` the reference rotation is left unchanged. Otherwise the aligned thrust
+direction is projected onto the cone by rotating it back toward :math:`\hat{\boldsymbol{t}}_0`, in the plane the two
+directions span, until the deflection equals :math:`\theta_\text{max}`. This is applied to the reference rotation as
+
+.. math::
+    [\mathcal{FM}]' = [\mathcal{FM}]\,[C]^T, \qquad
+    [C] = \text{PRV}\!\left( (\delta - \theta_\text{max})\,
+        \frac{\hat{\boldsymbol{t}}_0 \times \hat{\boldsymbol{t}}_r}{\|\hat{\boldsymbol{t}}_0 \times \hat{\boldsymbol{t}}_r\|} \right),
+
+where :math:`\text{PRV}(\cdot)` denotes the direction cosine matrix of a principal rotation vector. When the aligned
+and neutral directions are nearly antiparallel the rotation plane is ill-defined and an arbitrary axis orthogonal to
+:math:`\hat{\boldsymbol{t}}_0` is used. Because the projection reduces the platform rotation, a clamped reference no
+longer points the thruster exactly through the center of mass, and the resulting net thruster torque is non-zero.
+
 Body-frame outputs
 ^^^^^^^^^^^^^^^^^^
 The body-frame outputs are resolved from the platform frame through the composite direction cosine matrix
@@ -208,6 +233,10 @@ raises ``fsw::invalid_argument``.
       - 0
       - :math:`> 0`
       - integration time step [s] for the momentum dumping integral (the module update rate)
+    * - ``thetaMax``
+      - 0
+      - :math:`(0, \pi)`
+      - half-angle [rad] of the cone limiting the thrust deflection from its neutral direction (mandatory)
 
 In addition, when momentum dumping is enabled the reaction-wheel configuration read from ``rwConfigDataInMsg`` must
 have a wheel count not exceeding the compile-time maximum (``RW_EFF_CNT``) and unit-length spin axes (they are
@@ -226,6 +255,7 @@ then add the module to the simulation task (``reset()`` validates and builds the
     platformReference.K = K
     platformReference.Ki = Ki
     platformReference.controlPeriod = controlPeriod
+    platformReference.thetaMax = thetaMax
 
     platformReference.vehConfigInMsg.subscribeTo(vehConfigMsg)
     platformReference.thrusterConfigFInMsg.subscribeTo(thrConfigFMsg)
@@ -240,6 +270,7 @@ Module Assumptions and Limitations
 The reference rotation exists only when the thruster line of action can reach the center of mass, i.e. when the
 thrust moment arm about the joint :math:`M` does not exceed the distance :math:`b` from the joint to the center of
 mass (the ray-sphere discriminant in *Thrust-line alignment* is non-negative). When the center of mass coincides
-with the joint the reference rotation is undefined and the identity rotation is returned. The module places no bound
-on the platform deflection required to achieve the alignment; enforcing such a limit is the responsibility of the
-downstream module that converts the reported thruster direction into platform gimbal angles.
+with the joint the reference rotation is undefined and the identity rotation is returned. When the alignment would
+require deflecting the thruster beyond the configured cone half-angle :math:`\theta_\text{max}`, the reference is
+clamped to the cone (see *Deflection cone limit*); in that case the thruster is not aligned through the center of
+mass and the reported net torque is non-zero.

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -164,9 +164,15 @@ where :math:`\boldsymbol{h}_w` is the net momentum on the wheels, :math:`\boldsy
 and :math:`\kappa` (``K``) / :math:`\kappa_I` (``Ki``) the proportional and integral gains. The integral is
 accumulated with a trapezoidal rule using the configured ``controlPeriod`` as the fixed time step (the module is
 expected to run at that rate). The momentum and its integral are tracked in the body frame; the torque is converted
-to the platform frame (through the mount frame, using the nominal zero-torque pointing) and passed to the *Thruster
-pointing* solve above; because that solve reaches the requested torque exactly, the thruster produces
-:math:`\boldsymbol{L}_\text{req}` (up to the component along the thrust, which no thruster force can produce).
+to the platform frame (through the mount frame) and passed to the *Thruster pointing* solve above. Because that solve
+reaches the requested torque exactly, the thruster produces :math:`\boldsymbol{L}_\text{req}` (up to the component
+along the thrust, which no thruster force can produce).
+
+Converting the torque to the platform frame needs :math:`[\mathcal{FM}]`, which is the very quantity being solved
+for. The module breaks this circularity by reusing the **previous cycle's** reference DCM as the conversion estimate;
+on the first cycle, where no prior exists, it is seeded once with the nominal (zero-torque) pointing. The resulting
+one-cycle staleness is a small, bounded error that the momentum-dumping feedback loop absorbs, and it lets each cycle
+run a single pointing solve instead of two.
 
 Deflection cone limit
 ^^^^^^^^^^^^^^^^^^^^^

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -11,18 +11,18 @@ namespace {
 constexpr float kZeroTolerance = 1e-6F;  // module tolerance for treating a quantity as zero
 
 /*! Compute the first rotation that makes the thrust direction parallel to the center-of-mass direction. */
-Eigen::Matrix3f tprComputeFirstRotation(const Eigen::Vector3f& THat_F, const Eigen::Vector3f& rHat_CM_F) {
-    float phi = safeAcosf(THat_F.dot(rHat_CM_F));
-    Eigen::Vector3f e_phi = THat_F.cross(rHat_CM_F);
-    // if phi = pi, e_phi can be any vector perpendicular to THat_F
+Eigen::Matrix3f tprComputeFirstRotation(const Eigen::Vector3f& tHat_F, const Eigen::Vector3f& rHat_CM_F) {
+    float phi = safeAcosf(tHat_F.dot(rHat_CM_F));
+    Eigen::Vector3f e_phi = tHat_F.cross(rHat_CM_F);
+    // if phi = pi, e_phi can be any vector perpendicular to tHat_F
     if (fabsf(phi - std::numbers::pi_v<float>) < kZeroTolerance) {
         phi = std::numbers::pi_v<float>;
-        if (fabsf(THat_F(0)) > kZeroTolerance) {
-            e_phi = Eigen::Vector3f(-(THat_F(1) + THat_F(2)) / THat_F(0), 1.0F, 1.0F);
-        } else if (fabsf(THat_F(1)) > kZeroTolerance) {
-            e_phi = Eigen::Vector3f(1.0F, -(THat_F(0) + THat_F(2)) / THat_F(1), 1.0F);
+        if (fabsf(tHat_F(0)) > kZeroTolerance) {
+            e_phi = Eigen::Vector3f(-(tHat_F(1) + tHat_F(2)) / tHat_F(0), 1.0F, 1.0F);
+        } else if (fabsf(tHat_F(1)) > kZeroTolerance) {
+            e_phi = Eigen::Vector3f(1.0F, -(tHat_F(0) + tHat_F(2)) / tHat_F(1), 1.0F);
         } else {
-            e_phi = Eigen::Vector3f(1.0F, 1.0F, -(THat_F(0) + THat_F(1)) / THat_F(2));
+            e_phi = Eigen::Vector3f(1.0F, 1.0F, -(tHat_F(0) + tHat_F(1)) / tHat_F(2));
         }
     } else if (fabsf(phi) < kZeroTolerance) {
         phi = 0.0F;
@@ -36,14 +36,14 @@ Eigen::Matrix3f tprComputeFirstRotation(const Eigen::Vector3f& THat_F, const Eig
 Eigen::Matrix3f tprComputeSecondRotation(const Eigen::Vector3f& r_CM_F,
                                          const Eigen::Vector3f& r_TM_F,
                                          const Eigen::Vector3f& r_CT_F,
-                                         const Eigen::Vector3f& THat_F) {
+                                         const Eigen::Vector3f& tHat_F) {
     const float a = r_TM_F.norm();
     const float b = r_CM_F.norm();
     const float c1 = r_CT_F.norm();
 
     float psi = 0.0F;
     if (fabsf(a) >= kZeroTolerance) {
-        const float beta = safeAcosf(-r_TM_F.dot(THat_F) / a);
+        const float beta = safeAcosf(-r_TM_F.dot(tHat_F) / a);
         const float nu = safeAcosf(-r_TM_F.dot(r_CT_F) / (a * c1));
         const float c2 = (a * safeCosf(beta)) + safeSqrtf((b * b) - (a * a * safeSinf(beta) * safeSinf(beta)));
         const float cosGamma1 = ((a * a) + (b * b) - (c1 * c1)) / (2.0F * a * b);
@@ -51,21 +51,22 @@ Eigen::Matrix3f tprComputeSecondRotation(const Eigen::Vector3f& r_CM_F,
         psi = safeAsinf(((c1 * safeSinf(nu) * cosGamma2) - (c2 * safeSinf(beta) * cosGamma1)) / b);
     }
 
-    Eigen::Vector3f e_psi = THat_F.cross(r_CT_F);
+    Eigen::Vector3f e_psi = tHat_F.cross(r_CT_F);
     e_psi.normalize();
     const Eigen::Vector3f prv = psi * e_psi;
     return prvToDcm(prv);
 }
 
 /*! Compute the third rotation making the frame compliant with the tip-and-tilt platform constraint. */
-Eigen::Matrix3f tprComputeThirdRotation(const Eigen::Vector3f& e_theta, const Eigen::Matrix3f& F2M) {
+Eigen::Matrix3f tprComputeThirdRotation(const Eigen::Vector3f& e_theta, const Eigen::Matrix3f& dcm_F2M) {
     const float e1 = e_theta(0);
     const float e2 = e_theta(1);
     const float e3 = e_theta(2);
 
-    const float A = (2.0F * ((F2M(1, 0) * e2 * e2) + (F2M(0, 0) * e1 * e2) + (F2M(2, 0) * e2 * e3))) - F2M(1, 0);
-    const float B = 2.0F * ((F2M(2, 0) * e1) - (F2M(0, 0) * e3));
-    const float C = F2M(1, 0);
+    const float A =
+        (2.0F * ((dcm_F2M(1, 0) * e2 * e2) + (dcm_F2M(0, 0) * e1 * e2) + (dcm_F2M(2, 0) * e2 * e3))) - dcm_F2M(1, 0);
+    const float B = 2.0F * ((dcm_F2M(2, 0) * e1) - (dcm_F2M(0, 0) * e3));
+    const float C = dcm_F2M(1, 0);
     const float Delta = (B * B) - (4.0F * A * C);
 
     float theta = 0.0F;
@@ -110,18 +111,18 @@ Eigen::Matrix3f tprComputeThirdRotation(const Eigen::Vector3f& e_theta, const Ei
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- the vectors are distinct by frame and documented.
 Eigen::Matrix3f tprComputeFinalRotation(const Eigen::Vector3f& r_CM_M,
                                         const Eigen::Vector3f& r_TM_F,
-                                        const Eigen::Vector3f& T_F) {
-    const Eigen::Vector3f THat_F = T_F.normalized();
+                                        const Eigen::Vector3f& thrust_F) {
+    const Eigen::Vector3f tHat_F = thrust_F.normalized();
     const Eigen::Vector3f rHat_CM_F = r_CM_M.normalized();  // assume zero initial rotation between F and M
 
-    const Eigen::Matrix3f F1M = tprComputeFirstRotation(THat_F, rHat_CM_F);
-    const Eigen::Vector3f r_CM_F = F1M * r_CM_M;
+    const Eigen::Matrix3f dcm_F1M = tprComputeFirstRotation(tHat_F, rHat_CM_F);
+    const Eigen::Vector3f r_CM_F = dcm_F1M * r_CM_M;
     const Eigen::Vector3f r_CT_F = r_CM_F - r_TM_F;
-    const Eigen::Matrix3f F2F1 = tprComputeSecondRotation(r_CM_F, r_TM_F, r_CT_F, THat_F);
-    const Eigen::Matrix3f F2M = F2F1 * F1M;
-    const Eigen::Vector3f e_theta = (F2M * r_CM_M).normalized();
-    const Eigen::Matrix3f F3F2 = tprComputeThirdRotation(e_theta, F2M);
-    return F3F2 * F2M;
+    const Eigen::Matrix3f dcm_F2F1 = tprComputeSecondRotation(r_CM_F, r_TM_F, r_CT_F, tHat_F);
+    const Eigen::Matrix3f dcm_F2M = dcm_F2F1 * dcm_F1M;
+    const Eigen::Vector3f e_theta = (dcm_F2M * r_CM_M).normalized();
+    const Eigen::Matrix3f dcm_F3F2 = tprComputeThirdRotation(e_theta, dcm_F2M);
+    return dcm_F3F2 * dcm_F2M;
 }
 }  // namespace
 
@@ -159,23 +160,23 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
                                                                            const uint64_t callTime) {
     ThrusterPlatformReferenceOutput out{};
 
-    const Eigen::Matrix3f MB = mrpToDcm(this->cfg.getSigma_MB());   // B to M DCM
-    const Eigen::Vector3f r_CB_M = MB * in.r_CB_B;                  // position of C w.r.t. B in M-frame coordinates
-    const Eigen::Vector3f r_CM_M = r_CB_M + this->cfg.getR_BM_M();  // position of C w.r.t. M in M-frame coordinates
-    const Eigen::Vector3f r_TM_F = this->cfg.getR_FM_F() + in.rThrust_F;  // position of T w.r.t. M, F coordinates
-    const Eigen::Vector3f T_F = in.maxThrust * in.tHatThrust_F;           // thrust vector in F-frame coordinates
+    const Eigen::Matrix3f dcm_MB = mrpToDcm(this->cfg.getSigma_MB());  // B to M DCM
+    const Eigen::Vector3f r_CB_M = dcm_MB * in.r_CB_B;                 // position of C w.r.t. B in M-frame coordinates
+    const Eigen::Vector3f r_CM_M = r_CB_M + this->cfg.getR_BM_M();     // position of C w.r.t. M in M-frame coordinates
+    const Eigen::Vector3f r_TM_F = this->cfg.getR_FM_F() + in.r_TF_F;  // position of T w.r.t. M, F coordinates
+    const Eigen::Vector3f thrust_F = in.thrust * in.tHat_F;            // thrust vector in F-frame coordinates
 
-    Eigen::Matrix3f FM = tprComputeFinalRotation(r_CM_M, r_TM_F, T_F);
+    Eigen::Matrix3f dcm_FM = tprComputeFinalRotation(r_CM_M, r_TM_F, thrust_F);
 
     if (this->cfg.getMomentumDumping()) {
-        const ThrusterPlatformReferenceRwArrayConfig& rwConfig = this->cfg.getRwConfig();
+        const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig = this->cfg.getRwConfig();
 
         // compute net RW momentum in body frame
         Eigen::Vector3f hs_B = Eigen::Vector3f::Zero();
         for (uint32_t i = 0; i < rwConfig.numRW; ++i) {
             hs_B += rwConfig.JsList(i) * in.wheelSpeeds(i) * rwConfig.GsMatrix_B.col(i);
         }
-        const Eigen::Vector3f hs_M = MB * hs_B;
+        const Eigen::Vector3f hs_M = dcm_MB * hs_B;
 
         // update the trapezoidal integral of the RW momentum (dt is zero on the first call)
         const float dt = (this->priorTime == 0) ? 0.0F : static_cast<float>(callTime - this->priorTime) * kNano2SecF;
@@ -184,20 +185,20 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
         this->priorTime = callTime;
 
         // compute the offset vector that shifts the effective CM to produce the desired dumping torque
-        const Eigen::Vector3f T_M = FM.transpose() * T_F;
-        Eigen::Vector3f H = this->cfg.getK() * hs_M;
+        const Eigen::Vector3f thrust_M = dcm_FM.transpose() * thrust_F;
+        Eigen::Vector3f H_M = this->cfg.getK() * hs_M;
         if (this->cfg.getKi() > 0.0F) {
-            H += this->cfg.getKi() * this->hsInt_M;
+            H_M += this->cfg.getKi() * this->hsInt_M;
         }
-        const Eigen::Vector3f d_M = -1.0F / T_M.dot(T_M) * T_M.cross(H);
+        const Eigen::Vector3f d_M = -1.0F / thrust_M.dot(thrust_M) * thrust_M.cross(H_M);
 
         // recompute the platform rotation about the offset CM
-        const Eigen::Vector3f r_CMd_M = r_CM_M + d_M;
-        FM = tprComputeFinalRotation(r_CMd_M, r_TM_F, T_F);
+        const Eigen::Vector3f r_CdM_M = r_CM_M + d_M;
+        dcm_FM = tprComputeFinalRotation(r_CdM_M, r_TM_F, thrust_F);
     }
 
-    float theta1 = safeAtan2f(FM(1, 2), FM(1, 1));
-    float theta2 = safeAtan2f(FM(2, 0), FM(0, 0));
+    float theta1 = safeAtan2f(dcm_FM(1, 2), dcm_FM(1, 1));
+    float theta2 = safeAtan2f(dcm_FM(2, 0), dcm_FM(0, 0));
 
     // bound the reference angles between the allowed limits
     const float theta1Max = this->cfg.getTheta1Max();
@@ -214,25 +215,25 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
     }
 
     // rebuild the platform DCM with the bounded angles
-    FM = eulerAngles123ToDcm(Eigen::Vector3f(theta1, theta2, 0.0F));
+    dcm_FM = eulerAngles123ToDcm(Eigen::Vector3f(theta1, theta2, 0.0F));
 
     out.theta1 = theta1;
     out.theta2 = theta2;
 
     // mapping between the final platform frame and the body frame
-    const Eigen::Matrix3f FB = FM * MB;
+    const Eigen::Matrix3f dcm_FB = dcm_FM * dcm_MB;
 
     // thruster torque on the system in body frame coordinates
-    const Eigen::Vector3f r_CM_F = FM * r_CM_M;
+    const Eigen::Vector3f r_CM_F = dcm_FM * r_CM_M;
     const Eigen::Vector3f r_TC_F = r_TM_F - r_CM_F;
-    const Eigen::Vector3f Torque_F = T_F.cross(r_TC_F);
-    out.torqueRequestBody = FB.transpose() * Torque_F;
+    const Eigen::Vector3f Lreq_F = thrust_F.cross(r_TC_F);
+    out.Lreq_B = dcm_FB.transpose() * Lreq_F;
 
     // thruster configuration in body frame coordinates
-    const Eigen::Vector3f r_TC_B = FB.transpose() * r_TC_F;
-    out.rThrust_B = in.r_CB_B + r_TC_B;
-    out.tHatThrust_B = (FB.transpose() * T_F).normalized();
-    out.maxThrust = T_F.norm();
+    const Eigen::Vector3f r_TC_B = dcm_FB.transpose() * r_TC_F;
+    out.r_TB_B = in.r_CB_B + r_TC_B;
+    out.tHat_B = (dcm_FB.transpose() * thrust_F).normalized();
+    out.thrust = thrust_F.norm();
 
     return out;
 }

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -222,9 +222,6 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
     // mapping between the final platform frame and the body frame
     const Eigen::Matrix3f FB = FM * MB;
 
-    // thruster direction in body frame coordinates
-    out.rHat_XB_B = (FB.transpose() * T_F).normalized();
-
     // thruster torque on the system in body frame coordinates
     const Eigen::Vector3f r_CM_F = FM * r_CM_M;
     const Eigen::Vector3f r_TC_F = r_TM_F - r_CM_F;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -84,8 +84,8 @@ void ThrusterPlatformReferenceAlgorithm::setConfig(const ThrusterPlatformReferen
 
 /*! @brief Re-seed the runtime integrator state (RW momentum integral, prior sample) to its initial values. */
 void ThrusterPlatformReferenceAlgorithm::reInitialize() {
-    this->hsInt_M.setZero();
-    this->priorHs_M.setZero();
+    this->hsInt_B.setZero();
+    this->priorHs_B.setZero();
 }
 
 /*! This method computes the platform reference orientation that points the thruster line of action through the
@@ -115,17 +115,16 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
         for (uint32_t i = 0; i < rwConfig.numRW; ++i) {
             hs_B += rwConfig.JsList(i) * in.wheelSpeeds(i) * rwConfig.GsMatrix_B.col(i);
         }
-        const Eigen::Vector3f hs_M = dcm_MB * hs_B;
 
         // update the trapezoidal integral of the RW momentum using the fixed control period as the time step
         const float dt = this->cfg.getControlPeriod();
-        this->hsInt_M += 0.5F * dt * (this->priorHs_M + hs_M);
-        this->priorHs_M = hs_M;
+        this->hsInt_B += 0.5F * dt * (this->priorHs_B + hs_B);
+        this->priorHs_B = hs_B;
 
         // desired thruster torque about the center of mass: oppose the accumulated wheel momentum to dump it.
-        // Converted into the platform frame with the nominal zero-torque pointing, then re-point to produce it.
-        const Eigen::Vector3f Lreq_M = -this->cfg.getK() * hs_M - this->cfg.getKi() * this->hsInt_M;
-        const Eigen::Vector3f Lreq_F = dcm_FM * Lreq_M;
+        // Converted from the body frame into the platform frame (via the nominal zero-torque pointing) to re-point.
+        const Eigen::Vector3f Lreq_B = -this->cfg.getK() * hs_B - this->cfg.getKi() * this->hsInt_B;
+        const Eigen::Vector3f Lreq_F = dcm_FM * dcm_MB * Lreq_B;
         dcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Lreq_F);
     }
 

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -5,7 +5,6 @@
 
 #include "utilities/fsw/rigidBodyKinematics.hpp"
 #include "utilities/fsw/safeMath.h"
-#include "utilities/fsw/timeConstants.h"
 
 namespace {
 constexpr float kZeroTolerance = 1e-6F;  // module tolerance for treating a quantity as zero
@@ -146,7 +145,6 @@ void ThrusterPlatformReferenceAlgorithm::setConfig(const ThrusterPlatformReferen
 void ThrusterPlatformReferenceAlgorithm::reInitialize() {
     this->hsInt_M.setZero();
     this->priorHs_M.setZero();
-    this->priorTime = 0;
 }
 
 /*! This method computes the reference platform tip and tilt angles that align the thruster with the system center of
@@ -154,10 +152,8 @@ void ThrusterPlatformReferenceAlgorithm::reInitialize() {
  thruster-configuration quantities.
  @return ThrusterPlatformReferenceOutput reference angles and derived body-frame thruster quantities
  @param in per-cycle inputs read from the input messages
- @param callTime The clock time at which the function was called (nanoseconds)
 */
-ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const ThrusterPlatformReferenceInputs& in,
-                                                                           const uint64_t callTime) {
+ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const ThrusterPlatformReferenceInputs& in) {
     ThrusterPlatformReferenceOutput out{};
 
     const Eigen::Matrix3f dcm_MB = mrpToDcm(this->cfg.getSigma_MB());  // B to M DCM
@@ -178,11 +174,10 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
         }
         const Eigen::Vector3f hs_M = dcm_MB * hs_B;
 
-        // update the trapezoidal integral of the RW momentum (dt is zero on the first call)
-        const float dt = (this->priorTime == 0) ? 0.0F : static_cast<float>(callTime - this->priorTime) * kNano2SecF;
+        // update the trapezoidal integral of the RW momentum using the fixed control period as the time step
+        const float dt = this->cfg.getControlPeriod();
         this->hsInt_M += 0.5F * dt * (this->priorHs_M + hs_M);
         this->priorHs_M = hs_M;
-        this->priorTime = callTime;
 
         // compute the offset vector that shifts the effective CM to produce the desired dumping torque
         const Eigen::Vector3f thrust_M = dcm_FM.transpose() * thrust_F;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -82,10 +82,11 @@ void ThrusterPlatformReferenceAlgorithm::setConfig(const ThrusterPlatformReferen
     this->cfg = config;
 }
 
-/*! @brief Re-seed the runtime integrator state (RW momentum integral, prior sample) to its initial values. */
+/*! @brief Re-seed the runtime state (RW momentum integral, prior sample, prior pointing DCM) to its initial values. */
 void ThrusterPlatformReferenceAlgorithm::reInitialize() {
     this->hsInt_B.setZero();
     this->priorHs_B.setZero();
+    this->priorDcm_FM.setZero();
 }
 
 /*! This method computes the platform reference orientation that points the thruster line of action through the
@@ -104,8 +105,7 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
     const Eigen::Vector3f thrust_F = in.thrust * in.tHat_F;            // thrust vector in F-frame coordinates
     const Eigen::Vector3f tHat_F = thrust_F.normalized();              // thrust unit direction, F frame
 
-    // zero-torque pointing: align the thruster line of action through the center of mass
-    Eigen::Matrix3f dcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Eigen::Vector3f::Zero());
+    Eigen::Vector3f Lreq_F = Eigen::Vector3f::Zero();  // requested torque, platform frame (zero -> point through CM)
 
     if (this->cfg.getMomentumDumping()) {
         const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig = this->cfg.getRwConfig();
@@ -122,14 +122,21 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
         this->priorHs_B = hs_B;
 
         // desired thruster torque about the center of mass: oppose the accumulated wheel momentum to dump it.
-        // Converted from the body frame into the platform frame (via the nominal zero-torque pointing) to re-point.
         const Eigen::Vector3f Lreq_B = -this->cfg.getK() * hs_B - this->cfg.getKi() * this->hsInt_B;
-        const Eigen::Vector3f Lreq_F = dcm_FM * dcm_MB * Lreq_B;
-        dcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Lreq_F);
+
+        // Torque is converted from the body frame into the platform frame using the previous cycle's pointing; on the
+        // first cycle there is no prior, so seed it once with the nominal zero-torque pointing.
+        if (this->priorDcm_FM.isZero()) {
+            this->priorDcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Eigen::Vector3f::Zero());
+        }
+        Lreq_F = this->priorDcm_FM * dcm_MB * Lreq_B;
     }
+
+    Eigen::Matrix3f dcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Lreq_F);
 
     // limit the thrust deflection to the configured cone about its neutral direction
     dcm_FM = clampThrustDeflection(dcm_FM, tHat_F, this->cfg.getThetaMax());
+    this->priorDcm_FM = dcm_FM;  // save for the next cycle's torque conversion
 
     // mapping between the final platform frame and the body frame
     const Eigen::Matrix3f dcm_FB = dcm_FM * dcm_MB;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -37,69 +37,6 @@ Eigen::Matrix3f alignThrustLine(const Eigen::Vector3f& r_CM_M,
 
     return prvToDcm(prv_FM);
 }
-
-/*! Compute the third rotation making the frame compliant with the tip-and-tilt platform constraint. */
-Eigen::Matrix3f tprComputeThirdRotation(const Eigen::Vector3f& e_theta, const Eigen::Matrix3f& dcm_F2M) {
-    const float e1 = e_theta(0);
-    const float e2 = e_theta(1);
-    const float e3 = e_theta(2);
-
-    const float A =
-        (2.0F * ((dcm_F2M(1, 0) * e2 * e2) + (dcm_F2M(0, 0) * e1 * e2) + (dcm_F2M(2, 0) * e2 * e3))) - dcm_F2M(1, 0);
-    const float B = 2.0F * ((dcm_F2M(2, 0) * e1) - (dcm_F2M(0, 0) * e3));
-    const float C = dcm_F2M(1, 0);
-    const float Delta = (B * B) - (4.0F * A * C);
-
-    float theta = 0.0F;
-    if (fabsf(A) < kZeroTolerance) {
-        if (fabsf(B) < kZeroTolerance) {
-            // zero-th order equation has no solution; the minimum problem is solved by theta = pi
-            theta = std::numbers::pi_v<float>;
-        } else {
-            // first order equation
-            theta = 2.0F * safeAtanf(-C / B);
-        }
-    } else if (Delta < 0.0F) {
-        // second order equation has no solution; find the best solution of the minimum problem
-        float t = 0.0F;
-        if (fabsf(B) >= kZeroTolerance) {
-            const float q = (A - C) / B;
-            const float t1 = q + safeSqrtf((q * q) + 1.0F);
-            const float t2 = q - safeSqrtf((q * q) + 1.0F);
-            const float y1 = ((A * t1 * t1) + (B * t1) + C) / (1.0F + (t1 * t1));
-            const float y2 = ((A * t2 * t2) + (B * t2) + C) / (1.0F + (t2 * t2));
-            // choose the root that yields the smaller function value
-            t = (fabsf(y2) < fabsf(y1)) ? t2 : t1;
-        }
-        theta = 2.0F * safeAtanf(t);
-        const float y = ((A * t * t) + (B * t) + C) / (1.0F + (t * t));
-        // check whether the absolute function minimum is at theta = pi
-        if (fabsf(A) < fabsf(y)) {
-            theta = std::numbers::pi_v<float>;
-        }
-    } else {
-        const float t1 = (-B + safeSqrtf(Delta)) / (2.0F * A);
-        const float t2 = (-B - safeSqrtf(Delta)) / (2.0F * A);
-        const float t = (fabsf(t2) < fabsf(t1)) ? t2 : t1;
-        theta = 2.0F * safeAtanf(t);
-    }
-
-    const Eigen::Vector3f prv = theta * e_theta;
-    return prvToDcm(prv);
-}
-
-/*! Compose the rotations into the platform-frame DCM that aligns the thruster with the center of mass. */
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- the vectors are distinct by frame and documented.
-Eigen::Matrix3f tprComputeFinalRotation(const Eigen::Vector3f& r_CM_M,
-                                        const Eigen::Vector3f& r_TM_F,
-                                        const Eigen::Vector3f& thrust_F) {
-    const Eigen::Vector3f tHat_F = thrust_F.normalized();
-
-    const Eigen::Matrix3f dcm_F2M = alignThrustLine(r_CM_M, r_TM_F, tHat_F);
-    const Eigen::Vector3f e_theta = (dcm_F2M * r_CM_M).normalized();
-    const Eigen::Matrix3f dcm_F3F2 = tprComputeThirdRotation(e_theta, dcm_F2M);
-    return dcm_F3F2 * dcm_F2M;
-}
 }  // namespace
 
 /*! @brief Construct the algorithm with a validated configuration and seed the runtime integrator state.
@@ -124,10 +61,10 @@ void ThrusterPlatformReferenceAlgorithm::reInitialize() {
     this->priorHs_M.setZero();
 }
 
-/*! This method computes the reference platform tip and tilt angles that align the thruster with the system center of
- mass (optionally offset to dump reaction wheel momentum) and the associated body-heading, thruster-torque and
- thruster-configuration quantities.
- @return ThrusterPlatformReferenceOutput reference angles and derived body-frame thruster quantities
+/*! This method computes the platform reference orientation that aligns the thruster line of action with the system
+ center of mass (optionally offset to dump reaction wheel momentum) and the associated body-heading, thruster-torque
+ and thruster-configuration quantities.
+ @return ThrusterPlatformReferenceOutput derived body-frame thruster quantities
  @param in per-cycle inputs read from the input messages
 */
 ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const ThrusterPlatformReferenceInputs& in) {
@@ -138,8 +75,9 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
     const Eigen::Vector3f r_CM_M = r_CB_M + this->cfg.getR_BM_M();     // position of C w.r.t. M in M-frame coordinates
     const Eigen::Vector3f r_TM_F = this->cfg.getR_FM_F() + in.r_TF_F;  // position of T w.r.t. M, F coordinates
     const Eigen::Vector3f thrust_F = in.thrust * in.tHat_F;            // thrust vector in F-frame coordinates
+    const Eigen::Vector3f tHat_F = thrust_F.normalized();              // thrust unit direction, F frame
 
-    Eigen::Matrix3f dcm_FM = tprComputeFinalRotation(r_CM_M, r_TM_F, thrust_F);
+    Eigen::Matrix3f dcm_FM = alignThrustLine(r_CM_M, r_TM_F, tHat_F);
 
     if (this->cfg.getMomentumDumping()) {
         const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig = this->cfg.getRwConfig();
@@ -163,31 +101,8 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
 
         // recompute the platform rotation about the offset CM
         const Eigen::Vector3f r_CdM_M = r_CM_M + d_M;
-        dcm_FM = tprComputeFinalRotation(r_CdM_M, r_TM_F, thrust_F);
+        dcm_FM = alignThrustLine(r_CdM_M, r_TM_F, tHat_F);
     }
-
-    float theta1 = safeAtan2f(dcm_FM(1, 2), dcm_FM(1, 1));
-    float theta2 = safeAtan2f(dcm_FM(2, 0), dcm_FM(0, 0));
-
-    // bound the reference angles between the allowed limits
-    const float theta1Max = this->cfg.getTheta1Max();
-    const float theta2Max = this->cfg.getTheta2Max();
-    if ((theta1Max > kZeroTolerance) && (theta1 > theta1Max)) {
-        theta1 = theta1Max;
-    } else if ((theta1Max > kZeroTolerance) && (theta1 < -theta1Max)) {
-        theta1 = -theta1Max;
-    }
-    if ((theta2Max > kZeroTolerance) && (theta2 > theta2Max)) {
-        theta2 = theta2Max;
-    } else if ((theta2Max > kZeroTolerance) && (theta2 < -theta2Max)) {
-        theta2 = -theta2Max;
-    }
-
-    // rebuild the platform DCM with the bounded angles
-    dcm_FM = eulerAngles123ToDcm(Eigen::Vector3f(theta1, theta2, 0.0F));
-
-    out.theta1 = theta1;
-    out.theta2 = theta2;
 
     // mapping between the final platform frame and the body frame
     const Eigen::Matrix3f dcm_FB = dcm_FM * dcm_MB;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -10,21 +10,27 @@ namespace {
 constexpr float kZeroTolerance = 1e-6F;  // module tolerance for treating a quantity as zero
 constexpr float kSmallAngle = 1e-3F;     // small angle tolerance [rad]
 
-/*! Compute the platform rotation [FM] aligning the thruster line of action with the system center of mass. */
+/*! Compute the platform rotation [FM] that points the thruster so it produces the requested torque Lreq_F (the
+ thruster torque about the system center of mass, r_TC x thrust) on the body. A zero requested torque aligns the
+ thruster line of action through the center of mass. */
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- the vectors are distinct by frame and documented.
-Eigen::Matrix3f alignThrustLine(const Eigen::Vector3f& r_CM_M,
-                                const Eigen::Vector3f& r_TM_F,
-                                const Eigen::Vector3f& tHat_F) {
+Eigen::Matrix3f computeThrusterPointing(const Eigen::Vector3f& r_CM_M,
+                                        const Eigen::Vector3f& r_TM_F,
+                                        const Eigen::Vector3f& thrust_F,
+                                        const Eigen::Vector3f& Lreq_F) {
     Eigen::Vector3f prv_FM = Eigen::Vector3f::Zero();  // zero rotation when the center of mass coincides with the joint
 
-    const float b = r_CM_M.norm();
+    const float b = r_CM_M.norm();  // distance from the joint M to the center of mass (unchanged by any rotation)
     if (b >= kZeroTolerance) {
-        // thrust-ray / center-of-mass-sphere intersection (positive square-root branch)
-        const float rt = r_TM_F.dot(tHat_F);
-        const float ct = -rt + safeSqrtf((rt * rt) - r_TM_F.squaredNorm() + (b * b));
-        const Eigen::Vector3f r_CtM_F = r_TM_F + (ct * tHat_F);
+        const Eigen::Vector3f tHat_F = thrust_F.normalized();
 
-        // rotate r_CM_M onto the intersection point about the cross-product axis
+        // perpendicular arm (in F frame) of the requested-torque line: the CoM positions (in F frame) that give Lreq_F
+        const Eigen::Vector3f r_lineM_F = thrust_F.cross(r_TM_F.cross(thrust_F) - Lreq_F) / thrust_F.squaredNorm();
+        // r_CtM_F: intersect that line with the distance-b locus (arm r_lineM_F plus an offset along the thrust)
+        const float distAlongThrust = safeSqrtf((b * b) - r_lineM_F.squaredNorm());
+        const Eigen::Vector3f r_CtM_F = r_lineM_F + (distAlongThrust * tHat_F);
+
+        // shortest rotation carrying r_CM_M onto r_CtM_F, about their cross-product axis
         const Eigen::Vector3f rHat_CM_M = r_CM_M.stableNormalized();
         const Eigen::Vector3f rHat_CtM_F = r_CtM_F.stableNormalized();
         const float angle = safeAcosf(rHat_CM_M.dot(rHat_CtM_F));
@@ -82,9 +88,9 @@ void ThrusterPlatformReferenceAlgorithm::reInitialize() {
     this->priorHs_M.setZero();
 }
 
-/*! This method computes the platform reference orientation that aligns the thruster line of action with the system
- center of mass (optionally offset to dump reaction wheel momentum) and the associated body-heading, thruster-torque
- and thruster-configuration quantities.
+/*! This method computes the platform reference orientation that points the thruster line of action through the
+ system center of mass (or produces a torque to dump reaction-wheel momentum) and the associated body-heading,
+ thruster-torque and thruster-configuration quantities.
  @return ThrusterPlatformReferenceOutput derived body-frame thruster quantities
  @param in per-cycle inputs read from the input messages
 */
@@ -98,7 +104,8 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
     const Eigen::Vector3f thrust_F = in.thrust * in.tHat_F;            // thrust vector in F-frame coordinates
     const Eigen::Vector3f tHat_F = thrust_F.normalized();              // thrust unit direction, F frame
 
-    Eigen::Matrix3f dcm_FM = alignThrustLine(r_CM_M, r_TM_F, tHat_F);
+    // zero-torque pointing: align the thruster line of action through the center of mass
+    Eigen::Matrix3f dcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Eigen::Vector3f::Zero());
 
     if (this->cfg.getMomentumDumping()) {
         const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig = this->cfg.getRwConfig();
@@ -115,14 +122,11 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
         this->hsInt_M += 0.5F * dt * (this->priorHs_M + hs_M);
         this->priorHs_M = hs_M;
 
-        // compute the offset vector that shifts the effective CM to produce the desired dumping torque
-        const Eigen::Vector3f thrust_M = dcm_FM.transpose() * thrust_F;
-        const Eigen::Vector3f H_M = (this->cfg.getK() * hs_M) + (this->cfg.getKi() * this->hsInt_M);
-        const Eigen::Vector3f d_M = -1.0F / thrust_M.dot(thrust_M) * thrust_M.cross(H_M);
-
-        // recompute the platform rotation about the offset CM
-        const Eigen::Vector3f r_CdM_M = r_CM_M + d_M;
-        dcm_FM = alignThrustLine(r_CdM_M, r_TM_F, tHat_F);
+        // desired thruster torque about the center of mass: oppose the accumulated wheel momentum to dump it.
+        // Converted into the platform frame with the nominal zero-torque pointing, then re-point to produce it.
+        const Eigen::Vector3f Lreq_M = -this->cfg.getK() * hs_M - this->cfg.getKi() * this->hsInt_M;
+        const Eigen::Vector3f Lreq_F = dcm_FM * Lreq_M;
+        dcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Lreq_F);
     }
 
     // limit the thrust deflection to the configured cone about its neutral direction
@@ -131,11 +135,11 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
     // mapping between the final platform frame and the body frame
     const Eigen::Matrix3f dcm_FB = dcm_FM * dcm_MB;
 
-    // thruster torque on the system in body frame coordinates
+    // achieved thruster torque on the system in body frame coordinates (can be different from requested due to clamp)
     const Eigen::Vector3f r_CM_F = dcm_FM * r_CM_M;
     const Eigen::Vector3f r_TC_F = r_TM_F - r_CM_F;
-    const Eigen::Vector3f Lreq_F = thrust_F.cross(r_TC_F);
-    out.Lreq_B = dcm_FB.transpose() * Lreq_F;
+    const Eigen::Vector3f torque_F = thrust_F.cross(r_TC_F);
+    out.Lreq_B = dcm_FB.transpose() * torque_F;
 
     // thruster configuration in body frame coordinates
     const Eigen::Vector3f r_TC_B = dcm_FB.transpose() * r_TC_F;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -186,10 +186,7 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
 
         // compute the offset vector that shifts the effective CM to produce the desired dumping torque
         const Eigen::Vector3f thrust_M = dcm_FM.transpose() * thrust_F;
-        Eigen::Vector3f H_M = this->cfg.getK() * hs_M;
-        if (this->cfg.getKi() > 0.0F) {
-            H_M += this->cfg.getKi() * this->hsInt_M;
-        }
+        const Eigen::Vector3f H_M = (this->cfg.getK() * hs_M) + (this->cfg.getKi() * this->hsInt_M);
         const Eigen::Vector3f d_M = -1.0F / thrust_M.dot(thrust_M) * thrust_M.cross(H_M);
 
         // recompute the platform rotation about the offset CM

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -8,52 +8,34 @@
 
 namespace {
 constexpr float kZeroTolerance = 1e-6F;  // module tolerance for treating a quantity as zero
+constexpr float kSmallAngle = 1e-3F;     // small angle tolerance [rad]
 
-/*! Compute the first rotation that makes the thrust direction parallel to the center-of-mass direction. */
-Eigen::Matrix3f tprComputeFirstRotation(const Eigen::Vector3f& tHat_F, const Eigen::Vector3f& rHat_CM_F) {
-    float phi = safeAcosf(tHat_F.dot(rHat_CM_F));
-    Eigen::Vector3f e_phi = tHat_F.cross(rHat_CM_F);
-    // if phi = pi, e_phi can be any vector perpendicular to tHat_F
-    if (fabsf(phi - std::numbers::pi_v<float>) < kZeroTolerance) {
-        phi = std::numbers::pi_v<float>;
-        if (fabsf(tHat_F(0)) > kZeroTolerance) {
-            e_phi = Eigen::Vector3f(-(tHat_F(1) + tHat_F(2)) / tHat_F(0), 1.0F, 1.0F);
-        } else if (fabsf(tHat_F(1)) > kZeroTolerance) {
-            e_phi = Eigen::Vector3f(1.0F, -(tHat_F(0) + tHat_F(2)) / tHat_F(1), 1.0F);
-        } else {
-            e_phi = Eigen::Vector3f(1.0F, 1.0F, -(tHat_F(0) + tHat_F(1)) / tHat_F(2));
-        }
-    } else if (fabsf(phi) < kZeroTolerance) {
-        phi = 0.0F;
-    }
-    e_phi.normalize();
-    const Eigen::Vector3f prv = phi * e_phi;
-    return prvToDcm(prv);
-}
+/*! Compute the platform rotation [FM] aligning the thruster line of action with the system center of mass. */
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- the vectors are distinct by frame and documented.
+Eigen::Matrix3f alignThrustLine(const Eigen::Vector3f& r_CM_M,
+                                const Eigen::Vector3f& r_TM_F,
+                                const Eigen::Vector3f& tHat_F) {
+    Eigen::Vector3f prv_FM = Eigen::Vector3f::Zero();  // zero rotation when the center of mass coincides with the joint
 
-/*! Compute the second rotation that zeroes the offset between the thrust direction and the CM-to-thruster vector. */
-Eigen::Matrix3f tprComputeSecondRotation(const Eigen::Vector3f& r_CM_F,
-                                         const Eigen::Vector3f& r_TM_F,
-                                         const Eigen::Vector3f& r_CT_F,
-                                         const Eigen::Vector3f& tHat_F) {
-    const float a = r_TM_F.norm();
-    const float b = r_CM_F.norm();
-    const float c1 = r_CT_F.norm();
+    const float b = r_CM_M.norm();
+    if (b >= kZeroTolerance) {
+        // thrust-ray / center-of-mass-sphere intersection (positive square-root branch)
+        const float rt = r_TM_F.dot(tHat_F);
+        const float ct = -rt + safeSqrtf((rt * rt) - r_TM_F.squaredNorm() + (b * b));
+        const Eigen::Vector3f r_CtM_F = r_TM_F + (ct * tHat_F);
 
-    float psi = 0.0F;
-    if (fabsf(a) >= kZeroTolerance) {
-        const float beta = safeAcosf(-r_TM_F.dot(tHat_F) / a);
-        const float nu = safeAcosf(-r_TM_F.dot(r_CT_F) / (a * c1));
-        const float c2 = (a * safeCosf(beta)) + safeSqrtf((b * b) - (a * a * safeSinf(beta) * safeSinf(beta)));
-        const float cosGamma1 = ((a * a) + (b * b) - (c1 * c1)) / (2.0F * a * b);
-        const float cosGamma2 = ((a * a) + (b * b) - (c2 * c2)) / (2.0F * a * b);
-        psi = safeAsinf(((c1 * safeSinf(nu) * cosGamma2) - (c2 * safeSinf(beta) * cosGamma1)) / b);
+        // rotate r_CM_M onto the intersection point about the cross-product axis
+        const Eigen::Vector3f rHat_CM_M = r_CM_M.stableNormalized();
+        const Eigen::Vector3f rHat_CtM_F = r_CtM_F.stableNormalized();
+        const float angle = safeAcosf(rHat_CM_M.dot(rHat_CtM_F));
+
+        const Eigen::Vector3f e_axis = (std::numbers::pi_v<float> - angle < kSmallAngle)
+                                           ? rHat_CM_M.unitOrthogonal()  // nearly opposite: any orthogonal axis
+                                           : rHat_CtM_F.cross(rHat_CM_M);
+        prv_FM = angle * e_axis.stableNormalized();
     }
 
-    Eigen::Vector3f e_psi = tHat_F.cross(r_CT_F);
-    e_psi.normalize();
-    const Eigen::Vector3f prv = psi * e_psi;
-    return prvToDcm(prv);
+    return prvToDcm(prv_FM);
 }
 
 /*! Compute the third rotation making the frame compliant with the tip-and-tilt platform constraint. */
@@ -106,19 +88,14 @@ Eigen::Matrix3f tprComputeThirdRotation(const Eigen::Vector3f& e_theta, const Ei
     return prvToDcm(prv);
 }
 
-/*! Compose the three rotations into the platform-frame DCM that aligns the thruster with the center of mass. */
+/*! Compose the rotations into the platform-frame DCM that aligns the thruster with the center of mass. */
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- the vectors are distinct by frame and documented.
 Eigen::Matrix3f tprComputeFinalRotation(const Eigen::Vector3f& r_CM_M,
                                         const Eigen::Vector3f& r_TM_F,
                                         const Eigen::Vector3f& thrust_F) {
     const Eigen::Vector3f tHat_F = thrust_F.normalized();
-    const Eigen::Vector3f rHat_CM_F = r_CM_M.normalized();  // assume zero initial rotation between F and M
 
-    const Eigen::Matrix3f dcm_F1M = tprComputeFirstRotation(tHat_F, rHat_CM_F);
-    const Eigen::Vector3f r_CM_F = dcm_F1M * r_CM_M;
-    const Eigen::Vector3f r_CT_F = r_CM_F - r_TM_F;
-    const Eigen::Matrix3f dcm_F2F1 = tprComputeSecondRotation(r_CM_F, r_TM_F, r_CT_F, tHat_F);
-    const Eigen::Matrix3f dcm_F2M = dcm_F2F1 * dcm_F1M;
+    const Eigen::Matrix3f dcm_F2M = alignThrustLine(r_CM_M, r_TM_F, tHat_F);
     const Eigen::Vector3f e_theta = (dcm_F2M * r_CM_M).normalized();
     const Eigen::Matrix3f dcm_F3F2 = tprComputeThirdRotation(e_theta, dcm_F2M);
     return dcm_F3F2 * dcm_F2M;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -37,6 +37,27 @@ Eigen::Matrix3f alignThrustLine(const Eigen::Vector3f& r_CM_M,
 
     return prvToDcm(prv_FM);
 }
+
+/*! Clamp the reference rotation so the thrust deflection from its neutral direction stays within the cone of
+ half-angle thetaMax. */
+Eigen::Matrix3f clampThrustDeflection(const Eigen::Matrix3f& dcm_FM, const Eigen::Vector3f& tHat_F, float thetaMax) {
+    const Eigen::Vector3f& tHatNeutral_M = tHat_F;                  // neutral thrust direction (F == M), M coordinates
+    const Eigen::Vector3f tHatRef_M = dcm_FM.transpose() * tHat_F;  // reference thrust direction, M coordinates
+    const float deflection = safeAcosf(tHatNeutral_M.dot(tHatRef_M));
+
+    Eigen::Matrix3f dcm_FcM = dcm_FM;  // clamped platform reference frame Fc; equals [FM] while within the cone
+    if (deflection > thetaMax) {
+        // rotate the platform reference from the aligned frame F to the clamped frame Fc, removing the excess
+        // deflection (deflection - thetaMax) so the thrust lands on the cone.
+        Eigen::Vector3f prvAxis_F = dcm_FM * (tHatRef_M.cross(tHatNeutral_M));
+        if (std::numbers::pi_v<float> - deflection < kSmallAngle) {
+            prvAxis_F = tHat_F.unitOrthogonal();  // nearly opposite: any orthogonal axis
+        }
+        const Eigen::Vector3f prv_FcF_F = (deflection - thetaMax) * prvAxis_F.stableNormalized();
+        dcm_FcM = prvToDcm(prv_FcF_F) * dcm_FM;
+    }
+    return dcm_FcM;
+}
 }  // namespace
 
 /*! @brief Construct the algorithm with a validated configuration and seed the runtime integrator state.
@@ -103,6 +124,9 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
         const Eigen::Vector3f r_CdM_M = r_CM_M + d_M;
         dcm_FM = alignThrustLine(r_CdM_M, r_TM_F, tHat_F);
     }
+
+    // limit the thrust deflection to the configured cone about its neutral direction
+    dcm_FM = clampThrustDeflection(dcm_FM, tHat_F, this->cfg.getThetaMax());
 
     // mapping between the final platform frame and the body frame
     const Eigen::Matrix3f dcm_FB = dcm_FM * dcm_MB;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -66,6 +66,41 @@ Eigen::Matrix3f clampThrustDeflection(const Eigen::Matrix3f& dcm_FM, const Eigen
 }
 }  // namespace
 
+/*! @brief Advance the RW momentum integrator and return the momentum-dumping torque request in the platform frame.
+ The desired thruster torque opposes the accumulated reaction-wheel momentum. It is converted from the body frame to
+ the platform frame using the previous cycle's pointing, seeded once with the nominal pointing on the first cycle.
+ @return requested thruster torque, platform-frame coordinates
+*/
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- the vectors are distinct by frame and documented.
+Eigen::Vector3f ThrusterPlatformReferenceAlgorithm::computeDumpingTorque(const ThrusterPlatformReferenceInputs& in,
+                                                                         const Eigen::Vector3f& r_CM_M,
+                                                                         const Eigen::Vector3f& r_TM_F,
+                                                                         const Eigen::Vector3f& thrust_F,
+                                                                         const Eigen::Matrix3f& dcm_MB) {
+    const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig = this->cfg.getRwConfig();
+
+    // compute net RW momentum in body frame
+    Eigen::Vector3f hs_B = Eigen::Vector3f::Zero();
+    for (uint32_t i = 0; i < rwConfig.numRW; ++i) {
+        hs_B += rwConfig.JsList(i) * in.wheelSpeeds(i) * rwConfig.GsMatrix_B.col(i);
+    }
+
+    // update the trapezoidal integral of the RW momentum using the fixed control period as the time step
+    const float dt = this->cfg.getControlPeriod();
+    this->hsInt_B += 0.5F * dt * (this->priorHs_B + hs_B);
+    this->priorHs_B = hs_B;
+
+    // desired thruster torque about the center of mass: oppose the accumulated wheel momentum to dump it.
+    const Eigen::Vector3f Lreq_B = -this->cfg.getK() * hs_B - this->cfg.getKi() * this->hsInt_B;
+
+    // Torque is converted from the body frame into the platform frame using the previous cycle's pointing; on the
+    // first cycle there is no prior, so seed it once with the nominal zero-torque pointing.
+    if (this->priorDcm_FM.isZero()) {
+        this->priorDcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Eigen::Vector3f::Zero());
+    }
+    return this->priorDcm_FM * dcm_MB * Lreq_B;
+}
+
 /*! @brief Construct the algorithm with a validated configuration and seed the runtime integrator state.
  @param config Validated configuration (geometry, gains, angle bounds, RW configuration).
 */
@@ -105,31 +140,10 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
     const Eigen::Vector3f thrust_F = in.thrust * in.tHat_F;            // thrust vector in F-frame coordinates
     const Eigen::Vector3f tHat_F = thrust_F.normalized();              // thrust unit direction, F frame
 
-    Eigen::Vector3f Lreq_F = Eigen::Vector3f::Zero();  // requested torque, platform frame (zero -> point through CM)
-
+    // requested torque, platform frame (zero -> point through CM; non-zero when dumping reaction-wheel momentum)
+    Eigen::Vector3f Lreq_F = Eigen::Vector3f::Zero();
     if (this->cfg.getMomentumDumping()) {
-        const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig = this->cfg.getRwConfig();
-
-        // compute net RW momentum in body frame
-        Eigen::Vector3f hs_B = Eigen::Vector3f::Zero();
-        for (uint32_t i = 0; i < rwConfig.numRW; ++i) {
-            hs_B += rwConfig.JsList(i) * in.wheelSpeeds(i) * rwConfig.GsMatrix_B.col(i);
-        }
-
-        // update the trapezoidal integral of the RW momentum using the fixed control period as the time step
-        const float dt = this->cfg.getControlPeriod();
-        this->hsInt_B += 0.5F * dt * (this->priorHs_B + hs_B);
-        this->priorHs_B = hs_B;
-
-        // desired thruster torque about the center of mass: oppose the accumulated wheel momentum to dump it.
-        const Eigen::Vector3f Lreq_B = -this->cfg.getK() * hs_B - this->cfg.getKi() * this->hsInt_B;
-
-        // Torque is converted from the body frame into the platform frame using the previous cycle's pointing; on the
-        // first cycle there is no prior, so seed it once with the nominal zero-torque pointing.
-        if (this->priorDcm_FM.isZero()) {
-            this->priorDcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Eigen::Vector3f::Zero());
-        }
-        Lreq_F = this->priorDcm_FM * dcm_MB * Lreq_B;
+        Lreq_F = this->computeDumpingTorque(in, r_CM_M, r_TM_F, thrust_F, dcm_MB);
     }
 
     Eigen::Matrix3f dcm_FM = computeThrusterPointing(r_CM_M, r_TM_F, thrust_F, Lreq_F);

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -137,8 +137,9 @@ ThrusterPlatformReferenceOutput ThrusterPlatformReferenceAlgorithm::update(const
     // achieved thruster torque on the system in body frame coordinates (can be different from requested due to clamp)
     const Eigen::Vector3f r_CM_F = dcm_FM * r_CM_M;
     const Eigen::Vector3f r_TC_F = r_TM_F - r_CM_F;
-    const Eigen::Vector3f torque_F = thrust_F.cross(r_TC_F);
-    out.Lreq_B = dcm_FB.transpose() * torque_F;
+    const Eigen::Vector3f Lachieved_B = dcm_FB.transpose() * r_TC_F.cross(thrust_F);
+    // torque to be compensated by the wheels (opposite of achieved torque) as feed-forward
+    out.Lcomp_B = -Lachieved_B;
 
     // thruster configuration in body frame coordinates
     const Eigen::Vector3f r_TC_B = dcm_FB.transpose() * r_TC_F;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -183,6 +183,8 @@ class ThrusterPlatformReferenceAlgorithm final {
     ThrusterPlatformReferenceConfig cfg;                 //!< [-] validated configuration
     Eigen::Vector3f hsInt_B{Eigen::Vector3f::Zero()};    //!< [Nms] integral of RW momentum, B frame
     Eigen::Vector3f priorHs_B{Eigen::Vector3f::Zero()};  //!< [Nms] prior RW momentum, B frame
+    Eigen::Matrix3f priorDcm_FM{
+        Eigen::Matrix3f::Zero()};  //!< [-] previous cycle's reference DCM [FM] (torque-conversion seed; zero if unset)
 };
 
 #endif  // F32XMERA_THRUSTER_PLATFORM_REFERENCE_ALGORITHM_H

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -33,10 +33,10 @@ struct ThrusterPlatformReferenceInputs {
 
 /*! @brief Outputs of the thruster platform reference algorithm. */
 struct ThrusterPlatformReferenceOutput {
-    Eigen::Vector3f Lreq_B{Eigen::Vector3f::Zero()};  //!< [Nm] torque to be compensated by the RWs, B frame
-    Eigen::Vector3f r_TB_B{Eigen::Vector3f::Zero()};  //!< [m] thrust application point w.r.t. B origin, B frame
-    Eigen::Vector3f tHat_B{Eigen::Vector3f::Zero()};  //!< [-] thrust unit direction, B frame
-    float thrust{};                                   //!< [N] thrust magnitude
+    Eigen::Vector3f Lcomp_B{Eigen::Vector3f::Zero()};  //!< [Nm] torque to be compensated by the RWs, B frame
+    Eigen::Vector3f r_TB_B{Eigen::Vector3f::Zero()};   //!< [m] thrust application point w.r.t. B origin, B frame
+    Eigen::Vector3f tHat_B{Eigen::Vector3f::Zero()};   //!< [-] thrust unit direction, B frame
+    float thrust{};                                    //!< [N] thrust magnitude
 };
 
 /*!

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -33,7 +33,6 @@ struct ThrusterPlatformReferenceInputs {
 struct ThrusterPlatformReferenceOutput {
     float theta1{};                                              //!< [rad] platform tip reference angle
     float theta2{};                                              //!< [rad] platform tilt reference angle
-    Eigen::Vector3f rHat_XB_B{Eigen::Vector3f::Zero()};          //!< [-] thrust heading unit vector, B frame
     Eigen::Vector3f torqueRequestBody{Eigen::Vector3f::Zero()};  //!< [Nm] torque to be compensated by the RWs, B frame
     Eigen::Vector3f rThrust_B{Eigen::Vector3f::Zero()};     //!< [m] thrust application point w.r.t. B origin, B frame
     Eigen::Vector3f tHatThrust_B{Eigen::Vector3f::Zero()};  //!< [-] thrust unit direction, B frame

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -12,7 +12,7 @@
 inline constexpr int kMaxNumRw = THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW;  //!< [-] maximum number of reaction wheels
 
 /*! @brief Reaction-wheel spin-axis configuration used for momentum dumping. */
-struct ThrusterPlatformReferenceRwArrayConfig {
+struct ThrusterPlatformReferenceRwArrayConfiguration {
     uint32_t numRW{};  //!< [-] number of reaction wheels on the vehicle
     Eigen::Matrix<float, 3, kMaxNumRw> GsMatrix_B{
         Eigen::Matrix<float, 3, kMaxNumRw>::Zero()};  //!< [-] RW spin axes in body frame, one column per wheel
@@ -21,22 +21,22 @@ struct ThrusterPlatformReferenceRwArrayConfig {
 
 /*! @brief Per-cycle inputs to the thruster platform reference algorithm. */
 struct ThrusterPlatformReferenceInputs {
-    Eigen::Vector3f r_CB_B{Eigen::Vector3f::Zero()};        //!< [m] center of mass w.r.t. B origin, B frame
-    Eigen::Vector3f rThrust_F{Eigen::Vector3f::Zero()};     //!< [m] thrust application point w.r.t. F origin, F frame
-    Eigen::Vector3f tHatThrust_F{Eigen::Vector3f::Zero()};  //!< [-] thrust unit direction, F frame
-    float maxThrust{};                                      //!< [N] thrust magnitude
+    Eigen::Vector3f r_CB_B{Eigen::Vector3f::Zero()};  //!< [m] center of mass w.r.t. B origin, B frame
+    Eigen::Vector3f r_TF_F{Eigen::Vector3f::Zero()};  //!< [m] thrust application point w.r.t. F origin, F frame
+    Eigen::Vector3f tHat_F{Eigen::Vector3f::Zero()};  //!< [-] thrust unit direction, F frame
+    float thrust{};                                   //!< [N] thrust magnitude
     Eigen::Vector<float, kMaxNumRw> wheelSpeeds{
         Eigen::Vector<float, kMaxNumRw>::Zero()};  //!< [r/s] reaction-wheel speeds
 };
 
 /*! @brief Outputs of the thruster platform reference algorithm. */
 struct ThrusterPlatformReferenceOutput {
-    float theta1{};                                              //!< [rad] platform tip reference angle
-    float theta2{};                                              //!< [rad] platform tilt reference angle
-    Eigen::Vector3f torqueRequestBody{Eigen::Vector3f::Zero()};  //!< [Nm] torque to be compensated by the RWs, B frame
-    Eigen::Vector3f rThrust_B{Eigen::Vector3f::Zero()};     //!< [m] thrust application point w.r.t. B origin, B frame
-    Eigen::Vector3f tHatThrust_B{Eigen::Vector3f::Zero()};  //!< [-] thrust unit direction, B frame
-    float maxThrust{};                                      //!< [N] thrust magnitude
+    float theta1{};                                   //!< [rad] platform tip reference angle
+    float theta2{};                                   //!< [rad] platform tilt reference angle
+    Eigen::Vector3f Lreq_B{Eigen::Vector3f::Zero()};  //!< [Nm] torque to be compensated by the RWs, B frame
+    Eigen::Vector3f r_TB_B{Eigen::Vector3f::Zero()};  //!< [m] thrust application point w.r.t. B origin, B frame
+    Eigen::Vector3f tHat_B{Eigen::Vector3f::Zero()};  //!< [-] thrust unit direction, B frame
+    float thrust{};                                   //!< [N] thrust magnitude
 };
 
 /*!
@@ -58,7 +58,7 @@ class ThrusterPlatformReferenceConfig final {
                                                   float theta1Max,
                                                   float theta2Max,
                                                   bool momentumDumping,
-                                                  const ThrusterPlatformReferenceRwArrayConfig& rwConfig) {
+                                                  const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig) {
         if (!isValidSigma_MB(sigma_MB)) {
             FSW_THROW_INVALID_ARGUMENT("thrusterPlatformReference: sigma_MB must be finite.");
         }
@@ -87,7 +87,7 @@ class ThrusterPlatformReferenceConfig final {
         }
 
         // Store unit-length spin axes so the momentum sum uses exact unit directions.
-        ThrusterPlatformReferenceRwArrayConfig normalizedRwConfig = rwConfig;
+        ThrusterPlatformReferenceRwArrayConfiguration normalizedRwConfig = rwConfig;
         for (uint32_t i = 0U; i < normalizedRwConfig.numRW; ++i) {
             normalizedRwConfig.GsMatrix_B.col(i).normalize();
         }
@@ -102,7 +102,7 @@ class ThrusterPlatformReferenceConfig final {
     static bool isValidKi(float Ki) { return fsw::is_finite(Ki) && Ki >= 0.0F; }
     static bool isValidTheta1Max(float theta1Max) { return fsw::is_finite(theta1Max); }
     static bool isValidTheta2Max(float theta2Max) { return fsw::is_finite(theta2Max); }
-    static bool isValidRwConfig(const ThrusterPlatformReferenceRwArrayConfig& rwConfig) {
+    static bool isValidRwConfig(const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig) {
         if (rwConfig.numRW > static_cast<uint32_t>(kMaxNumRw) || !rwConfig.GsMatrix_B.allFinite() ||
             !rwConfig.JsList.allFinite()) {
             return false;
@@ -125,7 +125,7 @@ class ThrusterPlatformReferenceConfig final {
     float getTheta1Max() const { return theta1Max; }
     float getTheta2Max() const { return theta2Max; }
     bool getMomentumDumping() const { return momentumDumping; }
-    const ThrusterPlatformReferenceRwArrayConfig& getRwConfig() const { return rwConfig; }
+    const ThrusterPlatformReferenceRwArrayConfiguration& getRwConfig() const { return rwConfig; }
 
    private:
     // NOLINTBEGIN(bugprone-easily-swappable-parameters, modernize-pass-by-value)
@@ -141,7 +141,7 @@ class ThrusterPlatformReferenceConfig final {
                                     float theta1Max,
                                     float theta2Max,
                                     bool momentumDumping,
-                                    const ThrusterPlatformReferenceRwArrayConfig& rwConfig)
+                                    const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig)
         : sigma_MB(sigma_MB),
           r_BM_M(r_BM_M),
           r_FM_F(r_FM_F),
@@ -161,7 +161,7 @@ class ThrusterPlatformReferenceConfig final {
     float theta1Max;
     float theta2Max;
     bool momentumDumping;
-    ThrusterPlatformReferenceRwArrayConfig rwConfig;
+    ThrusterPlatformReferenceRwArrayConfiguration rwConfig;
 };
 
 /*! @brief Pure algorithm computing the tip/tilt reference of a dual-gimballed thruster platform. */

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -180,6 +180,14 @@ class ThrusterPlatformReferenceAlgorithm final {
     ThrusterPlatformReferenceOutput update(const ThrusterPlatformReferenceInputs& in);
 
    private:
+    /*! Advance the RW momentum integrator and return the momentum-dumping torque request in the platform frame. */
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) -- the vectors are distinct by frame and documented.
+    Eigen::Vector3f computeDumpingTorque(const ThrusterPlatformReferenceInputs& in,
+                                         const Eigen::Vector3f& r_CM_M,
+                                         const Eigen::Vector3f& r_TM_F,
+                                         const Eigen::Vector3f& thrust_F,
+                                         const Eigen::Matrix3f& dcm_MB);
+
     ThrusterPlatformReferenceConfig cfg;                 //!< [-] validated configuration
     Eigen::Vector3f hsInt_B{Eigen::Vector3f::Zero()};    //!< [Nms] integral of RW momentum, B frame
     Eigen::Vector3f priorHs_B{Eigen::Vector3f::Zero()};  //!< [Nms] prior RW momentum, B frame

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -181,8 +181,8 @@ class ThrusterPlatformReferenceAlgorithm final {
 
    private:
     ThrusterPlatformReferenceConfig cfg;                 //!< [-] validated configuration
-    Eigen::Vector3f hsInt_M{Eigen::Vector3f::Zero()};    //!< [Nms] integral of RW momentum, M frame
-    Eigen::Vector3f priorHs_M{Eigen::Vector3f::Zero()};  //!< [Nms] prior RW momentum, M frame
+    Eigen::Vector3f hsInt_B{Eigen::Vector3f::Zero()};    //!< [Nms] integral of RW momentum, B frame
+    Eigen::Vector3f priorHs_B{Eigen::Vector3f::Zero()};  //!< [Nms] prior RW momentum, B frame
 };
 
 #endif  // F32XMERA_THRUSTER_PLATFORM_REFERENCE_ALGORITHM_H

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -56,6 +56,7 @@ class ThrusterPlatformReferenceConfig final {
                                                   const Eigen::Vector3f& r_FM_F,
                                                   float K,
                                                   float Ki,
+                                                  float controlPeriod,
                                                   float theta1Max,
                                                   float theta2Max,
                                                   bool momentumDumping,
@@ -74,6 +75,9 @@ class ThrusterPlatformReferenceConfig final {
         }
         if (!isValidKi(Ki)) {
             FSW_THROW_INVALID_ARGUMENT("thrusterPlatformReference: Ki must be finite and non-negative.");
+        }
+        if (!isValidControlPeriod(controlPeriod)) {
+            FSW_THROW_INVALID_ARGUMENT("thrusterPlatformReference: controlPeriod must be finite and positive.");
         }
         if (!isValidTheta1Max(theta1Max)) {
             FSW_THROW_INVALID_ARGUMENT("thrusterPlatformReference: theta1Max must be finite.");
@@ -95,7 +99,16 @@ class ThrusterPlatformReferenceConfig final {
 
         // Bound sigma_MB to the principal MRP set (norm <= 1) by switching to the shadow set if needed, so the
         // stored orientation is always a well-conditioned MRP representation.
-        return {mrpSwitch(sigma_MB), r_BM_M, r_FM_F, K, Ki, theta1Max, theta2Max, momentumDumping, normalizedRwConfig};
+        return {mrpSwitch(sigma_MB),
+                r_BM_M,
+                r_FM_F,
+                K,
+                Ki,
+                controlPeriod,
+                theta1Max,
+                theta2Max,
+                momentumDumping,
+                normalizedRwConfig};
     }
 
     static bool isValidSigma_MB(const Eigen::Vector3f& sigma_MB) { return sigma_MB.allFinite(); }
@@ -103,6 +116,9 @@ class ThrusterPlatformReferenceConfig final {
     static bool isValidR_FM_F(const Eigen::Vector3f& r_FM_F) { return r_FM_F.allFinite(); }
     static bool isValidK(float K) { return fsw::is_finite(K) && K >= 0.0F; }
     static bool isValidKi(float Ki) { return fsw::is_finite(Ki) && Ki >= 0.0F; }
+    static bool isValidControlPeriod(float controlPeriod) {
+        return fsw::is_finite(controlPeriod) && controlPeriod > 0.0F;
+    }
     static bool isValidTheta1Max(float theta1Max) { return fsw::is_finite(theta1Max); }
     static bool isValidTheta2Max(float theta2Max) { return fsw::is_finite(theta2Max); }
     static bool isValidRwConfig(const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig) {
@@ -125,6 +141,7 @@ class ThrusterPlatformReferenceConfig final {
     const Eigen::Vector3f& getR_FM_F() const { return r_FM_F; }
     float getK() const { return K; }
     float getKi() const { return Ki; }
+    float getControlPeriod() const { return controlPeriod; }
     float getTheta1Max() const { return theta1Max; }
     float getTheta2Max() const { return theta2Max; }
     bool getMomentumDumping() const { return momentumDumping; }
@@ -141,6 +158,7 @@ class ThrusterPlatformReferenceConfig final {
                                     const Eigen::Vector3f& r_FM_F,
                                     float K,
                                     float Ki,
+                                    float controlPeriod,
                                     float theta1Max,
                                     float theta2Max,
                                     bool momentumDumping,
@@ -150,6 +168,7 @@ class ThrusterPlatformReferenceConfig final {
           r_FM_F(r_FM_F),
           K(K),
           Ki(Ki),
+          controlPeriod(controlPeriod),
           theta1Max(theta1Max),
           theta2Max(theta2Max),
           momentumDumping(momentumDumping),
@@ -161,6 +180,7 @@ class ThrusterPlatformReferenceConfig final {
     Eigen::Vector3f r_FM_F;
     float K;
     float Ki;
+    float controlPeriod;
     float theta1Max;
     float theta2Max;
     bool momentumDumping;
@@ -173,13 +193,12 @@ class ThrusterPlatformReferenceAlgorithm final {
     explicit ThrusterPlatformReferenceAlgorithm(const ThrusterPlatformReferenceConfig& config);
     void setConfig(const ThrusterPlatformReferenceConfig& config);
     void reInitialize();
-    ThrusterPlatformReferenceOutput update(const ThrusterPlatformReferenceInputs& in, uint64_t callTime);
+    ThrusterPlatformReferenceOutput update(const ThrusterPlatformReferenceInputs& in);
 
    private:
     ThrusterPlatformReferenceConfig cfg;                 //!< [-] validated configuration
     Eigen::Vector3f hsInt_M{Eigen::Vector3f::Zero()};    //!< [Nms] integral of RW momentum, M frame
     Eigen::Vector3f priorHs_M{Eigen::Vector3f::Zero()};  //!< [Nms] prior RW momentum, M frame
-    uint64_t priorTime{};                                //!< [ns] prior call time
 };
 
 #endif  // F32XMERA_THRUSTER_PLATFORM_REFERENCE_ALGORITHM_H

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include <Eigen/Core>
+#include <numbers>
 
 inline constexpr int kMaxNumRw = THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW;  //!< [-] maximum number of reaction wheels
 
@@ -41,11 +42,11 @@ struct ThrusterPlatformReferenceOutput {
 /*!
  * @brief Validated configuration for the thruster platform reference algorithm.
  *
- * Bundles the platform mounting geometry, the momentum-dumping gains, and the reaction-wheel configuration used for
- * momentum dumping. An instance can only exist if the geometry vectors are finite, the gains are finite and
- * non-negative, the control period is finite and positive, and the reaction-wheel configuration count does not
- * exceed the compile-time maximum with finite spin axes and inertias. Construct via
- * ThrusterPlatformReferenceConfig::create(...).
+ * Bundles the platform mounting geometry, the momentum-dumping gains, the thrust-deflection cone limit, and the
+ * reaction-wheel configuration used for momentum dumping. An instance can only exist if the geometry vectors are
+ * finite, the gains are finite and non-negative, the control period is finite and positive, the deflection cone
+ * half-angle lies in (0, pi), and the reaction-wheel configuration count does not exceed the compile-time maximum
+ * with finite spin axes and inertias. Construct via ThrusterPlatformReferenceConfig::create(...).
  */
 class ThrusterPlatformReferenceConfig final {
    public:
@@ -55,6 +56,7 @@ class ThrusterPlatformReferenceConfig final {
                                                   float K,
                                                   float Ki,
                                                   float controlPeriod,
+                                                  float thetaMax,
                                                   bool momentumDumping,
                                                   const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig) {
         if (!isValidSigma_MB(sigma_MB)) {
@@ -75,6 +77,9 @@ class ThrusterPlatformReferenceConfig final {
         if (!isValidControlPeriod(controlPeriod)) {
             FSW_THROW_INVALID_ARGUMENT("thrusterPlatformReference: controlPeriod must be finite and positive.");
         }
+        if (!isValidThetaMax(thetaMax)) {
+            FSW_THROW_INVALID_ARGUMENT("thrusterPlatformReference: thetaMax must lie in the open interval (0, pi).");
+        }
         if (!isValidRwConfig(rwConfig)) {
             FSW_THROW_INVALID_ARGUMENT(
                 "thrusterPlatformReference: rwConfig.numRW must not exceed the compile-time maximum, its inertias "
@@ -89,7 +94,8 @@ class ThrusterPlatformReferenceConfig final {
 
         // Bound sigma_MB to the principal MRP set (norm <= 1) by switching to the shadow set if needed, so the
         // stored orientation is always a well-conditioned MRP representation.
-        return {mrpSwitch(sigma_MB), r_BM_M, r_FM_F, K, Ki, controlPeriod, momentumDumping, normalizedRwConfig};
+        return {
+            mrpSwitch(sigma_MB), r_BM_M, r_FM_F, K, Ki, controlPeriod, thetaMax, momentumDumping, normalizedRwConfig};
     }
 
     static bool isValidSigma_MB(const Eigen::Vector3f& sigma_MB) { return sigma_MB.allFinite(); }
@@ -99,6 +105,9 @@ class ThrusterPlatformReferenceConfig final {
     static bool isValidKi(float Ki) { return fsw::is_finite(Ki) && Ki >= 0.0F; }
     static bool isValidControlPeriod(float controlPeriod) {
         return fsw::is_finite(controlPeriod) && controlPeriod > 0.0F;
+    }
+    static bool isValidThetaMax(float thetaMax) {
+        return fsw::is_finite(thetaMax) && thetaMax > 0.0F && thetaMax < std::numbers::pi_v<float>;
     }
     static bool isValidRwConfig(const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig) {
         if (rwConfig.numRW > static_cast<uint32_t>(kMaxNumRw) || !rwConfig.GsMatrix_B.allFinite() ||
@@ -121,6 +130,7 @@ class ThrusterPlatformReferenceConfig final {
     float getK() const { return K; }
     float getKi() const { return Ki; }
     float getControlPeriod() const { return controlPeriod; }
+    float getThetaMax() const { return thetaMax; }
     bool getMomentumDumping() const { return momentumDumping; }
     const ThrusterPlatformReferenceRwArrayConfiguration& getRwConfig() const { return rwConfig; }
 
@@ -136,6 +146,7 @@ class ThrusterPlatformReferenceConfig final {
                                     float K,
                                     float Ki,
                                     float controlPeriod,
+                                    float thetaMax,
                                     bool momentumDumping,
                                     const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig)
         : sigma_MB(sigma_MB),
@@ -144,6 +155,7 @@ class ThrusterPlatformReferenceConfig final {
           K(K),
           Ki(Ki),
           controlPeriod(controlPeriod),
+          thetaMax(thetaMax),
           momentumDumping(momentumDumping),
           rwConfig(rwConfig) {}
     // NOLINTEND(bugprone-easily-swappable-parameters, modernize-pass-by-value)
@@ -154,6 +166,7 @@ class ThrusterPlatformReferenceConfig final {
     float K;
     float Ki;
     float controlPeriod;
+    float thetaMax;
     bool momentumDumping;
     ThrusterPlatformReferenceRwArrayConfiguration rwConfig;
 };

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -4,6 +4,7 @@
 #include "thrusterPlatformReferenceTypes.h"
 #include "utilities/fsw/freestandingInvalidArgument.h"
 #include "utilities/fsw/freestandingIsFinite.hpp"
+#include "utilities/fsw/rigidBodyKinematics.hpp"
 #include <math.h>
 #include <stdint.h>
 
@@ -92,7 +93,9 @@ class ThrusterPlatformReferenceConfig final {
             normalizedRwConfig.GsMatrix_B.col(i).normalize();
         }
 
-        return {sigma_MB, r_BM_M, r_FM_F, K, Ki, theta1Max, theta2Max, momentumDumping, normalizedRwConfig};
+        // Bound sigma_MB to the principal MRP set (norm <= 1) by switching to the shadow set if needed, so the
+        // stored orientation is always a well-conditioned MRP representation.
+        return {mrpSwitch(sigma_MB), r_BM_M, r_FM_F, K, Ki, theta1Max, theta2Max, momentumDumping, normalizedRwConfig};
     }
 
     static bool isValidSigma_MB(const Eigen::Vector3f& sigma_MB) { return sigma_MB.allFinite(); }

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.h
@@ -32,8 +32,6 @@ struct ThrusterPlatformReferenceInputs {
 
 /*! @brief Outputs of the thruster platform reference algorithm. */
 struct ThrusterPlatformReferenceOutput {
-    float theta1{};                                   //!< [rad] platform tip reference angle
-    float theta2{};                                   //!< [rad] platform tilt reference angle
     Eigen::Vector3f Lreq_B{Eigen::Vector3f::Zero()};  //!< [Nm] torque to be compensated by the RWs, B frame
     Eigen::Vector3f r_TB_B{Eigen::Vector3f::Zero()};  //!< [m] thrust application point w.r.t. B origin, B frame
     Eigen::Vector3f tHat_B{Eigen::Vector3f::Zero()};  //!< [-] thrust unit direction, B frame
@@ -43,11 +41,11 @@ struct ThrusterPlatformReferenceOutput {
 /*!
  * @brief Validated configuration for the thruster platform reference algorithm.
  *
- * Bundles the platform mounting geometry, the momentum-dumping gains, the tip/tilt angle bounds, and the
- * reaction-wheel configuration used for momentum dumping. An instance can only exist if the geometry vectors are
- * finite, the gains are finite and non-negative, the angle bounds are finite (a non-positive bound disables
- * clamping on that axis), and the reaction-wheel configuration count does not exceed the compile-time maximum with
- * finite spin axes and inertias. Construct via ThrusterPlatformReferenceConfig::create(...).
+ * Bundles the platform mounting geometry, the momentum-dumping gains, and the reaction-wheel configuration used for
+ * momentum dumping. An instance can only exist if the geometry vectors are finite, the gains are finite and
+ * non-negative, the control period is finite and positive, and the reaction-wheel configuration count does not
+ * exceed the compile-time maximum with finite spin axes and inertias. Construct via
+ * ThrusterPlatformReferenceConfig::create(...).
  */
 class ThrusterPlatformReferenceConfig final {
    public:
@@ -57,8 +55,6 @@ class ThrusterPlatformReferenceConfig final {
                                                   float K,
                                                   float Ki,
                                                   float controlPeriod,
-                                                  float theta1Max,
-                                                  float theta2Max,
                                                   bool momentumDumping,
                                                   const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig) {
         if (!isValidSigma_MB(sigma_MB)) {
@@ -79,12 +75,6 @@ class ThrusterPlatformReferenceConfig final {
         if (!isValidControlPeriod(controlPeriod)) {
             FSW_THROW_INVALID_ARGUMENT("thrusterPlatformReference: controlPeriod must be finite and positive.");
         }
-        if (!isValidTheta1Max(theta1Max)) {
-            FSW_THROW_INVALID_ARGUMENT("thrusterPlatformReference: theta1Max must be finite.");
-        }
-        if (!isValidTheta2Max(theta2Max)) {
-            FSW_THROW_INVALID_ARGUMENT("thrusterPlatformReference: theta2Max must be finite.");
-        }
         if (!isValidRwConfig(rwConfig)) {
             FSW_THROW_INVALID_ARGUMENT(
                 "thrusterPlatformReference: rwConfig.numRW must not exceed the compile-time maximum, its inertias "
@@ -99,16 +89,7 @@ class ThrusterPlatformReferenceConfig final {
 
         // Bound sigma_MB to the principal MRP set (norm <= 1) by switching to the shadow set if needed, so the
         // stored orientation is always a well-conditioned MRP representation.
-        return {mrpSwitch(sigma_MB),
-                r_BM_M,
-                r_FM_F,
-                K,
-                Ki,
-                controlPeriod,
-                theta1Max,
-                theta2Max,
-                momentumDumping,
-                normalizedRwConfig};
+        return {mrpSwitch(sigma_MB), r_BM_M, r_FM_F, K, Ki, controlPeriod, momentumDumping, normalizedRwConfig};
     }
 
     static bool isValidSigma_MB(const Eigen::Vector3f& sigma_MB) { return sigma_MB.allFinite(); }
@@ -119,8 +100,6 @@ class ThrusterPlatformReferenceConfig final {
     static bool isValidControlPeriod(float controlPeriod) {
         return fsw::is_finite(controlPeriod) && controlPeriod > 0.0F;
     }
-    static bool isValidTheta1Max(float theta1Max) { return fsw::is_finite(theta1Max); }
-    static bool isValidTheta2Max(float theta2Max) { return fsw::is_finite(theta2Max); }
     static bool isValidRwConfig(const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig) {
         if (rwConfig.numRW > static_cast<uint32_t>(kMaxNumRw) || !rwConfig.GsMatrix_B.allFinite() ||
             !rwConfig.JsList.allFinite()) {
@@ -142,8 +121,6 @@ class ThrusterPlatformReferenceConfig final {
     float getK() const { return K; }
     float getKi() const { return Ki; }
     float getControlPeriod() const { return controlPeriod; }
-    float getTheta1Max() const { return theta1Max; }
-    float getTheta2Max() const { return theta2Max; }
     bool getMomentumDumping() const { return momentumDumping; }
     const ThrusterPlatformReferenceRwArrayConfiguration& getRwConfig() const { return rwConfig; }
 
@@ -159,8 +136,6 @@ class ThrusterPlatformReferenceConfig final {
                                     float K,
                                     float Ki,
                                     float controlPeriod,
-                                    float theta1Max,
-                                    float theta2Max,
                                     bool momentumDumping,
                                     const ThrusterPlatformReferenceRwArrayConfiguration& rwConfig)
         : sigma_MB(sigma_MB),
@@ -169,8 +144,6 @@ class ThrusterPlatformReferenceConfig final {
           K(K),
           Ki(Ki),
           controlPeriod(controlPeriod),
-          theta1Max(theta1Max),
-          theta2Max(theta2Max),
           momentumDumping(momentumDumping),
           rwConfig(rwConfig) {}
     // NOLINTEND(bugprone-easily-swappable-parameters, modernize-pass-by-value)
@@ -181,13 +154,11 @@ class ThrusterPlatformReferenceConfig final {
     float K;
     float Ki;
     float controlPeriod;
-    float theta1Max;
-    float theta2Max;
     bool momentumDumping;
     ThrusterPlatformReferenceRwArrayConfiguration rwConfig;
 };
 
-/*! @brief Pure algorithm computing the tip/tilt reference of a dual-gimballed thruster platform. */
+/*! @brief Pure algorithm computing the reference orientation of a thruster platform. */
 class ThrusterPlatformReferenceAlgorithm final {
    public:
     explicit ThrusterPlatformReferenceAlgorithm(const ThrusterPlatformReferenceConfig& config);

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
@@ -22,6 +22,7 @@ ThrusterPlatformReferenceConfig configFromC(const ThrusterPlatformReferenceConfi
                                                    c.K,
                                                    c.Ki,
                                                    c.controlPeriod,
+                                                   c.thetaMax,
                                                    c.momentumDumping,
                                                    rwArrayConfigFromC(c.rwConfig));
 }

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
@@ -22,8 +22,6 @@ ThrusterPlatformReferenceConfig configFromC(const ThrusterPlatformReferenceConfi
                                                    c.K,
                                                    c.Ki,
                                                    c.controlPeriod,
-                                                   c.theta1Max,
-                                                   c.theta2Max,
                                                    c.momentumDumping,
                                                    rwArrayConfigFromC(c.rwConfig));
 }
@@ -67,8 +65,6 @@ ThrusterPlatformReferenceOutput_c ThrusterPlatformReferenceAlgorithm_update(
         reinterpret_cast<::ThrusterPlatformReferenceAlgorithm*>(self)->update(inputsFromC(*inputs));
 
     ThrusterPlatformReferenceOutput_c result{};
-    result.theta1 = out.theta1;
-    result.theta2 = out.theta2;
     eigenVectorToCArray(out.Lreq_B, result.Lreq_B.data);
     eigenVectorToCArray(out.r_TB_B, result.r_TB_B.data);
     eigenVectorToCArray(out.tHat_B, result.tHat_B.data);

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
@@ -66,7 +66,7 @@ ThrusterPlatformReferenceOutput_c ThrusterPlatformReferenceAlgorithm_update(
         reinterpret_cast<::ThrusterPlatformReferenceAlgorithm*>(self)->update(inputsFromC(*inputs));
 
     ThrusterPlatformReferenceOutput_c result{};
-    eigenVectorToCArray(out.Lreq_B, result.Lreq_B.data);
+    eigenVectorToCArray(out.Lcomp_B, result.Lcomp_B.data);
     eigenVectorToCArray(out.r_TB_B, result.r_TB_B.data);
     eigenVectorToCArray(out.tHat_B, result.tHat_B.data);
     result.thrust = out.thrust;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "thrusterPlatformReferenceAlgorithm.h"
 #include "thrusterPlatformReferenceTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
 
@@ -15,16 +16,24 @@ ThrusterPlatformReferenceRwArrayConfiguration rwArrayConfigFromC(
     return out;
 }
 
-ThrusterPlatformReferenceConfig configFromC(const ThrusterPlatformReferenceConfig_c& c) {
-    return ThrusterPlatformReferenceConfig::create(cArrayToEigenVector3<float>(c.sigma_MB.data),
-                                                   cArrayToEigenVector3<float>(c.r_BM_M.data),
-                                                   cArrayToEigenVector3<float>(c.r_FM_F.data),
-                                                   c.K,
-                                                   c.Ki,
-                                                   c.controlPeriod,
-                                                   c.thetaMax,
-                                                   c.momentumDumping,
-                                                   rwArrayConfigFromC(c.rwConfig));
+ThrusterPlatformReferenceConfig makeConfig(const Vector3f_c& sigma_MB,
+                                           const Vector3f_c& r_BM_M,
+                                           const Vector3f_c& r_FM_F,
+                                           float K,
+                                           float Ki,
+                                           float controlPeriod,
+                                           float thetaMax,
+                                           bool momentumDumping,
+                                           const ThrusterPlatformReferenceRwArrayConfiguration_c& rwConfig) {
+    return ThrusterPlatformReferenceConfig::create(cArrayToEigenVector3<float>(sigma_MB.data),
+                                                   cArrayToEigenVector3<float>(r_BM_M.data),
+                                                   cArrayToEigenVector3<float>(r_FM_F.data),
+                                                   K,
+                                                   Ki,
+                                                   controlPeriod,
+                                                   thetaMax,
+                                                   momentumDumping,
+                                                   rwArrayConfigFromC(rwConfig));
 }
 
 ThrusterPlatformReferenceInputs inputsFromC(const ThrusterPlatformReferenceInputs_c& c) {
@@ -40,30 +49,65 @@ ThrusterPlatformReferenceInputs inputsFromC(const ThrusterPlatformReferenceInput
 
 uint32_t ThrusterPlatformReferenceAlgorithm_getMaxNumRw(void) { return THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW; }
 
+bool ThrusterPlatformReferenceAlgorithm_validateConfig(
+    const Vector3f_c* sigma_MB,
+    const Vector3f_c* r_BM_M,
+    const Vector3f_c* r_FM_F,
+    float K,
+    float Ki,
+    float controlPeriod,
+    float thetaMax,
+    bool momentumDumping,
+    const ThrusterPlatformReferenceRwArrayConfiguration_c* rwConfig) {
+    try {
+        (void)makeConfig(*sigma_MB, *r_BM_M, *r_FM_F, K, Ki, controlPeriod, thetaMax, momentumDumping, *rwConfig);
+        return true;
+    } catch (const fsw::invalid_argument&) {
+        return false;
+    }
+}
+
 ThrusterPlatformReferenceAlgorithmHandle* ThrusterPlatformReferenceAlgorithm_create(
-    const ThrusterPlatformReferenceConfig_c* config) {
-    return reinterpret_cast<ThrusterPlatformReferenceAlgorithmHandle*>(
-        new ::ThrusterPlatformReferenceAlgorithm(configFromC(*config)));
+    const Vector3f_c* sigma_MB,
+    const Vector3f_c* r_BM_M,
+    const Vector3f_c* r_FM_F,
+    float K,
+    float Ki,
+    float controlPeriod,
+    float thetaMax,
+    bool momentumDumping,
+    const ThrusterPlatformReferenceRwArrayConfiguration_c* rwConfig) {
+    return reinterpret_cast<ThrusterPlatformReferenceAlgorithmHandle*>(new ::ThrusterPlatformReferenceAlgorithm(
+        makeConfig(*sigma_MB, *r_BM_M, *r_FM_F, K, Ki, controlPeriod, thetaMax, momentumDumping, *rwConfig)));
 }
 
 void ThrusterPlatformReferenceAlgorithm_destroy(ThrusterPlatformReferenceAlgorithmHandle* self) {
-    delete reinterpret_cast<::ThrusterPlatformReferenceAlgorithm*>(self);
+    fsw::deleteHandle<::ThrusterPlatformReferenceAlgorithm>(self);
 }
 
 void ThrusterPlatformReferenceAlgorithm_setConfig(ThrusterPlatformReferenceAlgorithmHandle* self,
-                                                  const ThrusterPlatformReferenceConfig_c* config) {
-    reinterpret_cast<::ThrusterPlatformReferenceAlgorithm*>(self)->setConfig(configFromC(*config));
+                                                  const Vector3f_c* sigma_MB,
+                                                  const Vector3f_c* r_BM_M,
+                                                  const Vector3f_c* r_FM_F,
+                                                  float K,
+                                                  float Ki,
+                                                  float controlPeriod,
+                                                  float thetaMax,
+                                                  bool momentumDumping,
+                                                  const ThrusterPlatformReferenceRwArrayConfiguration_c* rwConfig) {
+    fsw::fromHandle<::ThrusterPlatformReferenceAlgorithm>(self)->setConfig(
+        makeConfig(*sigma_MB, *r_BM_M, *r_FM_F, K, Ki, controlPeriod, thetaMax, momentumDumping, *rwConfig));
 }
 
 void ThrusterPlatformReferenceAlgorithm_reInitialize(ThrusterPlatformReferenceAlgorithmHandle* self) {
-    reinterpret_cast<::ThrusterPlatformReferenceAlgorithm*>(self)->reInitialize();
+    fsw::fromHandle<::ThrusterPlatformReferenceAlgorithm>(self)->reInitialize();
 }
 
 ThrusterPlatformReferenceOutput_c ThrusterPlatformReferenceAlgorithm_update(
     ThrusterPlatformReferenceAlgorithmHandle* self,
     const ThrusterPlatformReferenceInputs_c* inputs) {
     const ThrusterPlatformReferenceOutput out =
-        reinterpret_cast<::ThrusterPlatformReferenceAlgorithm*>(self)->update(inputsFromC(*inputs));
+        fsw::fromHandle<::ThrusterPlatformReferenceAlgorithm>(self)->update(inputsFromC(*inputs));
 
     ThrusterPlatformReferenceOutput_c result{};
     eigenVectorToCArray(out.Lcomp_B, result.Lcomp_B.data);

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
@@ -6,8 +6,9 @@
 #include <Eigen/Core>
 
 namespace {
-ThrusterPlatformReferenceRwArrayConfig rwArrayConfigFromC(const ThrusterPlatformReferenceRwArrayConfig_c& c) {
-    ThrusterPlatformReferenceRwArrayConfig out{};
+ThrusterPlatformReferenceRwArrayConfiguration rwArrayConfigFromC(
+    const ThrusterPlatformReferenceRwArrayConfiguration_c& c) {
+    ThrusterPlatformReferenceRwArrayConfiguration out{};
     out.numRW = c.numRW;
     out.GsMatrix_B = cArrayToEigenMatrix<float, 3, kMaxNumRw>(c.GsMatrix_B);
     out.JsList = cArrayToEigenVector(c.JsList);
@@ -29,9 +30,9 @@ ThrusterPlatformReferenceConfig configFromC(const ThrusterPlatformReferenceConfi
 ThrusterPlatformReferenceInputs inputsFromC(const ThrusterPlatformReferenceInputs_c& c) {
     ThrusterPlatformReferenceInputs out{};
     out.r_CB_B = cArrayToEigenVector3<float>(c.r_CB_B.data);
-    out.rThrust_F = cArrayToEigenVector3<float>(c.rThrust_F.data);
-    out.tHatThrust_F = cArrayToEigenVector3<float>(c.tHatThrust_F.data);
-    out.maxThrust = c.maxThrust;
+    out.r_TF_F = cArrayToEigenVector3<float>(c.r_TF_F.data);
+    out.tHat_F = cArrayToEigenVector3<float>(c.tHat_F.data);
+    out.thrust = c.thrust;
     out.wheelSpeeds = cArrayToEigenVector(c.wheelSpeeds);
     return out;
 }
@@ -68,9 +69,9 @@ ThrusterPlatformReferenceOutput_c ThrusterPlatformReferenceAlgorithm_update(
     ThrusterPlatformReferenceOutput_c result{};
     result.theta1 = out.theta1;
     result.theta2 = out.theta2;
-    eigenVectorToCArray(out.torqueRequestBody, result.torqueRequestBody.data);
-    eigenVectorToCArray(out.rThrust_B, result.rThrust_B.data);
-    eigenVectorToCArray(out.tHatThrust_B, result.tHatThrust_B.data);
-    result.maxThrust = out.maxThrust;
+    eigenVectorToCArray(out.Lreq_B, result.Lreq_B.data);
+    eigenVectorToCArray(out.r_TB_B, result.r_TB_B.data);
+    eigenVectorToCArray(out.tHat_B, result.tHat_B.data);
+    result.thrust = out.thrust;
     return result;
 }

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
@@ -68,7 +68,6 @@ ThrusterPlatformReferenceOutput_c ThrusterPlatformReferenceAlgorithm_update(
     ThrusterPlatformReferenceOutput_c result{};
     result.theta1 = out.theta1;
     result.theta2 = out.theta2;
-    eigenVectorToCArray(out.rHat_XB_B, result.rHat_XB_B.data);
     eigenVectorToCArray(out.torqueRequestBody, result.torqueRequestBody.data);
     eigenVectorToCArray(out.rThrust_B, result.rThrust_B.data);
     eigenVectorToCArray(out.tHatThrust_B, result.tHatThrust_B.data);

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.cpp
@@ -21,6 +21,7 @@ ThrusterPlatformReferenceConfig configFromC(const ThrusterPlatformReferenceConfi
                                                    cArrayToEigenVector3<float>(c.r_FM_F.data),
                                                    c.K,
                                                    c.Ki,
+                                                   c.controlPeriod,
                                                    c.theta1Max,
                                                    c.theta2Max,
                                                    c.momentumDumping,
@@ -61,10 +62,9 @@ void ThrusterPlatformReferenceAlgorithm_reInitialize(ThrusterPlatformReferenceAl
 
 ThrusterPlatformReferenceOutput_c ThrusterPlatformReferenceAlgorithm_update(
     ThrusterPlatformReferenceAlgorithmHandle* self,
-    const ThrusterPlatformReferenceInputs_c* inputs,
-    const uint64_t callTime) {
+    const ThrusterPlatformReferenceInputs_c* inputs) {
     const ThrusterPlatformReferenceOutput out =
-        reinterpret_cast<::ThrusterPlatformReferenceAlgorithm*>(self)->update(inputsFromC(*inputs), callTime);
+        reinterpret_cast<::ThrusterPlatformReferenceAlgorithm*>(self)->update(inputsFromC(*inputs));
 
     ThrusterPlatformReferenceOutput_c result{};
     result.theta1 = out.theta1;

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.h
@@ -50,15 +50,13 @@ void ThrusterPlatformReferenceAlgorithm_reInitialize(ThrusterPlatformReferenceAl
 
 /**
  * @brief Compute the platform tip/tilt reference and derived body-frame thruster quantities.
- * @param self     Pointer to the instance.
- * @param inputs   Pointer to the per-cycle inputs (algorithm-native POD).
- * @param callTime Time stamp for the update (nanoseconds), used for the momentum-dumping integral.
+ * @param self   Pointer to the instance.
+ * @param inputs Pointer to the per-cycle inputs (algorithm-native POD).
  * @return ThrusterPlatformReferenceOutput_c reference angles and derived body-frame thruster quantities.
  */
 ThrusterPlatformReferenceOutput_c ThrusterPlatformReferenceAlgorithm_update(
     ThrusterPlatformReferenceAlgorithmHandle* self,
-    const ThrusterPlatformReferenceInputs_c* inputs,
-    uint64_t callTime);
+    const ThrusterPlatformReferenceInputs_c* inputs);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.h
@@ -3,6 +3,7 @@
 
 #include "thrusterPlatformReferenceTypes.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -21,12 +22,44 @@ typedef struct ThrusterPlatformReferenceAlgorithmHandle ThrusterPlatformReferenc
 uint32_t ThrusterPlatformReferenceAlgorithm_getMaxNumRw(void);
 
 /**
+ * @brief Report whether a configuration would be accepted by create/setConfig.
+ * @param sigma_MB        MRP of the M frame w.r.t. the B frame; must be finite.
+ * @param r_BM_M          B frame origin w.r.t. M origin, M coordinates; must be finite.
+ * @param r_FM_F          F frame origin w.r.t. M origin, F coordinates; must be finite.
+ * @param K               [1/s] momentum-dumping proportional gain; must be finite and >= 0.
+ * @param Ki              [-]   momentum-dumping integral gain; must be finite and >= 0.
+ * @param controlPeriod   [s]   dumping-integral time step; must be finite and > 0.
+ * @param thetaMax        [rad] thrust-deflection cone half-angle; must lie in the open interval (0, pi).
+ * @param momentumDumping [-]   whether reaction-wheel momentum dumping is active.
+ * @param rwConfig        RW configuration; numRW <= max, finite inertias, near-unit spin axes.
+ * @return true when the configuration is valid. Never throws, so it can guard the throwing
+ *         create/setConfig from an invalid configuration.
+ */
+bool ThrusterPlatformReferenceAlgorithm_validateConfig(const Vector3f_c* sigma_MB,
+                                                       const Vector3f_c* r_BM_M,
+                                                       const Vector3f_c* r_FM_F,
+                                                       float K,
+                                                       float Ki,
+                                                       float controlPeriod,
+                                                       float thetaMax,
+                                                       bool momentumDumping,
+                                                       const ThrusterPlatformReferenceRwArrayConfiguration_c* rwConfig);
+
+/**
  * @brief Construct a new ThrusterPlatformReferenceAlgorithm instance from the supplied configuration.
- * @param config Pointer to the configuration to apply (validated; throws on invalid input).
+ * Validate the values with validateConfig first; invalid input throws.
  * @return Pointer to a new ThrusterPlatformReferenceAlgorithm (must be destroyed).
  */
 ThrusterPlatformReferenceAlgorithmHandle* ThrusterPlatformReferenceAlgorithm_create(
-    const ThrusterPlatformReferenceConfig_c* config);
+    const Vector3f_c* sigma_MB,
+    const Vector3f_c* r_BM_M,
+    const Vector3f_c* r_FM_F,
+    float K,
+    float Ki,
+    float controlPeriod,
+    float thetaMax,
+    bool momentumDumping,
+    const ThrusterPlatformReferenceRwArrayConfiguration_c* rwConfig);
 
 /**
  * @brief Destroy a previously created ThrusterPlatformReferenceAlgorithm.
@@ -36,11 +69,19 @@ void ThrusterPlatformReferenceAlgorithm_destroy(ThrusterPlatformReferenceAlgorit
 
 /**
  * @brief Replace the algorithm's configuration at runtime without disturbing its runtime state.
- * @param self   Pointer to the instance.
- * @param config Pointer to the configuration to apply (validated; throws on invalid input).
+ * Validate the values with validateConfig first; invalid input throws.
+ * @param self Pointer to the instance.
  */
 void ThrusterPlatformReferenceAlgorithm_setConfig(ThrusterPlatformReferenceAlgorithmHandle* self,
-                                                  const ThrusterPlatformReferenceConfig_c* config);
+                                                  const Vector3f_c* sigma_MB,
+                                                  const Vector3f_c* r_BM_M,
+                                                  const Vector3f_c* r_FM_F,
+                                                  float K,
+                                                  float Ki,
+                                                  float controlPeriod,
+                                                  float thetaMax,
+                                                  bool momentumDumping,
+                                                  const ThrusterPlatformReferenceRwArrayConfiguration_c* rwConfig);
 
 /**
  * @brief Re-seed the runtime integrator state (RW momentum integral, prior sample) to its initial values.

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm_c.h
@@ -49,10 +49,10 @@ void ThrusterPlatformReferenceAlgorithm_setConfig(ThrusterPlatformReferenceAlgor
 void ThrusterPlatformReferenceAlgorithm_reInitialize(ThrusterPlatformReferenceAlgorithmHandle* self);
 
 /**
- * @brief Compute the platform tip/tilt reference and derived body-frame thruster quantities.
+ * @brief Compute the platform reference orientation and derived body-frame thruster quantities.
  * @param self   Pointer to the instance.
  * @param inputs Pointer to the per-cycle inputs (algorithm-native POD).
- * @return ThrusterPlatformReferenceOutput_c reference angles and derived body-frame thruster quantities.
+ * @return ThrusterPlatformReferenceOutput_c derived body-frame thruster quantities.
  */
 ThrusterPlatformReferenceOutput_c ThrusterPlatformReferenceAlgorithm_update(
     ThrusterPlatformReferenceAlgorithmHandle* self,

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceF32.i
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceF32.i
@@ -14,5 +14,4 @@
 %include "msgPayloadDef/RWArrayConfigMsgF32Payload.h"
 %include "msgPayloadDef/RWSpeedMsgF32Payload.h"
 %include "msgPayloadDef/CmdTorqueBodyMsgF32Payload.h"
-%include "msgPayloadDef/HingedRigidBodyMsgF32Payload.h"
 %include "msgPayloadDef/BodyHeadingMsgF32Payload.h"

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
@@ -63,10 +63,10 @@ typedef struct {
  * @brief Plain-old-data mirror of the C++ ThrusterPlatformReferenceOutput.
  */
 typedef struct {
-    Vector3f_c Lreq_B; /*!< [Nm] torque to be compensated by the RWs, B frame */
-    Vector3f_c r_TB_B; /*!< [m]  thrust application point w.r.t. B origin, B frame */
-    Vector3f_c tHat_B; /*!< [-]  thrust unit direction, B frame */
-    float thrust;      /*!< [N]  thrust magnitude */
+    Vector3f_c Lcomp_B; /*!< [Nm] torque to be compensated by the RWs, B frame */
+    Vector3f_c r_TB_B;  /*!< [m]  thrust application point w.r.t. B origin, B frame */
+    Vector3f_c tHat_B;  /*!< [-]  thrust unit direction, B frame */
+    float thrust;       /*!< [N]  thrust magnitude */
 } ThrusterPlatformReferenceOutput_c;
 
 #ifdef __cplusplus

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
@@ -33,7 +33,6 @@ typedef struct {
  *  - sigma_MB / r_BM_M / r_FM_F must be finite
  *  - K / Ki must be finite and non-negative
  *  - controlPeriod [s] must be finite and positive; used as the integration step for the dumping integral
- *  - theta1Max / theta2Max must be finite (a non-positive bound disables clamping on that axis)
  *  - rwConfig.numRW must not exceed THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW; each spin axis a unit vector
  */
 typedef struct {
@@ -43,8 +42,6 @@ typedef struct {
     float K;              /*!< [1/s] momentum dumping proportional gain */
     float Ki;             /*!< [-]   momentum dumping integral gain */
     float controlPeriod;  /*!< [s]   integration step for the momentum dumping integral (> 0) */
-    float theta1Max;      /*!< [rad] absolute bound on the tip angle */
-    float theta2Max;      /*!< [rad] absolute bound on the tilt angle */
     bool momentumDumping; /*!< [-]   whether reaction wheel momentum dumping is active */
     ThrusterPlatformReferenceRwArrayConfiguration_c rwConfig; /*!< [-] RW configuration used for momentum dumping */
 } ThrusterPlatformReferenceConfig_c;
@@ -64,8 +61,6 @@ typedef struct {
  * @brief Plain-old-data mirror of the C++ ThrusterPlatformReferenceOutput.
  */
 typedef struct {
-    float theta1;      /*!< [rad] platform tip reference angle */
-    float theta2;      /*!< [rad] platform tilt reference angle */
     Vector3f_c Lreq_B; /*!< [Nm] torque to be compensated by the RWs, B frame */
     Vector3f_c r_TB_B; /*!< [m]  thrust application point w.r.t. B origin, B frame */
     Vector3f_c tHat_B; /*!< [-]  thrust unit direction, B frame */

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
@@ -32,6 +32,7 @@ typedef struct {
  * input.
  *  - sigma_MB / r_BM_M / r_FM_F must be finite
  *  - K / Ki must be finite and non-negative
+ *  - controlPeriod [s] must be finite and positive; used as the integration step for the dumping integral
  *  - theta1Max / theta2Max must be finite (a non-positive bound disables clamping on that axis)
  *  - rwConfig.numRW must not exceed THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW; each spin axis a unit vector
  */
@@ -41,6 +42,7 @@ typedef struct {
     Vector3f_c r_FM_F;    /*!< [m]   F frame origin w.r.t. M frame origin, F frame coordinates */
     float K;              /*!< [1/s] momentum dumping proportional gain */
     float Ki;             /*!< [-]   momentum dumping integral gain */
+    float controlPeriod;  /*!< [s]   integration step for the momentum dumping integral (> 0) */
     float theta1Max;      /*!< [rad] absolute bound on the tip angle */
     float theta2Max;      /*!< [rad] absolute bound on the tilt angle */
     bool momentumDumping; /*!< [-]   whether reaction wheel momentum dumping is active */

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
@@ -15,14 +15,14 @@ extern "C" {
 #define THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW 36
 
 /**
- * @brief Plain-old-data mirror of the C++ ThrusterPlatformReferenceRwArrayConfig.
+ * @brief Plain-old-data mirror of the C++ ThrusterPlatformReferenceRwArrayConfiguration.
  */
 typedef struct {
     uint32_t numRW; /*!< [-]    number of reaction wheels on the vehicle */
     float GsMatrix_B[3 *
                      THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW]; /*!< [-]   RW spin axes in body frame, three per wheel */
     float JsList[THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW];     /*!< [kgm2] RW spin-axis inertias */
-} ThrusterPlatformReferenceRwArrayConfig_c;
+} ThrusterPlatformReferenceRwArrayConfiguration_c;
 
 /**
  * @brief Plain-old-data mirror of the C++ ThrusterPlatformReferenceConfig.
@@ -44,17 +44,17 @@ typedef struct {
     float theta1Max;      /*!< [rad] absolute bound on the tip angle */
     float theta2Max;      /*!< [rad] absolute bound on the tilt angle */
     bool momentumDumping; /*!< [-]   whether reaction wheel momentum dumping is active */
-    ThrusterPlatformReferenceRwArrayConfig_c rwConfig; /*!< [-] RW configuration used for momentum dumping */
+    ThrusterPlatformReferenceRwArrayConfiguration_c rwConfig; /*!< [-] RW configuration used for momentum dumping */
 } ThrusterPlatformReferenceConfig_c;
 
 /**
  * @brief Plain-old-data mirror of the C++ ThrusterPlatformReferenceInputs.
  */
 typedef struct {
-    Vector3f_c r_CB_B;       /*!< [m]   center of mass w.r.t. B origin, B frame */
-    Vector3f_c rThrust_F;    /*!< [m]   thrust application point w.r.t. F origin, F frame */
-    Vector3f_c tHatThrust_F; /*!< [-]   thrust unit direction, F frame */
-    float maxThrust;         /*!< [N]   thrust magnitude */
+    Vector3f_c r_CB_B; /*!< [m]   center of mass w.r.t. B origin, B frame */
+    Vector3f_c r_TF_F; /*!< [m]   thrust application point w.r.t. F origin, F frame */
+    Vector3f_c tHat_F; /*!< [-]   thrust unit direction, F frame */
+    float thrust;      /*!< [N]   thrust magnitude */
     float wheelSpeeds[THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW]; /*!< [r/s] reaction-wheel speeds */
 } ThrusterPlatformReferenceInputs_c;
 
@@ -62,12 +62,12 @@ typedef struct {
  * @brief Plain-old-data mirror of the C++ ThrusterPlatformReferenceOutput.
  */
 typedef struct {
-    float theta1;                 /*!< [rad] platform tip reference angle */
-    float theta2;                 /*!< [rad] platform tilt reference angle */
-    Vector3f_c torqueRequestBody; /*!< [Nm] torque to be compensated by the RWs, B frame */
-    Vector3f_c rThrust_B;         /*!< [m]  thrust application point w.r.t. B origin, B frame */
-    Vector3f_c tHatThrust_B;      /*!< [-]  thrust unit direction, B frame */
-    float maxThrust;              /*!< [N]  thrust magnitude */
+    float theta1;      /*!< [rad] platform tip reference angle */
+    float theta2;      /*!< [rad] platform tilt reference angle */
+    Vector3f_c Lreq_B; /*!< [Nm] torque to be compensated by the RWs, B frame */
+    Vector3f_c r_TB_B; /*!< [m]  thrust application point w.r.t. B origin, B frame */
+    Vector3f_c tHat_B; /*!< [-]  thrust unit direction, B frame */
+    float thrust;      /*!< [N]  thrust magnitude */
 } ThrusterPlatformReferenceOutput_c;
 
 #ifdef __cplusplus

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
@@ -3,7 +3,6 @@
 
 #include "utilities/fsw/plainCAlgorithmDataTypes.h"
 
-#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -23,30 +22,6 @@ typedef struct {
                      THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW]; /*!< [-]   RW spin axes in body frame, three per wheel */
     float JsList[THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW];     /*!< [kgm2] RW spin-axis inertias */
 } ThrusterPlatformReferenceRwArrayConfiguration_c;
-
-/**
- * @brief Plain-old-data mirror of the C++ ThrusterPlatformReferenceConfig.
- *
- * Caller fills this struct and passes it to ThrusterPlatformReferenceAlgorithm_create or _setConfig.
- * The C++ side validates each field via ThrusterPlatformReferenceConfig::create and throws on invalid
- * input.
- *  - sigma_MB / r_BM_M / r_FM_F must be finite
- *  - K / Ki must be finite and non-negative
- *  - controlPeriod [s] must be finite and positive; used as the integration step for the dumping integral
- *  - thetaMax [rad] must lie in the open interval (0, pi); half-angle of the thrust-deflection cone
- *  - rwConfig.numRW must not exceed THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW; each spin axis a unit vector
- */
-typedef struct {
-    Vector3f_c sigma_MB;  /*!< [-]   MRP orientation of the M frame w.r.t. the B frame */
-    Vector3f_c r_BM_M;    /*!< [m]   B frame origin w.r.t. M frame origin, M frame coordinates */
-    Vector3f_c r_FM_F;    /*!< [m]   F frame origin w.r.t. M frame origin, F frame coordinates */
-    float K;              /*!< [1/s] momentum dumping proportional gain */
-    float Ki;             /*!< [-]   momentum dumping integral gain */
-    float controlPeriod;  /*!< [s]   integration step for the momentum dumping integral (> 0) */
-    float thetaMax;       /*!< [rad] half-angle of the thrust-deflection cone, in (0, pi) */
-    bool momentumDumping; /*!< [-]   whether reaction wheel momentum dumping is active */
-    ThrusterPlatformReferenceRwArrayConfiguration_c rwConfig; /*!< [-] RW configuration used for momentum dumping */
-} ThrusterPlatformReferenceConfig_c;
 
 /**
  * @brief Plain-old-data mirror of the C++ ThrusterPlatformReferenceInputs.

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
@@ -64,7 +64,6 @@ typedef struct {
 typedef struct {
     float theta1;                 /*!< [rad] platform tip reference angle */
     float theta2;                 /*!< [rad] platform tilt reference angle */
-    Vector3f_c rHat_XB_B;         /*!< [-]  thrust heading unit vector, B frame */
     Vector3f_c torqueRequestBody; /*!< [Nm] torque to be compensated by the RWs, B frame */
     Vector3f_c rThrust_B;         /*!< [m]  thrust application point w.r.t. B origin, B frame */
     Vector3f_c tHatThrust_B;      /*!< [-]  thrust unit direction, B frame */

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceTypes.h
@@ -33,6 +33,7 @@ typedef struct {
  *  - sigma_MB / r_BM_M / r_FM_F must be finite
  *  - K / Ki must be finite and non-negative
  *  - controlPeriod [s] must be finite and positive; used as the integration step for the dumping integral
+ *  - thetaMax [rad] must lie in the open interval (0, pi); half-angle of the thrust-deflection cone
  *  - rwConfig.numRW must not exceed THRUSTER_PLATFORM_REFERENCE_MAX_NUM_RW; each spin axis a unit vector
  */
 typedef struct {
@@ -42,6 +43,7 @@ typedef struct {
     float K;              /*!< [1/s] momentum dumping proportional gain */
     float Ki;             /*!< [-]   momentum dumping integral gain */
     float controlPeriod;  /*!< [s]   integration step for the momentum dumping integral (> 0) */
+    float thetaMax;       /*!< [rad] half-angle of the thrust-deflection cone, in (0, pi) */
     bool momentumDumping; /*!< [-]   whether reaction wheel momentum dumping is active */
     ThrusterPlatformReferenceRwArrayConfiguration_c rwConfig; /*!< [-] RW configuration used for momentum dumping */
 } ThrusterPlatformReferenceConfig_c;


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2201
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
V&V of thrusterPlatformReference.

The first 5 commit cleanup the module (renaming, simplifying code,...) and introduce changes like in other modules (such as a controlPeriod parameter instead of dynamically computing the control period.

The remaining commits simplify the pointing math (using vector math), remove the tip-tilt assumption of the module, and use a torque based instead of CoM-offset based logic to determine the thruster platform orientation.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't
add or update any tests justify this choice. -->
Tests updated where needed, all tests pass.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and
completeness? -->
RST updated.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.
