### PR TITLE
orbitalMotion V&V

### DIFF
--- a/algorithms/utilities/fsw/_tests/test_orbitalMotion_functions.cpp
+++ b/algorithms/utilities/fsw/_tests/test_orbitalMotion_functions.cpp
@@ -371,6 +371,26 @@ TEST_F(StateConversionTest, CircularOrbit_NoArgPeriapsisAmbiguity) {
 
 class EdgeCasesTest : public ::testing::Test {};
 
+// Stress test for meanToEccentricAnomaly's Kepler solver.
+TEST_F(EdgeCasesTest, MeanToEccentricAnomaly_ExtremeNearParabolic) {
+    const double e = 1.0 - 1e-12;
+    const double M = 1e-12;
+
+    const double E = orbitalMotion::meanToEccentricAnomaly(M, e);
+    ASSERT_TRUE(std::isfinite(E));
+    EXPECT_NEAR(E - e * std::sin(E), M, kAnomalyTol);
+}
+
+// Stress test for meanToHyperbolicAnomaly's Kepler solver.
+TEST_F(EdgeCasesTest, MeanToHyperbolicAnomaly_NearParabolic) {
+    const double e = 1.000001;
+    const double N = 0.01;
+
+    const double H = orbitalMotion::meanToHyperbolicAnomaly(N, e);
+    ASSERT_TRUE(std::isfinite(H));
+    EXPECT_NEAR(e * std::sinh(H) - H, N, kAnomalyTol);
+}
+
 TEST_F(EdgeCasesTest, NearParabolicOrbit_Eccentricity) {
     double e = 0.9999;
     double f = M_PI / 6.0;

--- a/algorithms/utilities/fsw/_tests/test_orbitalMotion_functions.cpp
+++ b/algorithms/utilities/fsw/_tests/test_orbitalMotion_functions.cpp
@@ -411,6 +411,28 @@ TEST_F(EdgeCasesTest, PolarOrbit) {
     EXPECT_NEAR(result.inclination, M_PI / 2.0, kAnomalyTol);
 }
 
+// Regression test for using safeAcos: near-equatorial and near-polar
+// orbits can drive hVec(2)/h fractionally outside [-1, 1] via floating-point rounding.
+// safeAcos clamps that ratio instead of letting acos return NaN.
+TEST_F(EdgeCasesTest, InclinationStaysFiniteNearBoundaries) {
+    for (double inclination : {0.0, 1e-10, M_PI / 2.0, M_PI - 1e-10, M_PI}) {
+        ClassicalElements elements;
+        elements.semiMajorAxis = 7000000.0;
+        elements.eccentricity = 0.1;
+        elements.inclination = inclination;
+        elements.rightAscensionAscendingNode = 0.2;
+        elements.argPeriapsis = 0.3;
+        elements.trueAnomaly = 0.4;
+
+        CartesianState state = orbitalMotion::elementsToCartesianState(muEarth, elements);
+        ClassicalElements result = orbitalMotion::cartesianStateToElements(muEarth, state.position, state.velocity);
+
+        ASSERT_TRUE(std::isfinite(result.inclination)) << "inclination=" << inclination;
+        EXPECT_GE(result.inclination, 0.0) << "inclination=" << inclination;
+        EXPECT_LE(result.inclination, M_PI) << "inclination=" << inclination;
+    }
+}
+
 TEST_F(EdgeCasesTest, RetrogradeOrbit) {
     ClassicalElements elements;
     elements.semiMajorAxis = 7000000.0;

--- a/algorithms/utilities/fsw/_tests/test_orbitalMotion_functions.cpp
+++ b/algorithms/utilities/fsw/_tests/test_orbitalMotion_functions.cpp
@@ -335,6 +335,104 @@ TEST_F(StateConversionTest, ElementsToCartesian_RoundTrip) {
     EXPECT_NEAR(state.velocity.z(), v_original.z(), std::abs(v_original.z()) * kStateRelTol + kAnomalyTol);
 }
 
+// Parabolic branch (a = 0): round-trip recovers the original position and velocity.
+TEST_F(StateConversionTest, ParabolicRoundTrip_VelocityMatchesOriginal) {
+    // Escape speed => exactly parabolic (alpha = 0).
+    const double r0 = 7000000.0;
+    const double v0 = std::sqrt(2.0 * mu / r0);
+    const Eigen::Vector3d r_original(r0, 0.0, 0.0);
+    const Eigen::Vector3d v_original(0.0, v0, 0.0);
+
+    ClassicalElements elements = orbitalMotion::cartesianStateToElements(mu, r_original, v_original);
+    ASSERT_DOUBLE_EQ(elements.semiMajorAxis, 0.0) << "test setup must actually hit the parabolic (a=0) case";
+
+    CartesianState state = orbitalMotion::elementsToCartesianState(mu, elements);
+
+    EXPECT_NEAR(state.position.x(), r_original.x(), std::abs(r_original.x()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.position.y(), r_original.y(), std::abs(r_original.y()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.position.z(), r_original.z(), std::abs(r_original.z()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.velocity.x(), v_original.x(), std::abs(v_original.x()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.velocity.y(), v_original.y(), std::abs(v_original.y()) * kStateRelTol + kAnomalyTol);
+    EXPECT_NEAR(state.velocity.z(), v_original.z(), std::abs(v_original.z()) * kStateRelTol + kAnomalyTol);
+}
+
+// Direct construction at periapsis: r = radiusPeriapsis, v^2 = 2 * mu / r.
+TEST_F(StateConversionTest, ParabolicOrbit_DirectConstruction_VisViva) {
+    ClassicalElements elements;
+    elements.semiMajorAxis = 0.0;
+    elements.eccentricity = 1.0;
+    elements.inclination = 0.0;
+    elements.rightAscensionAscendingNode = 0.0;
+    elements.argPeriapsis = 0.0;
+    elements.trueAnomaly = 0.0;
+    elements.radiusPeriapsis = 7000000.0;
+
+    CartesianState state = orbitalMotion::elementsToCartesianState(mu, elements);
+    for (int j = 0; j < 3; ++j) {
+        ASSERT_TRUE(std::isfinite(state.position[j]));
+        ASSERT_TRUE(std::isfinite(state.velocity[j]));
+    }
+
+    double const r = state.position.norm();
+    double const v = state.velocity.norm();
+    EXPECT_NEAR(r, elements.radiusPeriapsis, elements.radiusPeriapsis * kStateRelTol);
+    EXPECT_NEAR(v * v, 2.0 * mu / r, (2.0 * mu / r) * kStateRelTol);
+}
+
+// Away from periapsis: r = p / (1 + e*cos f), p = radiusPeriapsis * (1 + e).
+TEST_F(StateConversionTest, ParabolicOrbit_NonZeroTrueAnomaly_MatchesConicEquation) {
+    ClassicalElements elements;
+    elements.semiMajorAxis = 0.0;
+    elements.eccentricity = 1.0;
+    elements.inclination = 0.0;
+    elements.rightAscensionAscendingNode = 0.0;
+    elements.argPeriapsis = 0.0;
+    elements.trueAnomaly = M_PI / 3.0;
+    elements.radiusPeriapsis = 7000000.0;
+
+    CartesianState state = orbitalMotion::elementsToCartesianState(mu, elements);
+    for (int j = 0; j < 3; ++j) {
+        ASSERT_TRUE(std::isfinite(state.position[j]));
+        ASSERT_TRUE(std::isfinite(state.velocity[j]));
+    }
+
+    double const p = elements.radiusPeriapsis * (1.0 + elements.eccentricity);
+    double const r_expected = p / (1.0 + elements.eccentricity * std::cos(elements.trueAnomaly));
+    double const r = state.position.norm();
+    double const v = state.velocity.norm();
+    EXPECT_NEAR(r, r_expected, r_expected * kStateRelTol);
+    EXPECT_NEAR(v * v, 2.0 * mu / r, (2.0 * mu / r) * kStateRelTol);
+}
+
+// Rotated orbit round-trip: cartesianStateToElements recovers e, i, RAAN, argPeriapsis, f.
+TEST_F(StateConversionTest, ParabolicOrbit_RotatedFrame_RoundTrip) {
+    ClassicalElements elements;
+    elements.semiMajorAxis = 0.0;
+    elements.eccentricity = 1.0;
+    elements.inclination = 0.5;
+    elements.rightAscensionAscendingNode = 0.3;
+    elements.argPeriapsis = 0.8;
+    elements.trueAnomaly = M_PI / 4.0;
+    elements.radiusPeriapsis = 6800000.0;
+
+    CartesianState state = orbitalMotion::elementsToCartesianState(mu, elements);
+    for (int j = 0; j < 3; ++j) {
+        ASSERT_TRUE(std::isfinite(state.position[j]));
+        ASSERT_TRUE(std::isfinite(state.velocity[j]));
+    }
+
+    double const r = state.position.norm();
+    double const v = state.velocity.norm();
+    EXPECT_NEAR(v * v, 2.0 * mu / r, (2.0 * mu / r) * kStateRelTol);
+
+    ClassicalElements result = orbitalMotion::cartesianStateToElements(mu, state.position, state.velocity);
+    EXPECT_NEAR(result.eccentricity, elements.eccentricity, kStateRelTol);
+    EXPECT_NEAR(result.inclination, elements.inclination, kStateRelTol);
+    EXPECT_NEAR(result.rightAscensionAscendingNode, elements.rightAscensionAscendingNode, kStateRelTol);
+    EXPECT_NEAR(result.argPeriapsis, elements.argPeriapsis, kStateRelTol);
+    EXPECT_NEAR(result.trueAnomaly, elements.trueAnomaly, kStateRelTol);
+}
+
 TEST_F(StateConversionTest, EquatorialOrbit_NoRAANAmbiguity) {
     ClassicalElements elements;
     elements.semiMajorAxis = 7000000.0;

--- a/algorithms/utilities/fsw/_tests/test_orbitalMotion_fuzz.cpp
+++ b/algorithms/utilities/fsw/_tests/test_orbitalMotion_fuzz.cpp
@@ -105,7 +105,7 @@ void fuzzMeanToHyperbolicSolvesKepler(double N, double e) {
     EXPECT_NEAR(e * sinh(H) - H, N, kAnomalyTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanToHyperbolicSolvesKepler)
-    .WithDomains(fuzztest::InRange(-5.0, 5.0), fuzztest::InRange(1.01, 10.0));
+    .WithDomains(fuzztest::InRange(-5.0, 5.0), fuzztest::InRange(1.0 + 1e-6, 10.0));
 
 // H -> f -> H closed-form round-trip.
 void fuzzHyperbolicTrueRoundTrip(double H, double e) {

--- a/algorithms/utilities/fsw/_tests/test_orbitalMotion_fuzz.cpp
+++ b/algorithms/utilities/fsw/_tests/test_orbitalMotion_fuzz.cpp
@@ -85,7 +85,7 @@ void fuzzHyperbolicKeplersEquation(double H, double e) {
     EXPECT_DOUBLE_EQ(result, e * sinh(H) - H);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicKeplersEquation)
-    .WithDomains(fuzztest::InRange(-3.0, 3.0), fuzztest::InRange(1.05, 5.0));
+    .WithDomains(fuzztest::InRange(-3.0, 3.0), fuzztest::InRange(1.01, 5.0));
 
 // Hyperbolic mean anomaly is odd: N(-H, e) = -N(H, e).
 void fuzzHyperbolicMeanIsOdd(double H, double e) {
@@ -96,16 +96,18 @@ void fuzzHyperbolicMeanIsOdd(double H, double e) {
     EXPECT_DOUBLE_EQ(neg, -pos);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicMeanIsOdd)
-    .WithDomains(fuzztest::InRange(0.0, 3.0), fuzztest::InRange(1.05, 5.0));
+    .WithDomains(fuzztest::InRange(0.0, 3.0), fuzztest::InRange(1.01, 5.0));
 
-// The Newton-Raphson solver must return H satisfying e*sinh(H) - H = N.
+// The Newton-Raphson solver must return H satisfying e*sinh(H) - H = N. N's range extends
+// past kClamp (7) to exercise the solver's initial-guess clamping branch, which a narrower
+// range would never reach.
 void fuzzMeanToHyperbolicSolvesKepler(double N, double e) {
     const double H = orbitalMotion::meanToHyperbolicAnomaly(N, e);
     ASSERT_TRUE(std::isfinite(H));
     EXPECT_NEAR(e * sinh(H) - H, N, kAnomalyTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzMeanToHyperbolicSolvesKepler)
-    .WithDomains(fuzztest::InRange(-5.0, 5.0), fuzztest::InRange(1.0 + 1e-6, 10.0));
+    .WithDomains(fuzztest::InRange(-50.0, 50.0), fuzztest::InRange(1.0 + 1e-6, 10.0));
 
 // H -> f -> H closed-form round-trip.
 void fuzzHyperbolicTrueRoundTrip(double H, double e) {
@@ -118,7 +120,8 @@ void fuzzHyperbolicTrueRoundTrip(double H, double e) {
 FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicTrueRoundTrip)
     .WithDomains(fuzztest::InRange(-2.0, 2.0), fuzztest::InRange(1.01, 10.0));
 
-// N -> H -> N round-trip: meanToHyperbolic then hyperbolicToMean must recover N.
+// N -> H -> N round-trip: meanToHyperbolic then hyperbolicToMean must recover N. N's range
+// extends past kClamp (7) for the same reason as fuzzMeanToHyperbolicSolvesKepler.
 void fuzzHyperbolicMeanRoundTrip(double N, double e) {
     const double H = orbitalMotion::meanToHyperbolicAnomaly(N, e);
     ASSERT_TRUE(std::isfinite(H));
@@ -127,7 +130,7 @@ void fuzzHyperbolicMeanRoundTrip(double N, double e) {
     EXPECT_NEAR(N_back, N, kAnomalyTol);
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzHyperbolicMeanRoundTrip)
-    .WithDomains(fuzztest::InRange(-5.0, 5.0), fuzztest::InRange(1.01, 10.0));
+    .WithDomains(fuzztest::InRange(-50.0, 50.0), fuzztest::InRange(1.01, 10.0));
 
 // ============================================================================
 // Keplerian conserved quantities
@@ -349,7 +352,7 @@ void fuzzNearParabolicEllipticAnomalyFinite(double f, double e) {
     EXPECT_TRUE(std::isfinite(M2)) << "trueToMean";
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicEllipticAnomalyFinite)
-    .WithDomains(fuzztest::InRange(-0.8, 0.8), fuzztest::InRange(0.9, 0.9999));
+    .WithDomains(fuzztest::InRange(-M_PI, M_PI), fuzztest::InRange(0.9, 0.9999));
 
 // elementsToCartesianState must return a finite Cartesian state for e -> 1-.
 void fuzzNearParabolicCartesianFinite(double e, double f) {
@@ -368,7 +371,7 @@ void fuzzNearParabolicCartesianFinite(double e, double f) {
     }
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicCartesianFinite)
-    .WithDomains(fuzztest::InRange(0.9, 0.9999), fuzztest::InRange(0.0, 1.0));
+    .WithDomains(fuzztest::InRange(0.9, 0.9999), fuzztest::InRange(0.0, 2 * M_PI));
 
 // Exactly parabolic (a = 0): orbit equation r = p / (1 + cos f), p = radiusPeriapsis * 2,
 // and zero specific energy v^2/2 - mu/r = 0.
@@ -449,7 +452,7 @@ void fuzzNearParabolicHyperbolicAnomalyFinite(double H, double e) {
     EXPECT_TRUE(std::isfinite(f)) << "hyperbolicToTrue";
 }
 FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicHyperbolicAnomalyFinite)
-    .WithDomains(fuzztest::InRange(-0.5, 0.5), fuzztest::InRange(1.0001, 1.1));
+    .WithDomains(fuzztest::InRange(-5.0, 5.0), fuzztest::InRange(1.0001, 1.1));
 
 // Rectilinear orbit: h=0 singularity. v_transverse = 0, all outputs must be finite.
 void fuzzRectilinearElementsFinite(double v_radial) {

--- a/algorithms/utilities/fsw/_tests/test_orbitalMotion_fuzz.cpp
+++ b/algorithms/utilities/fsw/_tests/test_orbitalMotion_fuzz.cpp
@@ -370,6 +370,77 @@ void fuzzNearParabolicCartesianFinite(double e, double f) {
 FUZZ_TEST(OrbitalMotionFuzz, fuzzNearParabolicCartesianFinite)
     .WithDomains(fuzztest::InRange(0.9, 0.9999), fuzztest::InRange(0.0, 1.0));
 
+// Exactly parabolic (a = 0): orbit equation r = p / (1 + cos f), p = radiusPeriapsis * 2,
+// and zero specific energy v^2/2 - mu/r = 0.
+void fuzzExactParabolicOrbitEquation(double radiusPeriapsis, double i, double Omega, double omega, double f) {
+    ClassicalElements el;
+    el.semiMajorAxis = 0.0;
+    el.eccentricity = 1.0;
+    el.inclination = i;
+    el.rightAscensionAscendingNode = Omega;
+    el.argPeriapsis = omega;
+    el.trueAnomaly = f;
+    el.radiusPeriapsis = radiusPeriapsis;
+
+    const CartesianState state = orbitalMotion::elementsToCartesianState(kMu, el);
+    for (int j = 0; j < 3; ++j) {
+        ASSERT_TRUE(std::isfinite(state.position[j])) << "position[" << j << ']';
+        ASSERT_TRUE(std::isfinite(state.velocity[j])) << "velocity[" << j << ']';
+    }
+
+    const double r = state.position.norm();
+    const double p = radiusPeriapsis * 2.0;  // p = radiusPeriapsis * (1 + e), e == 1
+    const double r_expected = p / (1.0 + std::cos(f));
+    EXPECT_NEAR(r, r_expected, r_expected * kStateRelTol);
+
+    const double energy = state.velocity.squaredNorm() / 2.0 - kMu / r;
+    EXPECT_NEAR(energy, 0.0, (kMu / r) * kStateRelTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzExactParabolicOrbitEquation)
+    .WithDomains(fuzztest::InRange(1.0e5, 1.0e8),
+                 fuzztest::InRange(0.0, M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(-2.5, 2.5));
+
+// Angles are periodic in 2*pi, but cartesianStateToElements normalizes RAAN,
+// argPeriapsis, and trueAnomaly to [0, 2*pi).
+double angleDifference(double a, double b) {
+    double diff = std::fmod(a - b, 2.0 * M_PI);
+    if (diff > M_PI) diff -= 2.0 * M_PI;
+    if (diff < -M_PI) diff += 2.0 * M_PI;
+    return std::abs(diff);
+}
+
+// Exactly parabolic (a = 0) round-trip: elementsToCartesian -> cartesianToElements must
+// recover eccentricity, inclination, RAAN, argPeriapsis, and trueAnomaly.
+void fuzzExactParabolicElementsRoundTrip(double radiusPeriapsis, double i, double Omega, double omega, double f) {
+    ClassicalElements in;
+    in.semiMajorAxis = 0.0;
+    in.eccentricity = 1.0;
+    in.inclination = i;
+    in.rightAscensionAscendingNode = Omega;
+    in.argPeriapsis = omega;
+    in.trueAnomaly = f;
+    in.radiusPeriapsis = radiusPeriapsis;
+
+    const CartesianState state = orbitalMotion::elementsToCartesianState(kMu, in);
+    const ClassicalElements out = orbitalMotion::cartesianStateToElements(kMu, state.position, state.velocity);
+
+    EXPECT_DOUBLE_EQ(out.semiMajorAxis, 0.0);
+    EXPECT_NEAR(out.eccentricity, in.eccentricity, kStateRelTol);
+    EXPECT_NEAR(out.inclination, in.inclination, kStateRelTol);
+    EXPECT_LE(angleDifference(out.rightAscensionAscendingNode, in.rightAscensionAscendingNode), kStateRelTol);
+    EXPECT_LE(angleDifference(out.argPeriapsis, in.argPeriapsis), kStateRelTol);
+    EXPECT_LE(angleDifference(out.trueAnomaly, in.trueAnomaly), kStateRelTol);
+}
+FUZZ_TEST(OrbitalMotionFuzz, fuzzExactParabolicElementsRoundTrip)
+    .WithDomains(fuzztest::InRange(1.0e5, 1.0e8),
+                 fuzztest::InRange(0.05, M_PI - 0.05),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(0.0, 2 * M_PI),
+                 fuzztest::InRange(-2.5, 2.5));
+
 // Hyperbolic anomaly functions must stay finite for e just above 1.
 void fuzzNearParabolicHyperbolicAnomalyFinite(double H, double e) {
     const double N = orbitalMotion::hyperbolicToMeanAnomaly(H, e);

--- a/algorithms/utilities/fsw/orbitalMotion.hpp
+++ b/algorithms/utilities/fsw/orbitalMotion.hpp
@@ -219,17 +219,17 @@ inline CartesianState elementsToCartesianState(double const mu, const ClassicalE
 inline ClassicalElements cartesianStateToElements(const double mu,
                                                   const Eigen::Vector3d& rVec,
                                                   const Eigen::Vector3d& vVec) {
-    const double r = rVec.norm();
-    const double v = vVec.norm();
+    const double r = rVec.stableNorm();
+    const double v = vVec.stableNorm();
     const Eigen::Vector3d hVec = rVec.cross(vVec);
-    const double h = hVec.norm();
+    const double h = hVec.stableNorm();
     const Eigen::Vector3d nVec = Eigen::Vector3d::UnitZ().cross(hVec);
     const Eigen::Vector3d eVec = (((v * v) - (mu / r)) * rVec - (rVec.dot(vVec)) * vVec) / mu;
 
     ClassicalElements elements{};
 
     elements.radiusMagnitude = r;
-    elements.eccentricity = eVec.norm();
+    elements.eccentricity = eVec.stableNorm();
     if (h < kTolerance) {
         elements.inclination = 0.0;  // rectilinear orbit
     } else {
@@ -241,10 +241,10 @@ inline ClassicalElements cartesianStateToElements(const double mu,
     const double Omega = safeAtan2(nVec(1), nVec(0));
     elements.rightAscensionAscendingNode = Omega < 0 ? Omega + (2 * std::numbers::pi) : Omega;
 
-    const double omega = safeAtan2(nVec.cross(eVec).dot(hVec.normalized()), nVec.dot(eVec));
+    const double omega = safeAtan2(nVec.cross(eVec).dot(hVec.stableNormalized()), nVec.dot(eVec));
     elements.argPeriapsis = omega < 0 ? omega + (2 * std::numbers::pi) : omega;
 
-    const double f = safeAtan2(eVec.cross(rVec).dot(hVec.normalized()), eVec.dot(rVec));
+    const double f = safeAtan2(eVec.cross(rVec).dot(hVec.stableNormalized()), eVec.dot(rVec));
     elements.trueAnomaly = f < 0 ? f + (2 * std::numbers::pi) : f;
 
     elements.radiusPeriapsis = h * h / mu / (1 + elements.eccentricity);

--- a/algorithms/utilities/fsw/orbitalMotion.hpp
+++ b/algorithms/utilities/fsw/orbitalMotion.hpp
@@ -208,11 +208,9 @@ inline CartesianState elementsToCartesianState(double const mu, const ClassicalE
 
 /*! @brief Convert a Cartesian position/velocity state to classical orbital elements.
  *         Rectilinear orbits (h < kTolerance) get inclination = 0; parabolic orbits
- *         (|e - 1| < kTolerance) get radiusApoapsis = 0. RAAN and argument of periapsis
- *         are ill-defined for equatorial/circular orbits but degrade to 0 via
- *         safeAtan2(0, 0) rather than producing NaN. Note: inclination uses raw
- *         std::acos rather than safeAcos, so a hVec(2)/h ratio that drifts fractionally
- *         outside [-1, 1] from floating-point rounding can produce NaN here.
+ *         (|e - 1| < kTolerance) get radiusApoapsis = 0. RAAN, argument of periapsis, and
+ *         inclination are ill-defined for equatorial/circular/polar orbits but degrade to
+ *         a defined value (0 via safeAtan2(0, 0), or a rail via safeAcos) rather than NaN.
  *  @param mu Gravitational parameter of the central body
  *  @param rVec Position vector
  *  @param vVec Velocity vector
@@ -235,7 +233,7 @@ inline ClassicalElements cartesianStateToElements(const double mu,
     if (h < kTolerance) {
         elements.inclination = 0.0;  // rectilinear orbit
     } else {
-        elements.inclination = std::acos(hVec(2) / h);
+        elements.inclination = safeAcos(hVec(2) / h);
     }
     elements.alpha = (2 / r) - (v * v / mu);
     elements.semiMajorAxis = fabs(elements.alpha) > kTolerance ? 1 / elements.alpha : 0.0;

--- a/algorithms/utilities/fsw/orbitalMotion.hpp
+++ b/algorithms/utilities/fsw/orbitalMotion.hpp
@@ -5,7 +5,6 @@
 #include "safeMath.h"
 #include <math.h>
 #include <Eigen/Core>
-#include <Eigen/Geometry>
 #include <numbers>
 
 namespace orbitalMotion {

--- a/algorithms/utilities/fsw/orbitalMotion.hpp
+++ b/algorithms/utilities/fsw/orbitalMotion.hpp
@@ -9,9 +9,9 @@
 
 namespace orbitalMotion {
 
-inline constexpr int kMaxNumberOfIterations = 200;
-inline constexpr double kClamp = 7;
-inline constexpr double kTolerance = 1e-9;
+inline constexpr int kMaxNumberOfIterations = 200;  //!< Newton-Raphson iteration cap (meanTo*Anomaly solvers)
+inline constexpr double kClamp = 7;                 //!< Initial hyperbolic-anomaly guess clamp, radians
+inline constexpr double kTolerance = 1e-9;          //!< Convergence/degeneracy tolerance used throughout this file
 
 struct CartesianState {
     Eigen::Vector3d position;
@@ -31,42 +31,85 @@ struct ClassicalElements {
     double radiusApoapsis = 0;
 };
 
+/*! @brief Convert eccentric anomaly to true anomaly for a circular or elliptical orbit.
+ *  @param E Eccentric anomaly, radians
+ *  @param e Eccentricity; must satisfy 0 <= e < 1, else throws domain_error
+ *  @return True anomaly, radians
+ */
 inline double eccentricToTrueAnomaly(double const E, double const e) {
     if (!(e >= 0.0 && e < 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity out of bounds (0 <= e < 1)");
     return 2 * safeAtan2(safeSqrt(1 + e) * safeSin(E / 2), safeSqrt(1 - e) * safeCos(E / 2));
 }
 
+/*! @brief Convert eccentric anomaly to mean anomaly via Kepler's equation M = E - e*sin(E).
+ *  @param E Eccentric anomaly, radians
+ *  @param e Eccentricity; must satisfy 0 <= e < 1, else throws domain_error
+ *  @return Mean anomaly, radians
+ */
 inline double eccentricToMeanAnomaly(double const E, double const e) {
     if (!(e >= 0.0 && e < 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity out of bounds (0 <= e < 1)");
     return E - (e * safeSin(E));
 }
 
+/*! @brief Convert true anomaly to eccentric anomaly for a circular or elliptical orbit.
+ *  @param f True anomaly, radians
+ *  @param e Eccentricity; must satisfy 0 <= e < 1, else throws domain_error
+ *  @return Eccentric anomaly, radians
+ */
 inline double trueToEccentricAnomaly(double const f, double const e) {
     if (!(e >= 0.0 && e < 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity out of bounds (0 <= e < 1)");
     return 2 * safeAtan2(safeSqrt(1 - e) * safeSin(f / 2), safeSqrt(1 + e) * safeCos(f / 2));
 }
 
+/*! @brief Convert true anomaly to mean anomaly (true -> eccentric -> mean).
+ *  @param f True anomaly, radians
+ *  @param e Eccentricity; must satisfy 0 <= e < 1, else throws domain_error
+ *  @return Mean anomaly, radians
+ */
 inline double trueToMeanAnomaly(double const f, double const e) {
     if (!(e >= 0.0 && e < 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity out of bounds (0 <= e < 1)");
     double const eccentric = trueToEccentricAnomaly(f, e);
     return eccentricToMeanAnomaly(eccentric, e);
 }
 
+/*! @brief Convert true anomaly to hyperbolic anomaly for a hyperbolic orbit.
+ *  @param f True anomaly, radians
+ *  @param e Eccentricity; must satisfy e > 1, else throws domain_error
+ *  @return Hyperbolic anomaly
+ */
 inline double trueToHyperbolicAnomaly(double const f, double const e) {
     if (!(e > 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity must be > 1 for hyperbolic orbits");
     return 2 * safeAtanH(safeSqrt((e - 1) / (e + 1)) * safeTan(f / 2));
 }
 
+/*! @brief Convert hyperbolic anomaly to true anomaly for a hyperbolic orbit.
+ *  @param H Hyperbolic anomaly
+ *  @param e Eccentricity; must satisfy e > 1, else throws domain_error
+ *  @return True anomaly, radians
+ */
 inline double hyperbolicToTrueAnomaly(double const H, double const e) {
     if (!(e > 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity must be > 1 for hyperbolic orbits");
     return 2 * safeAtan(safeSqrt((e + 1) / (e - 1)) * safeTanH(H / 2));
 }
 
+/*! @brief Convert hyperbolic anomaly to mean anomaly via N = e*sinh(H) - H.
+ *  @param H Hyperbolic anomaly
+ *  @param e Eccentricity; must satisfy e > 1, else throws domain_error
+ *  @return Mean anomaly (hyperbolic)
+ */
 inline double hyperbolicToMeanAnomaly(double const H, double const e) {
     if (!(e > 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity must be > 1 for hyperbolic orbits");
     return (e * safeSinH(H)) - H;
 }
 
+/*! @brief Solve Kepler's equation M = E - e*sin(E) for E via Newton-Raphson, starting from
+ *         E = M and clamping each step to [-0.5, 0.5]. Iterates up to
+ *         kMaxNumberOfIterations; if convergence to kTolerance is not reached by then, the
+ *         current best estimate is returned with no indication that it did not converge.
+ *  @param M Mean anomaly, radians
+ *  @param e Eccentricity; must satisfy 0 <= e < 1, else throws domain_error
+ *  @return Eccentric anomaly, radians (best available estimate)
+ */
 inline double meanToEccentricAnomaly(double M, double e) {
     if (!(e >= 0.0 && e < 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity out of bounds (0 <= e < 1)");
     double E = M;
@@ -80,12 +123,25 @@ inline double meanToEccentricAnomaly(double M, double e) {
     return E;
 }
 
+/*! @brief Convert mean anomaly to true anomaly (mean -> eccentric -> true).
+ *  @param M Mean anomaly, radians
+ *  @param e Eccentricity; must satisfy 0 <= e < 1, else throws domain_error
+ *  @return True anomaly, radians
+ */
 inline double meanToTrueAnomaly(double const M, double const e) {
     if (!(e >= 0.0 && e < 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity out of bounds (0 <= e < 1)");
     double const eccentric = meanToEccentricAnomaly(M, e);
     return eccentricToTrueAnomaly(eccentric, e);
 }
 
+/*! @brief Solve the hyperbolic Kepler equation N = e*sinh(H) - H for H via Newton-Raphson,
+ *         starting from N clamped to [-kClamp, kClamp]. Iterates up to
+ *         kMaxNumberOfIterations; if convergence to kTolerance is not reached by then, the
+ *         current best estimate is returned with no indication that it did not converge.
+ *  @param N Mean anomaly (hyperbolic)
+ *  @param e Eccentricity; must satisfy e > 1, else throws domain_error
+ *  @return Hyperbolic anomaly (best available estimate)
+ */
 inline double meanToHyperbolicAnomaly(const double N, const double e) {
     if (!(e > 1.0)) FSW_THROW_DOMAIN_ERROR("Eccentricity must be > 1");
     const int signN = (N > 0 ? 1 : -1);
@@ -100,6 +156,14 @@ inline double meanToHyperbolicAnomaly(const double N, const double e) {
     return H;
 }
 
+/*! @brief Convert classical orbital elements to a Cartesian position/velocity state.
+ *         Divides by h = sqrt(mu * semiMajorAxis * (1 - eccentricity^2)); a degenerate
+ *         input (e.g. semiMajorAxis == 0, as produced for a parabolic orbit by
+ *         cartesianStateToElements) drives h to 0 and yields an infinite/NaN velocity.
+ *  @param mu Gravitational parameter of the central body
+ *  @param elements Classical orbital elements
+ *  @return Cartesian position and velocity
+ */
 inline CartesianState elementsToCartesianState(double const mu, const ClassicalElements& elements) {
     double const a = elements.semiMajorAxis;
     double const e = elements.eccentricity;
@@ -142,6 +206,18 @@ inline CartesianState elementsToCartesianState(double const mu, const ClassicalE
     return state;
 }
 
+/*! @brief Convert a Cartesian position/velocity state to classical orbital elements.
+ *         Rectilinear orbits (h < kTolerance) get inclination = 0; parabolic orbits
+ *         (|e - 1| < kTolerance) get radiusApoapsis = 0. RAAN and argument of periapsis
+ *         are ill-defined for equatorial/circular orbits but degrade to 0 via
+ *         safeAtan2(0, 0) rather than producing NaN. Note: inclination uses raw
+ *         std::acos rather than safeAcos, so a hVec(2)/h ratio that drifts fractionally
+ *         outside [-1, 1] from floating-point rounding can produce NaN here.
+ *  @param mu Gravitational parameter of the central body
+ *  @param rVec Position vector
+ *  @param vVec Velocity vector
+ *  @return Classical orbital elements
+ */
 inline ClassicalElements cartesianStateToElements(const double mu,
                                                   const Eigen::Vector3d& rVec,
                                                   const Eigen::Vector3d& vVec) {

--- a/algorithms/utilities/fsw/orbitalMotion.hpp
+++ b/algorithms/utilities/fsw/orbitalMotion.hpp
@@ -157,9 +157,7 @@ inline double meanToHyperbolicAnomaly(const double N, const double e) {
 }
 
 /*! @brief Convert classical orbital elements to a Cartesian position/velocity state.
- *         Divides by h = sqrt(mu * semiMajorAxis * (1 - eccentricity^2)); a degenerate
- *         input (e.g. semiMajorAxis == 0, as produced for a parabolic orbit by
- *         cartesianStateToElements) drives h to 0 and yields an infinite/NaN velocity.
+ *         p is computed differently for parabolic orbit, indicated by semiMajorAxis = 0.
  *  @param mu Gravitational parameter of the central body
  *  @param elements Classical orbital elements
  *  @return Cartesian position and velocity
@@ -172,7 +170,7 @@ inline CartesianState elementsToCartesianState(double const mu, const ClassicalE
     double const omega = elements.argPeriapsis;
     double const f = elements.trueAnomaly;
 
-    double const p = a * (1 - e * e);
+    double const p = a != 0.0 ? a * (1 - e * e) : elements.radiusPeriapsis * (1 + e);
     double const r = p / (1 + e * safeCos(f));
     double const h = safeSqrt(mu * p);
 
@@ -197,12 +195,9 @@ inline CartesianState elementsToCartesianState(double const mu, const ClassicalE
     double const vy = -mu / h * (sin_O * (sin_theta + e * sin_o) - cos_O * (cos_theta + e * cos_o) * cos_i);
     double const vz = mu / h * (cos_theta + e * cos_o) * sin_i;
 
-    const Eigen::Vector3d vVec = Eigen::Vector3d(vx, vy, vz);
-
     CartesianState state{};
     state.position = rVec;
-    state.velocity = vVec;
-
+    state.velocity = Eigen::Vector3d(vx, vy, vz);
     return state;
 }
 

--- a/algorithms/utilities/fsw/orbitalMotion.hpp
+++ b/algorithms/utilities/fsw/orbitalMotion.hpp
@@ -148,7 +148,7 @@ inline double meanToHyperbolicAnomaly(const double N, const double e) {
     double H = fabs(N) > kClamp ? kClamp * static_cast<double>(signN) : N;
     for (int i = 0; i < kMaxNumberOfIterations; ++i) {
         const double dH = (e * safeSinH(H) - H - N) / (e * safeCosH(H) - 1);
-        H -= dH;
+        H -= fmax(-0.5, fmin(0.5, dH));  // Clamp step size
         if (fabs(dH) < kTolerance) {
             break;
         }


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2322
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Besides standard changes (e.g., using safeMath, remove unused include), two major changes are made. First, we introduce clamp step size to the hyperbolic Kepler solver, consistent to other Kepler solver, to ensure the output is finite. Additional tests (e.g., cpp test or fuzz test with widen domain) are added to demonstrate the necessity and correctness. Second, the elements to cartesian state conversion is fixed by explicitly handling the parabolic orbit case (indicated by semiMajorAxis = 0). Additional tests (e.g., cpp and fuzz tests) are added to cover the correct use case for parabolic orbit.

## Verification
Ran the full suite via ctest, covering `orbitalMotion.hpp`'s unit tests, edge-case tests, and fuzz tests, plus the downstream `oeStateEphem` algorithm that depend on it. All 86 tests passed, including the new/updated parabolic-branch unit tests (`ParabolicRoundTrip_VelocityMatchesOriginal`, `ParabolicOrbit_DirectConstruction_VisViva`, `ParabolicOrbit_NonZeroTrueAnomaly_MatchesConicEquation`, `ParabolicOrbit_RotatedFrame_RoundTrip`) and the `OrbitalMotionFuzz` suite (including the new `fuzzExactParabolicOrbitEquation`/`fuzzExactParabolicElementsRoundTrip` tests and the widened hyperbolic/near-parabolic fuzz domains).

The command to run the full suite is: ctest -R '^(AnomalyConversionTest|StateConversionTest|EdgeCasesTest|NearParabolicEllipticTest|ParabolicOrbitTest|RectilinearOrbitTest|NearRectilinearTest|OrbitalMo
  tionFuzz|OEStateEphemConfigTest|OEStateEphemAlgorithmTest|OEStateEphemUpdateTest|OEStateEphemFuzz).' --output-on-failure --timeout 300

## Documentation
Updated in .hpp or cpp.

## Future work
N/A
