### PR TITLE
Narrow the scope of the excluded std:: includes check

### DIFF
--- a/.github/scripts/check_freestanding_includes.sh
+++ b/.github/scripts/check_freestanding_includes.sh
@@ -4,17 +4,19 @@
 # Scans production algorithm sources (excluding _tests/ directories) for
 # headers that are not available in a freestanding C++ environment.
 #
-# Usage:  check_freestanding_includes.sh <source_root>
+# Usage:  check_freestanding_includes.sh <path> [<path>...]
+#         Each path may be a directory (swept recursively) or a single file, so
+#         the check can run either as a full sweep or over just the files a
+#         commit touched.
 # Example: check_freestanding_includes.sh algorithms/
+#          check_freestanding_includes.sh algorithms/triad/triadAlgorithm.cpp
 
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <source_root>" >&2
+  echo "Usage: $0 <path> [<path>...]" >&2
   exit 2
 fi
-
-SOURCE_ROOT="$1"
 
 # Headers that fail under -ffreestanding (GCC/GNAT Pro RISC-V).
 BANNED_HEADERS=(
@@ -41,10 +43,13 @@ pattern="#include[[:space:]]*<(${joined})>"
 
 VIOLATIONS=0
 
-while IFS= read -r file; do
+check_file() {
+  local file="$1"
+  local matches match
+
   # Skip test directories
   if [[ "$file" == */_tests/* ]]; then
-    continue
+    return
   fi
 
   if matches=$(grep -nE "$pattern" "$file" 2>/dev/null); then
@@ -53,7 +58,20 @@ while IFS= read -r file; do
       VIOLATIONS=$((VIOLATIONS + 1))
     done <<< "$matches"
   fi
-done < <(find "$SOURCE_ROOT" -type f \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' \))
+}
+
+for target in "$@"; do
+  if [[ -d "$target" ]]; then
+    while IFS= read -r file; do
+      check_file "$file"
+    done < <(find "$target" -type f \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' \))
+  elif [[ -f "$target" ]]; then
+    check_file "$target"
+  else
+    echo "No such file or directory: ${target}" >&2
+    exit 2
+  fi
+done
 
 if [[ $VIOLATIONS -gt 0 ]]; then
   echo ""

--- a/.github/scripts/check_freestanding_includes.sh
+++ b/.github/scripts/check_freestanding_includes.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # check_freestanding_includes.sh
 #
-# Scans production algorithm sources (excluding _tests/ directories) for
-# headers that are not available in a freestanding C++ environment.
+# Scans the sources that compile into the freestanding library for headers that
+# are not available in a freestanding C++ environment.
+#
+# Only the code that reaches libgncAlgorithms.a is in scope: the
+# algorithm's *Algorithm / *Algorithm_c / *Types files (see the file(GLOB) in
+# the root CMakeLists.txt) and the header-only libraries they pull in
+# (utilities/fsw, filteringCore).
 #
 # Usage:  check_freestanding_includes.sh <path> [<path>...]
 #         Each path may be a directory (swept recursively) or a single file, so
 #         the check can run either as a full sweep or over just the files a
-#         commit touched.
+#         commit touched. Out-of-scope paths are skipped silently.
 # Example: check_freestanding_includes.sh algorithms/
 #          check_freestanding_includes.sh algorithms/triad/triadAlgorithm.cpp
 
@@ -41,14 +46,46 @@ joined=$(printf '%s|' "${BANNED_HEADERS[@]}")
 joined="${joined%|}"  # strip trailing |
 pattern="#include[[:space:]]*<(${joined})>"
 
+# Returns 0 when the given path is part of the freestanding build. This is the
+# single source of truth for scope: both the directory sweep and the explicit
+# file list run through it, so a full run and an incremental run always agree.
+is_in_scope() {
+  local path="${1#./}"
+
+  # Hosted-only test code.
+  if [[ "$path" == */_tests/* ]]; then
+    return 1
+  fi
+
+  # Anchor on algorithms/ so absolute and repository-relative paths both match.
+  local rel="${path##*algorithms/}"
+  if [[ "$rel" == "$path" && "$path" != algorithms/* ]]; then
+    return 1
+  fi
+
+  # Header-only libraries the algorithm sources include transitively.
+  if [[ "$rel" =~ ^utilities/fsw/[^/]+\.(h|hpp)$ ]]; then
+    return 0
+  fi
+  if [[ "$rel" =~ ^filteringCore/[^/]+\.(h|hpp)$ ]]; then
+    return 0
+  fi
+
+  # The per-algorithm freestanding core, its C shim, and the shim's POD types.
+  if [[ "$rel" =~ ^[^/]+/[^/]*(Algorithm(_c)?\.(h|cpp)|Types\.h)$ ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 VIOLATIONS=0
 
 check_file() {
   local file="$1"
   local matches match
 
-  # Skip test directories
-  if [[ "$file" == */_tests/* ]]; then
+  if ! is_in_scope "$file"; then
     return
   fi
 
@@ -75,7 +112,7 @@ done
 
 if [[ $VIOLATIONS -gt 0 ]]; then
   echo ""
-  echo "Found ${VIOLATIONS} banned include(s) in production code."
+  echo "Found ${VIOLATIONS} banned include(s) in freestanding code."
   echo "These headers are not available in freestanding mode."
   exit 1
 fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,16 @@ repos:
           name: Check for banned hosted includes
           language: script
           entry: .github/scripts/check_freestanding_includes.sh
-          args: [algorithms/]
-          files: '\.(h|hpp|cpp)$'
+          # Only the sources that compile into the freestanding library. The
+          # script re-applies this scope itself, so this filter is just a way to
+          # avoid running the hook on hosted-only edits. (?x) turns on verbose
+          # mode, which ignores whitespace and enables the trailing comments.
+          files: |-
+            (?x)
+              ^algorithms/(
+                  [^/]+/[^/]*(Algorithm(_c)?\.(h|cpp)|Types\.h)  # algorithm core, C shim, shim POD types
+                | utilities/fsw/[^/]+\.(h|hpp)                   # header-only FswUtilities
+                | filteringCore/[^/]+\.(h|hpp)                   # header-only filter infrastructure
+              )$
           exclude: '/_tests/'
-          pass_filenames: false
+          pass_filenames: true


### PR DESCRIPTION
* **Tickets addressed:**  ema-gnc-2382
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The custom pre-commit task which checks for non-freestanding `std::` includes had too broad a search. It picked up module adapters which aren't subject to the same restriction. This PR narrows the search scope so that only freestanding targeted code is scanned.

## Verification
Manually verified.

## Documentation
NA

## Future work
None
