### PR TITLE
Propagate cssComm input timeTag to output

### DIFF
--- a/algorithms/cssComm/_tests/test_cssComm.py
+++ b/algorithms/cssComm/_tests/test_cssComm.py
@@ -66,6 +66,9 @@ def test_css_comm(num_sensors, sensor_data):
 
     # NOTE: This is nonsense. These are more or less random numbers
     css_array_msg.CosValue = sensor_data
+
+    input_time_tag = 12.5
+    css_array_msg.timeTag = input_time_tag
     css_in_msg = messaging.CSSArraySensorMsgF32().write(css_array_msg)
     module.sensorListInMsg.subscribeTo(css_in_msg)
 
@@ -95,6 +98,8 @@ def test_css_comm(num_sensors, sensor_data):
 
     # Sensors beyond numSensors must be zero
     assert np.all(output_data[:, num_sensors:] == 0.0)
+
+    assert np.all(data_log.timeTag == input_time_tag)
 
     accuracy = 1e-6
 

--- a/algorithms/cssComm/cssComm.cpp
+++ b/algorithms/cssComm/cssComm.cpp
@@ -49,6 +49,7 @@ void CssComm::updateState(uint64_t callTime) {
     std::array<double, kMaxNumCssSensors> outputValues = this->algorithm->update(inputValues);
 
     CSSArraySensorMsgF32Payload outputBuffer{};
+    outputBuffer.timeTag = inMsgBuffer.timeTag;
     std::ranges::copy(outputValues.begin(), outputValues.end(), std::ranges::begin(outputBuffer.CosValue));
 
     /*! - Write aggregate output into output message */


### PR DESCRIPTION
* **Tickets addressed:**
* **Review:** By commit  
* **Merge strategy:** Merge (no squash) 

## Description
Fix time tag issue in cssComm

## Verification
Test added to confirm time tag is added in the update call of the adapter.

## Documentation
None

## Future work
None
