### PR TITLE
Undo the mistakenly merged pinned CI references

### DIFF
--- a/.github/workflows/downstream-build.yml
+++ b/.github/workflows/downstream-build.yml
@@ -26,7 +26,6 @@ jobs:
           set-safe-directory: true
           repository: lasp/adamant-xmera-components
           path: adamant-xmera-components
-          ref: feature/add-config-pattern-to-monitor
           persist-credentials: false
 
       - name: Check out fp32-fsw-xmera at PR head

--- a/.github/workflows/trigger_jenkins_renode.yml
+++ b/.github/workflows/trigger_jenkins_renode.yml
@@ -60,7 +60,7 @@ jobs:
       # branch's CI runs (e.g. one-off DROP / integration testing without
       # touching Jenkins UI). workflow_dispatch inputs still win over a
       # PIN; revert (or comment back) before merging.
-      ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/add-config-pattern-to-monitor'
+      # ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/your-branch-here'
       # ADAMANT_REF_PIN: 'feature/your-branch-here'
       # ADAMANT_EXAMPLE_REF_PIN: 'feature/your-branch-here'
       # PROJECT_REF_PIN: 'feature/your-branch-here'


### PR DESCRIPTION
* **Tickets addressed:** hot-fix
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
In my enthusiasm to merge the validate config branch I forgot to drop the "DROP" commit. This undoes that commit.

## Verification
CI will run.

## Documentation
NA

## Future work
None
