### PR TITLE
Fix Eigen includes and add a header self-sufficiency check

### DIFF
--- a/.github/scripts/check_header_self_sufficiency.sh
+++ b/.github/scripts/check_header_self_sufficiency.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# check_header_self_sufficiency.sh
+#
+# Compiles each header in the freestanding build as its own translation unit, so
+# a header that uses a declaration it never includes the definition for fails
+# here instead of in whichever consumer happens to include the right thing first.
+#
+# The motivating case is Eigen's module split: Eigen/Core *declares* members such
+# as MatrixBase::cross(), but Eigen/Geometry *defines* them. A header that calls
+# .cross() with only <Eigen/Core> compiles cleanly for as long as every consumer
+# drags in Geometry by some other path, and breaks the moment one does not. GCC
+# reports that as "inline function ... used but never defined" against the Eigen
+# header, which hides the fact that the defect is ours. clang-tidy cannot cover
+# this: misc-include-cleaner is disabled in .clang-tidy (too many false positives
+# on math and Eigen includes).
+#
+# Scope is the same idea as check_freestanding_includes.sh: only the headers that
+# reach libgncAlgorithms.a. Test code is hosted-only and excluded.
+#
+# Usage:  check_header_self_sufficiency.sh <path> [<path>...]
+#         Each path may be a directory (swept recursively) or a single file, so
+#         the check can run either as a full sweep or over just the files a
+#         commit touched. Out-of-scope paths are skipped silently.
+# Example: check_header_self_sufficiency.sh algorithms/
+#          check_header_self_sufficiency.sh algorithms/utilities/fsw/orbitalMotion.hpp
+#
+# Environment:
+#   EIGEN3_DIR  Required. Root of the freestanding Eigen checkout (the directory
+#               containing 'Eigen/'), matching the root CMakeLists.txt variable.
+#   CXX         Compiler to use. Defaults to g++-13, as in the CMake presets.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <path> [<path>...]" >&2
+  exit 2
+fi
+
+CXX="${CXX:-g++-13}"
+
+if [[ -z "${EIGEN3_DIR:-}" ]]; then
+  echo "EIGEN3_DIR is not set; it must point at the freestanding Eigen checkout." >&2
+  exit 2
+fi
+if [[ ! -d "${EIGEN3_DIR}/Eigen" ]]; then
+  echo "Eigen not found under ${EIGEN3_DIR}" >&2
+  exit 2
+fi
+if ! command -v "${CXX}" >/dev/null 2>&1; then
+  echo "Compiler '${CXX}' not found; set CXX to the compiler used by the presets." >&2
+  exit 2
+fi
+
+if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
+# Mirror the per-algorithm compile setup from add_algorithm() in the root
+# CMakeLists.txt: the freestanding force-include, EIGEN_FREESTANDING, the repo
+# root, and the algorithms/ prefix that FswUtilities supplies. The header's own
+# directory is added per file below, standing in for the per-target include dir.
+FORCE_INCLUDE="${EIGEN3_DIR}/Eigen/src/Freestanding/all_freestanding.hpp"
+COMMON_FLAGS=(
+  -std=gnu++23
+  -fsyntax-only
+  -DEIGEN_FREESTANDING=1
+  -include "${FORCE_INCLUDE}"
+  -I"${REPO_ROOT}"
+  -I"${REPO_ROOT}/algorithms"
+  -I"${EIGEN3_DIR}"
+)
+
+# The algorithms that actually compile into libgncAlgorithms.a, read from the
+# set(algorithms ...) list in the root CMakeLists.txt so this stays correct as
+# algorithms are added. Anything outside that list (e.g. mrpSteering,
+# rwMotorTorque) is built only by the xmera module build, where the superproject
+# supplies architecture/ and fswAlgorithms/ headers that do not exist here.
+FREESTANDING_ALGORITHMS="$(
+  sed -n '/^set(algorithms/,/^)/p' "${REPO_ROOT}/CMakeLists.txt" \
+    | sed -nE 's/^[[:space:]]*"([^"]+)".*/\1/p'
+)"
+if [[ -z "${FREESTANDING_ALGORITHMS}" ]]; then
+  echo "Could not read the algorithms list from ${REPO_ROOT}/CMakeLists.txt" >&2
+  exit 2
+fi
+
+# Returns 0 when the given path is a header in the freestanding build. This is
+# the single source of truth for scope: both the directory sweep and the explicit
+# file list run through it, so a full run and an incremental run always agree.
+#
+# Note this is deliberately tighter than check_freestanding_includes.sh. That
+# check only greps text, so an out-of-scope file costs nothing; this one compiles
+# the header, so a file that can never compile here has to be excluded rather
+# than reported as a defect.
+is_in_scope() {
+  local path="${1#./}"
+
+  # Hosted-only test code.
+  if [[ "$path" == */_tests/* ]]; then
+    return 1
+  fi
+
+  # Headers only; the .cpp files are already compiled by the build itself.
+  if [[ ! "$path" =~ \.(h|hpp)$ ]]; then
+    return 1
+  fi
+
+  # Anchor on algorithms/ so absolute and repository-relative paths both match.
+  local rel="${path##*algorithms/}"
+  if [[ "$rel" == "$path" && "$path" != algorithms/* ]]; then
+    return 1
+  fi
+
+  # A bridge header between xmera and f32 payload types; it includes
+  # architecture/ headers from the superproject and so is hosted-only.
+  if [[ "$rel" == "utilities/fsw/messageConversionHelpers.hpp" ]]; then
+    return 1
+  fi
+
+  # Header-only libraries the algorithm sources include transitively.
+  if [[ "$rel" =~ ^utilities/fsw/[^/]+\.(h|hpp)$ ]]; then
+    return 0
+  fi
+  if [[ "$rel" =~ ^filteringCore/[^/]+\.(h|hpp)$ ]]; then
+    return 0
+  fi
+
+  # The per-algorithm freestanding core, its C shim, the shim's POD types, and
+  # the filter specs headers alongside them -- but only for algorithms that are
+  # in the freestanding build. The <algorithm>/<algorithm>.h module headers are
+  # excluded: those are the xmera component wrappers and pull in sys_model.h.
+  local algorithm="${rel%%/*}"
+  local base="${rel##*/}"
+  if [[ "$rel" == "$algorithm" ]]; then
+    return 1
+  fi
+  if ! grep -qxF "$algorithm" <<< "${FREESTANDING_ALGORITHMS}"; then
+    return 1
+  fi
+  if [[ "$base" == "${algorithm}.h" ]]; then
+    return 1
+  fi
+  if [[ "$base" =~ (Algorithm(_c)?|Types|Specs)\.(h|hpp)$ ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+VIOLATIONS=0
+CHECKED=0
+
+check_file() {
+  local file="$1"
+
+  if ! is_in_scope "$file"; then
+    return
+  fi
+
+  CHECKED=$((CHECKED + 1))
+
+  local abs
+  abs="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"
+
+  # A self-sufficient header compiles with no diagnostics at all. Anything the
+  # compiler has to say -- warning or error -- is a defect in the header. The
+  # one-line translation unit goes in on stdin so the check needs no temp files.
+  local output
+  if ! output="$(printf '#include "%s"\n' "$abs" \
+                   | "${CXX}" "${COMMON_FLAGS[@]}" -I"$(dirname "$abs")" -x c++ - 2>&1)" \
+     || [[ -n "$output" ]]; then
+    echo "::error file=${file}::header is not self-sufficient when compiled alone"
+    echo "$output" | sed 's/^/    /'
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+}
+
+for target in "$@"; do
+  if [[ -d "$target" ]]; then
+    while IFS= read -r file; do
+      check_file "$file"
+    done < <(find "$target" -type f \( -name '*.h' -o -name '*.hpp' \) | sort)
+  elif [[ -f "$target" ]]; then
+    check_file "$target"
+  else
+    echo "No such file or directory: ${target}" >&2
+    exit 2
+  fi
+done
+
+if [[ $VIOLATIONS -gt 0 ]]; then
+  echo ""
+  echo "Found ${VIOLATIONS} of ${CHECKED} header(s) that do not compile standalone."
+  echo "Add the include that provides the definitions the header uses."
+  exit 1
+fi
+
+echo "All ${CHECKED} header(s) compile standalone."

--- a/.github/workflows/downstream-build.yml
+++ b/.github/workflows/downstream-build.yml
@@ -50,7 +50,7 @@ jobs:
           set-safe-directory: true
           repository: lasp/eigen
           path: eigen
-          ref: feature/freestanding
+          ref: 'fix/freestanding-packet-decl-macro-leak'
           persist-credentials: false
 
       - name: Run downstream unit tests and coverage

--- a/.github/workflows/freestanding-build.yml
+++ b/.github/workflows/freestanding-build.yml
@@ -71,3 +71,14 @@ jobs:
           file "$ARCHIVE" >> "$GITHUB_STEP_SUMMARY"
           ar -t "$ARCHIVE" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      # Compiles every freestanding header on its own, so a header that uses a
+      # declaration without including its definition fails here rather than in
+      # whichever consumer happens to include the right thing first. This job is
+      # the only one with both the freestanding Eigen checkout and g++-13, which
+      # the check needs; the pre-commit job has neither.
+      - name: Check header self-sufficiency
+        env:
+          EIGEN3_DIR: ${{ github.workspace }}/eigen
+          CXX: g++-13
+        run: ./.github/scripts/check_header_self_sufficiency.sh algorithms/

--- a/.github/workflows/freestanding-build.yml
+++ b/.github/workflows/freestanding-build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: lasp/eigen
-          ref: feature/freestanding
+          ref: 'fix/freestanding-packet-decl-macro-leak'
           path: eigen
           persist-credentials: false
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ macro(add_algorithm name)
 
   set_target_properties(${target_name} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 
+  # EIGEN_FREESTANDING selects Eigen's freestanding code paths. It is deliberately
+  # not paired with -ffreestanding here: on host presets we want those code paths
+  # compiled against the host libc, so __STDC_HOSTED__ stays 1 and Eigen's
+  # freestanding shims (freestanding_math.h and friends) defer to <cmath> etc.
+  # Only riscv32-toolchain.cmake passes -ffreestanding, where the shims take over.
   target_compile_definitions(${target_name} PRIVATE EIGEN_FREESTANDING=1)
 
   message(STATUS "Added algorithms ${target_name}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,16 +74,19 @@ message(STATUS "Build type: ${BUILD_TYPE_UPPER}")
 
 # 3) Native Linux flags (only when not cross-compiling)
 if(NOT CMAKE_CROSSCOMPILING)
+  # Set these absolutely rather than appending. Appending to the cache variable
+  # and re-FORCE-ing it re-reads the value written by the previous configure, so
+  # every reconfigure grew the flags (they had reached "-g -O0 -g -O0 -g -O0 -g").
+  # Assigning the final value is idempotent and repairs caches already polluted
+  # by the old behaviour. Per-target flags belong on the target, not here.
   if(BUILD_TYPE_UPPER STREQUAL "DEBUG")
     message(STATUS "Configuring native Linux Debug flags")
-    set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   -O0 -g" CACHE STRING "" FORCE)
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g"  CACHE STRING "" FORCE)
-    set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} " CACHE STRING "" FORCE)
+    set(CMAKE_C_FLAGS_DEBUG   "-O0 -g" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g" CACHE STRING "" FORCE)
   else()
     message(STATUS "Configuring native Linux Release flags")
-    set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE}   -O3 -DNDEBUG" CACHE STRING "" FORCE)
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -DNDEBUG" CACHE STRING "" FORCE)
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} " CACHE STRING "" FORCE)
+    set(CMAKE_C_FLAGS_RELEASE   "-O3 -DNDEBUG" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "" FORCE)
   endif()
 endif()
 

--- a/algorithms/celestialTwoBodyPoint/_tests/celestialTwoBodyPointTestHelpers.hpp
+++ b/algorithms/celestialTwoBodyPoint/_tests/celestialTwoBodyPointTestHelpers.hpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <math.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <algorithm>
 #include <cmath>
 

--- a/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
+++ b/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
@@ -3,12 +3,12 @@
 #include "utilities/fsw/safeMath.h"
 #include <math.h>
 
-CelestialTwoBodyPointAlgorithm::CelestialTwoBodyPointAlgorithm(const CelestialTwoBodyPointConfig &config)
+CelestialTwoBodyPointAlgorithm::CelestialTwoBodyPointAlgorithm(const CelestialTwoBodyPointConfig& config)
     : cfg(config) {
     setConfig(config);
 }
 
-void CelestialTwoBodyPointAlgorithm::setConfig(const CelestialTwoBodyPointConfig &config) { this->cfg = config; }
+void CelestialTwoBodyPointAlgorithm::setConfig(const CelestialTwoBodyPointConfig& config) { this->cfg = config; }
 
 /*! This method computes the attitude reference that points the primary axis at the primary
  celestial body while aligning a second axis as close as possible toward the secondary
@@ -20,9 +20,9 @@ void CelestialTwoBodyPointAlgorithm::setConfig(const CelestialTwoBodyPointConfig
  @return attitude reference output
  */
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-CelestialTwoBodyPointOutput CelestialTwoBodyPointAlgorithm::update(const InertialStateInput &primaryBodyState,
-                                                                   const InertialStateInput &secondaryBodyState,
-                                                                   const InertialStateInput &spacecraftState) const {
+CelestialTwoBodyPointOutput CelestialTwoBodyPointAlgorithm::update(const InertialStateInput& primaryBodyState,
+                                                                   const InertialStateInput& secondaryBodyState,
+                                                                   const InertialStateInput& spacecraftState) const {
     const Eigen::Vector3d r_PB_N = primaryBodyState.r_N - spacecraftState.r_N;
     const Eigen::Vector3d v_PB_N = primaryBodyState.v_N - spacecraftState.v_N;
     Eigen::Vector3d r_SB_N = secondaryBodyState.r_N - spacecraftState.r_N;
@@ -64,10 +64,10 @@ CelestialTwoBodyPointOutput CelestialTwoBodyPointAlgorithm::update(const Inertia
     return attRefOut;
 }
 
-CelestialTwoBodyPointOutput CelestialTwoBodyPointAlgorithm::rateAndAccelCalc(const Eigen::Vector3d &r_PB_N,
-                                                                             const Eigen::Vector3d &v_PB_N,
-                                                                             const Eigen::Vector3d &r_SB_N,
-                                                                             const Eigen::Vector3d &v_SB_N) {
+CelestialTwoBodyPointOutput CelestialTwoBodyPointAlgorithm::rateAndAccelCalc(const Eigen::Vector3d& r_PB_N,
+                                                                             const Eigen::Vector3d& v_PB_N,
+                                                                             const Eigen::Vector3d& r_SB_N,
+                                                                             const Eigen::Vector3d& v_SB_N) {
     /* Compute normal vector to plane of r_PB_N and r_SB_N. The rate/acceleration derivative chain is
        carried in double: it differences large position/velocity products and near-aligned/near-radial
        geometries, where float loses precision on the angular acceleration. Only the well-conditioned

--- a/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
+++ b/algorithms/celestialTwoBodyPoint/celestialTwoBodyPointAlgorithm.cpp
@@ -2,6 +2,7 @@
 #include "utilities/fsw/rigidBodyKinematics.hpp"
 #include "utilities/fsw/safeMath.h"
 #include <math.h>
+#include <Eigen/Geometry>
 
 CelestialTwoBodyPointAlgorithm::CelestialTwoBodyPointAlgorithm(const CelestialTwoBodyPointConfig& config)
     : cfg(config) {

--- a/algorithms/convertStPlatformToBody/_tests/test_convertStPlatformToBody_fuzz.cpp
+++ b/algorithms/convertStPlatformToBody/_tests/test_convertStPlatformToBody_fuzz.cpp
@@ -4,6 +4,7 @@
 
 #include "test_convertStPlatformToBody_helpers.h"
 #include <fuzztest/fuzztest.h>
+#include <Eigen/Geometry>
 #include <cmath>
 
 /*!

--- a/algorithms/dvGuidance/_tests/dvGuidanceTestHelpers.hpp
+++ b/algorithms/dvGuidance/_tests/dvGuidanceTestHelpers.hpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <cmath>
 #include <cstdint>
 

--- a/algorithms/dvGuidance/dvGuidanceAlgorithm.cpp
+++ b/algorithms/dvGuidance/dvGuidanceAlgorithm.cpp
@@ -2,6 +2,7 @@
 #include "utilities/fsw/rigidBodyKinematics.hpp"
 #include "utilities/fsw/timeConstants.h"
 #include <math.h>
+#include <Eigen/Geometry>
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 // bugprone-easily-swappable-parameters: the Vector3f / float / uint64 inputs are documented in the

--- a/algorithms/flybyPoint/_tests/flybyPointTestHelpers.hpp
+++ b/algorithms/flybyPoint/_tests/flybyPointTestHelpers.hpp
@@ -7,6 +7,7 @@
 #include "utilities/fsw/timeConstants.h"
 
 #include <gtest/gtest.h>
+#include <Eigen/Geometry>
 #include <numbers>
 
 struct ReferenceFlybyOutput {

--- a/algorithms/flybyPoint/flybyPointAlgorithm.cpp
+++ b/algorithms/flybyPoint/flybyPointAlgorithm.cpp
@@ -2,6 +2,7 @@
 #include "utilities/fsw/rigidBodyKinematics.hpp"
 #include "utilities/fsw/safeMath.h"
 #include "utilities/fsw/timeConstants.h"
+#include <Eigen/Geometry>
 #include <numbers>
 
 FlybyPointAlgorithm::FlybyPointAlgorithm(const FlybyPointConfig& config) : cfg(config) {}

--- a/algorithms/hillPoint/_tests/hillPointTestHelpers.hpp
+++ b/algorithms/hillPoint/_tests/hillPointTestHelpers.hpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <cmath>
 
 struct ReferenceHillPointOutput {

--- a/algorithms/hillPoint/_tests/test_hillPoint_fuzz.cpp
+++ b/algorithms/hillPoint/_tests/test_hillPoint_fuzz.cpp
@@ -2,6 +2,7 @@
 #include "utilities/testUtilities/eigenFuzzDomains.hpp"
 
 #include <fuzztest/fuzztest.h>
+#include <Eigen/Geometry>
 
 namespace {
 

--- a/algorithms/hillPoint/hillPointAlgorithm.cpp
+++ b/algorithms/hillPoint/hillPointAlgorithm.cpp
@@ -1,5 +1,6 @@
 #include "hillPointAlgorithm.h"
 #include "utilities/fsw/rigidBodyKinematics.hpp"
+#include <Eigen/Geometry>
 
 // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 // bugprone-easily-swappable-parameters: the Vector3d position/velocity inputs are documented in

--- a/algorithms/mrpFeedback/_tests/mrpFeedbackTestHelpers.hpp
+++ b/algorithms/mrpFeedback/_tests/mrpFeedbackTestHelpers.hpp
@@ -13,6 +13,7 @@
 #include "utilities/fsw/freestandingInvalidArgument.h"
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>

--- a/algorithms/mrpFeedback/mrpFeedbackAlgorithm.cpp
+++ b/algorithms/mrpFeedback/mrpFeedbackAlgorithm.cpp
@@ -1,6 +1,7 @@
 #include "mrpFeedbackAlgorithm.h"
 
 #include <math.h>
+#include <Eigen/Geometry>
 #include <optional>
 
 MrpFeedbackAlgorithm::MrpFeedbackAlgorithm(const MrpFeedbackConfig& config) : cfg(config) {

--- a/algorithms/mrpRotation/_tests/mrpRotationTestHelpers.hpp
+++ b/algorithms/mrpRotation/_tests/mrpRotationTestHelpers.hpp
@@ -7,6 +7,7 @@
 #include "utilities/fsw/timeConstants.h"
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <algorithm>
 #include <cstdint>
 #include <limits>

--- a/algorithms/mrpRotation/mrpRotationAlgorithm.cpp
+++ b/algorithms/mrpRotation/mrpRotationAlgorithm.cpp
@@ -1,5 +1,6 @@
 #include "mrpRotationAlgorithm.h"
 #include <utilities/fsw/eigenSupport.h>
+#include <Eigen/Geometry>
 #include <utilities/fsw/rigidBodyKinematics.hpp>
 
 /*! @brief Construct the algorithm with a validated configuration. Stores the configuration and seeds

--- a/algorithms/mrpSteering/_tests/mrpSteeringTestHelpers.hpp
+++ b/algorithms/mrpSteering/_tests/mrpSteeringTestHelpers.hpp
@@ -13,6 +13,7 @@
 #include <fswAlgorithms/fswUtilities/fswDefinitions.h>
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>

--- a/algorithms/mrpSteering/mrpSteeringAlgorithm.cpp
+++ b/algorithms/mrpSteering/mrpSteeringAlgorithm.cpp
@@ -4,6 +4,7 @@
 #include <fswAlgorithms/fswUtilities/fswDefinitions.h>
 #include <math.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <numbers>
 #include <optional>
 

--- a/algorithms/msgPayloadDef/OpNavCOBMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/OpNavCOBMsgF32Payload.h
@@ -1,6 +1,8 @@
 #ifndef COBOPNAV_MESSAGE_F32_H
 #define COBOPNAV_MESSAGE_F32_H
 
+#include <stdint.h>
+
 //!@brief Center of brightness optical navigation measurement message
 /*! This message is output by the center of brightness module and contains the center of brightness of the image
  * that was input, as well as the validity of the image processing process, the camera ID, and the number of pixels

--- a/algorithms/msgPayloadDef/OpNavCOMMsgF32Payload.h
+++ b/algorithms/msgPayloadDef/OpNavCOMMsgF32Payload.h
@@ -1,6 +1,8 @@
 #ifndef COMOPNAV_MESSAGE_F32_H
 #define COMOPNAV_MESSAGE_F32_H
 
+#include <stdint.h>
+
 //!@brief Center of mass optical navigation measurement message
 /*! This message is output by the center of brightness converter module and contains the center of mass (COM) after
  * offsetting the center of brightness (COB) using the phase angle correction.

--- a/algorithms/solarArrayReference/_tests/solarArrayReferenceTestHelpers.hpp
+++ b/algorithms/solarArrayReference/_tests/solarArrayReferenceTestHelpers.hpp
@@ -5,6 +5,7 @@
 #include "utilities/fsw/rigidBodyKinematics.hpp"
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <cmath>
 #include <vector>
 

--- a/algorithms/solarArrayReference/solarArrayReferenceAlgorithm.h
+++ b/algorithms/solarArrayReference/solarArrayReferenceAlgorithm.h
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <stdint.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <array>
 #include <numbers>
 

--- a/algorithms/sunAvoidance/_tests/sunAvoidanceIntegratedTestHelpers.hpp
+++ b/algorithms/sunAvoidance/_tests/sunAvoidanceIntegratedTestHelpers.hpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <cstdint>
 #include <numbers>
 

--- a/algorithms/sunAvoidance/_tests/sunAvoidanceTestHelpers.hpp
+++ b/algorithms/sunAvoidance/_tests/sunAvoidanceTestHelpers.hpp
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <cmath>
 #include <cstdint>
 #include <numbers>

--- a/algorithms/sunAvoidance/_tests/test_sunAvoidance.cpp
+++ b/algorithms/sunAvoidance/_tests/test_sunAvoidance.cpp
@@ -1,6 +1,7 @@
 #include "sunAvoidanceTestHelpers.hpp"
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <array>
 #include <cmath>
 #include <limits>

--- a/algorithms/sunAvoidance/sunAvoidanceAlgorithm.cpp
+++ b/algorithms/sunAvoidance/sunAvoidanceAlgorithm.cpp
@@ -2,6 +2,7 @@
 #include "utilities/fsw/rigidBodyKinematics.hpp"
 #include "utilities/fsw/safeMath.h"
 #include "utilities/fsw/timeConstants.h"
+#include <Eigen/Geometry>
 #include <numbers>
 
 /*! Construct from a validated configuration and seed the runtime maneuver state. */

--- a/algorithms/sunSearchPoint/_tests/test_sunSearchPoint.cpp
+++ b/algorithms/sunSearchPoint/_tests/test_sunSearchPoint.cpp
@@ -1,4 +1,5 @@
 #include "sunSearchPointTestHelpers.hpp"
+#include <Eigen/Geometry>
 
 // ---------------------------------------------------------------------------
 // Regression test

--- a/algorithms/sunlineFilter/sunlineFilterSpecs.h
+++ b/algorithms/sunlineFilter/sunlineFilterSpecs.h
@@ -6,6 +6,7 @@
 #include <filteringCore/state.hpp>
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include <variant>
 

--- a/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
+++ b/algorithms/thrusterPlatformReference/_tests/thrusterPlatformReferenceTestHelpers.hpp
@@ -5,6 +5,7 @@
 #include "utilities/fsw/rigidBodyKinematics.hpp"
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <cmath>
 
 // Build a validated configuration with momentum dumping disabled (pure center-of-mass alignment mode). The default

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReferenceAlgorithm.cpp
@@ -5,6 +5,7 @@
 
 #include "utilities/fsw/rigidBodyKinematics.hpp"
 #include "utilities/fsw/safeMath.h"
+#include <Eigen/Geometry>
 
 namespace {
 constexpr float kZeroTolerance = 1e-6F;  // module tolerance for treating a quantity as zero

--- a/algorithms/triad/_tests/triadTestHelpers.hpp
+++ b/algorithms/triad/_tests/triadTestHelpers.hpp
@@ -5,6 +5,7 @@
 #include "utilities/fsw/safeMath.h"
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <architecture/utilities/rigidBodyKinematics.hpp>
 #include <cmath>
 

--- a/algorithms/triad/triadAlgorithm.cpp
+++ b/algorithms/triad/triadAlgorithm.cpp
@@ -3,6 +3,7 @@
 #include "utilities/fsw/safeMath.h"
 #include <math.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <utility>
 
 TriadAlgorithm::TriadAlgorithm(const TriadConfig& config) : cfg(config) { setConfig(config); }

--- a/algorithms/utilities/fsw/_tests/test_orbitalMotion_degenerate.cpp
+++ b/algorithms/utilities/fsw/_tests/test_orbitalMotion_degenerate.cpp
@@ -13,7 +13,7 @@
 
 using orbitalMotion::CartesianState;
 using orbitalMotion::ClassicalElements;
-#include <Eigen/Geometry>
+#include <Eigen/Core>
 #include <cmath>
 
 constexpr double kMuEarth = 3.986004418e14;  // m^3/s^2

--- a/algorithms/utilities/fsw/_tests/test_orbitalMotion_functions.cpp
+++ b/algorithms/utilities/fsw/_tests/test_orbitalMotion_functions.cpp
@@ -1,6 +1,6 @@
 #include "utilities/fsw/orbitalMotion.hpp"
 #include <gtest/gtest.h>
-#include <Eigen/Dense>
+#include <Eigen/Core>
 #include <cmath>
 
 using orbitalMotion::CartesianState;

--- a/algorithms/utilities/fsw/orbitalMotion.hpp
+++ b/algorithms/utilities/fsw/orbitalMotion.hpp
@@ -5,6 +5,7 @@
 #include "safeMath.h"
 #include <math.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 #include <numbers>
 
 namespace orbitalMotion {


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Eigen build noise was three separate things, not one. Two of them were in the Eigen fork and are fixed over in lasp/eigen#2 — this PR is the part that belongs in fp32.

`.cross()` is declared in `Eigen/Core` but defined in `Eigen/Geometry`, and a few headers called it with only `Core` included. They compiled fine as long as some consumer happened to include `Geometry` first. `orbitalMotion.hpp` was the one raising the warning. Also, `mrpFeedbackAlgorithm.cpp`, got `Geometry` via `validInertiaCheck.h` -> `Eigen/Eigenvalues`.

## Verification
CI is being run with a DROP commit against lasp/eigen. Also added a check that compiles each header on its own, so next time this fails in the header instead of in whoever includes it. It runs in the freestanding build job, which is the only one with both Eigen and g++-13 (the pre-commit job has neither).

## Documentation
NA

## Future work
None