### PR TITLE
Remove reference operator from message write

### DIFF
--- a/algorithms/cobConverter/cobConverter.cpp
+++ b/algorithms/cobConverter/cobConverter.cpp
@@ -119,7 +119,7 @@ void CobConverter::updateState(const uint64_t currentSimNanos) {
     CobConverterDiagnosticMsgF32Payload diagnosticMsgBuffer{};
     diagnosticMsgBuffer.coberrorOutlierTrigger = out.diagnostic.coberrorOutlierTrigger;
 
-    this->opnavUnitVecOutMsg.write(&uVecOutMsgBuffer, this->moduleID, currentSimNanos);
-    this->comCorrectionOutMsg.write(&comMsgBuffer, this->moduleID, currentSimNanos);
-    this->cobConverterDiagnosticOutMsg.write(&diagnosticMsgBuffer, this->moduleID, currentSimNanos);
+    this->opnavUnitVecOutMsg.write(uVecOutMsgBuffer, this->moduleID, currentSimNanos);
+    this->comCorrectionOutMsg.write(comMsgBuffer, this->moduleID, currentSimNanos);
+    this->cobConverterDiagnosticOutMsg.write(diagnosticMsgBuffer, this->moduleID, currentSimNanos);
 }

--- a/algorithms/flybyPoint/flybyPoint.cpp
+++ b/algorithms/flybyPoint/flybyPoint.cpp
@@ -25,13 +25,13 @@ void FlybyPoint::updateState(uint64_t currentSimNanos) {
     eigenVectorToCArray(algo_output.sigma_RN, attMsgBuffer.sigma_RN);
     eigenVectorToCArray(algo_output.omega_RN_N, attMsgBuffer.omega_RN_N);
     eigenVectorToCArray(algo_output.domega_RN_N, attMsgBuffer.domega_RN_N);
-    this->attRefOutMsg.write(&attMsgBuffer, this->moduleID, currentSimNanos);
+    this->attRefOutMsg.write(attMsgBuffer, this->moduleID, currentSimNanos);
     FlybyDiagnosticMsgF32Payload flybyDiagnosticMsgBuffer{};
     flybyDiagnosticMsgBuffer.collinearityTrigger = algo_output.collinearityTrigger;
     flybyDiagnosticMsgBuffer.maxRateTrigger = algo_output.maxRateTrigger;
     flybyDiagnosticMsgBuffer.maxAccelerationTrigger = algo_output.maxAccelerationTrigger;
     flybyDiagnosticMsgBuffer.positionKnowledgeExceedTrigger = algo_output.positionKnowledgeExceedTrigger;
-    this->flybyDiagnosticOutMsg.write(&flybyDiagnosticMsgBuffer, this->moduleID, currentSimNanos);
+    this->flybyDiagnosticOutMsg.write(flybyDiagnosticMsgBuffer, this->moduleID, currentSimNanos);
 }
 
 std::tuple<Eigen::Vector3d, Eigen::Vector3d> FlybyPoint::readRelativeState() {

--- a/algorithms/inertialUKF/inertialUKF.cpp
+++ b/algorithms/inertialUKF/inertialUKF.cpp
@@ -57,10 +57,10 @@ void InertialUKF::updateState(uint64_t callTime) {
     eigenVectorToCArray(output.navAtt.sigma_BN, navAttOut.sigma_BN);
     eigenVectorToCArray(output.navAtt.omega_BN_B, navAttOut.omega_BN_B);
     eigenVectorToCArray(output.navAtt.vehSunPntBdy, navAttOut.vehSunPntBdy);
-    this->navStateOutMsg.write(&navAttOut, this->moduleID, callTime);
+    this->navStateOutMsg.write(navAttOut, this->moduleID, callTime);
 
     InertialFilterMsgF32Payload filtOut{};
     filtOut.timeTag = output.filter.timeTag;
     filtOut.numObs = output.filter.numObs;
-    this->filtDataOutMsg.write(&filtOut, this->moduleID, callTime);
+    this->filtDataOutMsg.write(filtOut, this->moduleID, callTime);
 }

--- a/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
+++ b/algorithms/mimuMajorityVote/mimuMajorityVote.cpp
@@ -31,8 +31,8 @@ void MimuMajorityVote::updateState(uint64_t const callTime) {
         faultPayload.omegaDifferencesMag[i] = output.omegaDifferencesMag.at(i);
     }
 
-    this->imuSensorBodyOutMsg.write(&imuOutPayload, this->moduleID, callTime);
-    this->mimuFaultMsg.write(&faultPayload, this->moduleID, callTime);
+    this->imuSensorBodyOutMsg.write(imuOutPayload, this->moduleID, callTime);
+    this->mimuFaultMsg.write(faultPayload, this->moduleID, callTime);
 }
 
 // Add imu to the majority vote module

--- a/algorithms/mrpFeedback/mrpFeedback.cpp
+++ b/algorithms/mrpFeedback/mrpFeedback.cpp
@@ -89,9 +89,9 @@ void MrpFeedback::updateState(const uint64_t callTime) {
 
     CmdTorqueBodyMsgF32Payload controlOut{};
     eigenVectorToCArray(out.controlTorque, controlOut.torqueRequestBody);
-    this->cmdTorqueOutMsg.write(&controlOut, moduleID, callTime);
+    this->cmdTorqueOutMsg.write(controlOut, moduleID, callTime);
 
     CmdTorqueBodyMsgF32Payload intFeedbackOut{};
     eigenVectorToCArray(out.integralFeedbackTorque, intFeedbackOut.torqueRequestBody);
-    this->intFeedbackTorqueOutMsg.write(&intFeedbackOut, this->moduleID, callTime);
+    this->intFeedbackTorqueOutMsg.write(intFeedbackOut, this->moduleID, callTime);
 }

--- a/algorithms/mrpRotation/mrpRotation.cpp
+++ b/algorithms/mrpRotation/mrpRotation.cpp
@@ -55,7 +55,7 @@ void MrpRotation::updateState(const uint64_t callTime) {
     eigenVectorToCArray(out.domega_RN_N, attRefOut.domega_RN_N);
 
     /*! - write attitude guidance reference output */
-    this->attRefOutMsg.write(&attRefOut, this->moduleID, callTime);
+    this->attRefOutMsg.write(attRefOut, this->moduleID, callTime);
 }
 
 /*! @brief Re-seed the algorithm's runtime integrator state from the configured initial values. */

--- a/algorithms/rateControl/rateControl.cpp
+++ b/algorithms/rateControl/rateControl.cpp
@@ -36,7 +36,7 @@ void RateControl::updateState(uint64_t callTime) {
         eigenVectorToCArray(out, torqueCmdOut.torqueRequestBody);
     }
 
-    this->cmdTorqueOutMsg.write(&torqueCmdOut, moduleID, callTime);
+    this->cmdTorqueOutMsg.write(torqueCmdOut, moduleID, callTime);
 }
 
 /*! Setter method for the derivative gain P.

--- a/algorithms/rwMotorTorque/rwMotorTorque.cpp
+++ b/algorithms/rwMotorTorque/rwMotorTorque.cpp
@@ -101,7 +101,7 @@ void RwMotorTorque::updateState(const uint64_t callTime) {
 
     RwMotorTorqueMsgF32Payload rwMotorTorques{};
     eigenVectorToCArray(motorTorque, rwMotorTorques.motorTorque);
-    this->rwMotorTorqueOutMsg.write(&rwMotorTorques, this->moduleID, callTime);
+    this->rwMotorTorqueOutMsg.write(rwMotorTorques, this->moduleID, callTime);
 }
 
 /*! Setter for the desiredControlAxes_B body-axis controllability selection (which of body x, y, z to control). */

--- a/algorithms/rwMotorVoltage/rwMotorVoltage.cpp
+++ b/algorithms/rwMotorVoltage/rwMotorVoltage.cpp
@@ -63,7 +63,7 @@ void RwMotorVoltage::updateState(uint64_t callTime) {
     RwMotorVoltageMsgF32Payload voltageOut{};
     std::ranges::copy(voltage, std::begin(voltageOut.voltage));
 
-    this->voltageOutMsg.write(&voltageOut, this->moduleID, callTime);
+    this->voltageOutMsg.write(voltageOut, this->moduleID, callTime);
 }
 
 /**

--- a/algorithms/sunAvoidance/sunAvoidance.cpp
+++ b/algorithms/sunAvoidance/sunAvoidance.cpp
@@ -81,5 +81,5 @@ void SunAvoidance::updateState(uint64_t callTime) {
     eigenVectorToCArray(out.domega_RN_N, attRef.domega_RN_N);
 
     /*! write output message */
-    this->attRefOutMsg.write(&attRef, this->moduleID, callTime);
+    this->attRefOutMsg.write(attRef, this->moduleID, callTime);
 }

--- a/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
+++ b/algorithms/thrusterPlatformReference/thrusterPlatformReference.cpp
@@ -98,11 +98,11 @@ void ThrusterPlatformReference::updateState(const uint64_t callTime) {
     // the body-frame thrust heading equals the body-frame thrust unit direction
     BodyHeadingMsgF32Payload bodyHeadingOut{};
     eigenVectorToCArray(out.tHat_B, bodyHeadingOut.rHat_XB_B);
-    this->bodyHeadingOutMsg.write(&bodyHeadingOut, this->moduleID, callTime);
+    this->bodyHeadingOutMsg.write(bodyHeadingOut, this->moduleID, callTime);
 
     THRConfigMsgF32Payload thrusterConfigOut{};
     eigenVectorToCArray(out.r_TB_B, thrusterConfigOut.rThrust_B);
     eigenVectorToCArray(out.tHat_B, thrusterConfigOut.tHatThrust_B);
     thrusterConfigOut.maxThrust = out.thrust;
-    this->thrusterConfigBOutMsg.write(&thrusterConfigOut, this->moduleID, callTime);
+    this->thrusterConfigBOutMsg.write(thrusterConfigOut, this->moduleID, callTime);
 }


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This updates the message `write()` calls to no longer use the reference operator. 

## Verification
All build and test should pass as expected. No new tests added.

## Documentation
NA

## Future work
None
