### PR TITLE
Add validate config sun search point

### DIFF
--- a/.github/workflows/downstream-build.yml
+++ b/.github/workflows/downstream-build.yml
@@ -26,6 +26,7 @@ jobs:
           set-safe-directory: true
           repository: lasp/adamant-xmera-components
           path: adamant-xmera-components
+          ref: 'feature/EMAGNCFSW-1113-add-sun-search-component'
           persist-credentials: false
 
       - name: Check out fp32-fsw-xmera at PR head

--- a/.github/workflows/trigger_jenkins_renode.yml
+++ b/.github/workflows/trigger_jenkins_renode.yml
@@ -60,7 +60,7 @@ jobs:
       # branch's CI runs (e.g. one-off DROP / integration testing without
       # touching Jenkins UI). workflow_dispatch inputs still win over a
       # PIN; revert (or comment back) before merging.
-      # ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/your-branch-here'
+      ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/EMAGNCFSW-1113-add-sun-search-component'
       # ADAMANT_REF_PIN: 'feature/your-branch-here'
       # ADAMANT_EXAMPLE_REF_PIN: 'feature/your-branch-here'
       # PROJECT_REF_PIN: 'feature/your-branch-here'

--- a/algorithms/sunSearchPoint/_tests/sunSearchPointTestHelpers.hpp
+++ b/algorithms/sunSearchPoint/_tests/sunSearchPointTestHelpers.hpp
@@ -33,7 +33,7 @@ inline SunSearchPointOutput observeAt(SunSearchPointAlgorithm& alg,
                                       uint64_t targetNs,
                                       const Eigen::Vector3f& sun,
                                       const Eigen::Vector3f& omega,
-                                      int css,
+                                      uint32_t css,
                                       uint64_t controlPeriodNs = kTestControlPeriodNs) {
     while (nextElapsedNs < targetNs) {
         (void)alg.update(Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), 0);
@@ -49,7 +49,7 @@ inline SunSearchPointOutput advanceTo(SunSearchPointAlgorithm& alg,
                                       uint64_t targetNs,
                                       const Eigen::Vector3f& sun,
                                       const Eigen::Vector3f& omega,
-                                      int css,
+                                      uint32_t css,
                                       uint64_t controlPeriodNs = kTestControlPeriodNs) {
     uint64_t nextElapsedNs = 0U;
     return observeAt(alg, nextElapsedNs, targetNs, sun, omega, css, controlPeriodNs);
@@ -81,7 +81,7 @@ inline SunSearchPointConfig makeSearchConfig(const std::array<RotationProperties
                                              const Eigen::Vector3f& sHatBdyCmd = Eigen::Vector3f{0.0F, 0.0F, 1.0F},
                                              float sunAxisSpinRate = 0.0F,
                                              const Eigen::Vector3f& omega_RN_B = Eigen::Vector3f::Zero(),
-                                             int observationThreshold = 4,
+                                             uint32_t observationThreshold = 4U,
                                              float controlPeriod = kTestControlPeriodSec) {
     return SunSearchPointConfig::create(
         rotations, sHatBdyCmd, sunAxisSpinRate, omega_RN_B, observationThreshold, controlPeriod);

--- a/algorithms/sunSearchPoint/_tests/sunSearchPointTestHelpers.hpp
+++ b/algorithms/sunSearchPoint/_tests/sunSearchPointTestHelpers.hpp
@@ -357,8 +357,20 @@ inline void searchConfigValidationChecks() {
     EXPECT_ANY_THROW((void)makeSearchConfig(makeValidRotations(), Eigen::Vector3f{2.0F, 0.0F, 0.0F}));
     EXPECT_NO_THROW((void)makeSearchConfig(makeValidRotations(), Eigen::Vector3f{0.0F, 1.0F, 0.0F}));
 
-    // controlPeriod must be finite and > 0.
+    // sunAxisSpinRate must be finite (any sign is allowed).
     const Eigen::Vector3f validSHat{0.0F, 0.0F, 1.0F};
+    EXPECT_NO_THROW((void)makeSearchConfig(makeValidRotations(), validSHat, -2.5F));
+    EXPECT_ANY_THROW((void)makeSearchConfig(makeValidRotations(), validSHat, std::numeric_limits<float>::infinity()));
+    EXPECT_ANY_THROW((void)makeSearchConfig(makeValidRotations(), validSHat, std::numeric_limits<float>::quiet_NaN()));
+
+    // omega_RN_B must be finite in every component.
+    EXPECT_NO_THROW((void)makeSearchConfig(makeValidRotations(), validSHat, 0.0F, Eigen::Vector3f{0.1F, -0.2F, 0.3F}));
+    EXPECT_ANY_THROW((void)makeSearchConfig(
+        makeValidRotations(), validSHat, 0.0F, Eigen::Vector3f{0.0F, std::numeric_limits<float>::infinity(), 0.0F}));
+    EXPECT_ANY_THROW((void)makeSearchConfig(
+        makeValidRotations(), validSHat, 0.0F, Eigen::Vector3f{0.0F, 0.0F, std::numeric_limits<float>::quiet_NaN()}));
+
+    // controlPeriod must be finite and > 0.
     EXPECT_ANY_THROW((void)makeSearchConfig(makeValidRotations(), validSHat, 0.0F, Eigen::Vector3f::Zero(), 4, 0.0F));
     EXPECT_ANY_THROW((void)makeSearchConfig(makeValidRotations(), validSHat, 0.0F, Eigen::Vector3f::Zero(), 4, -0.5F));
     EXPECT_ANY_THROW((void)makeSearchConfig(

--- a/algorithms/sunSearchPoint/_tests/test_sunSearchPoint.cpp
+++ b/algorithms/sunSearchPoint/_tests/test_sunSearchPoint.cpp
@@ -24,7 +24,7 @@ TEST(SunSearchPointTest, SetupTest) {
         defaultRotations(), Eigen::Vector3f{0.6F, 0.8F, 0.0F}, 1.5F, Eigen::Vector3f{0.1F, -0.2F, 0.3F}, 7);
 
     EXPECT_FLOAT_EQ(cfg.getSunAxisSpinRate(), 1.5F);
-    EXPECT_EQ(cfg.getObservationThreshold(), 7);
+    EXPECT_EQ(cfg.getObservationThreshold(), 7U);
 
     Eigen::Vector3f const expectedOmega{0.1F, -0.2F, 0.3F};
     Eigen::Vector3f retrieved_omega = cfg.getOmega_RN_B();

--- a/algorithms/sunSearchPoint/sunSearchPoint.cpp
+++ b/algorithms/sunSearchPoint/sunSearchPoint.cpp
@@ -84,9 +84,10 @@ void SunSearchPoint::updateState(uint64_t callTime) {
     Eigen::Vector3f const vehSunPntBdy = cArrayToEigenVector(sunDirectionMsgPayload.vehSunPntBdy);
     Eigen::Vector3f const omega_BN_B = cArrayToEigenVector(rateMsgPayload.omega_BN_B);
 
-    // Call the algorithm update method
-    SunSearchPointOutput output =
-        this->algorithm->update(vehSunPntBdy, omega_BN_B, filterResidualsMsgPayload.sizeOfObservations);
+    // sizeOfObservations is signed in the filter residuals message; the filter cannot report a
+    // negative size, so the count is always in range for the algorithm's unsigned argument.
+    SunSearchPointOutput output = this->algorithm->update(
+        vehSunPntBdy, omega_BN_B, static_cast<uint32_t>(filterResidualsMsgPayload.sizeOfObservations));
 
     // Convert algorithm output to MsgPayload
     AttGuidMsgF32Payload attGuidanceOutBuffer{};

--- a/algorithms/sunSearchPoint/sunSearchPoint.h
+++ b/algorithms/sunSearchPoint/sunSearchPoint.h
@@ -30,7 +30,7 @@ class SunSearchPoint final : public SysModel {
     Eigen::Vector3f sHatBdyCmd{Eigen::Vector3f::Zero()};  //!< [-] commanded body vector to point at the sun
     float sunAxisSpinRate{};                              //!< [rad/s] constant spin rate about the sun heading vector
     Eigen::Vector3f omega_RN_B{Eigen::Vector3f::Zero()};  //!< [rad/s] fallback rate when no sun is available
-    int observationThreshold{4};                          //!< [-] CSS count at or above which to transition to pointing
+    uint32_t observationThreshold{4U};                    //!< [-] CSS count at or above which to transition to pointing
     float controlPeriod{};                                //!< [s] update period; advances the search timeline (> 0)
 
     ReadFunctor<NavAttMsgF32Payload> rateInMsg;                      //!< Body angular velocity input message

--- a/algorithms/sunSearchPoint/sunSearchPoint.rst
+++ b/algorithms/sunSearchPoint/sunSearchPoint.rst
@@ -83,7 +83,7 @@ Module Parameters
       - zero
       - Body-fixed fallback rate commanded in the pointing phase when no sun direction is available
     * - observationThreshold
-      - int
+      - uint32_t
       - [-]
       - 4
       - CSS observation count at or above which the sun is considered acquired

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm.cpp
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm.cpp
@@ -54,7 +54,7 @@ void SunSearchPointAlgorithm::reInitialize() {
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 SunSearchPointOutput SunSearchPointAlgorithm::update(const Eigen::Vector3f& rHat_SB_B,
                                                      const Eigen::Vector3f& omega_BN_B,
-                                                     const int numCssViewingSun) {
+                                                     const uint32_t numCssViewingSun) {
     // Evaluate the one-way SEARCH -> POINT transition. The first rotation always runs to
     // completion; after that, a sufficient observation count transitions to pointing, and the
     // full sequence elapsing forces the transition regardless of observations.

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm.h
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm.h
@@ -45,7 +45,7 @@ class SunSearchPointConfig final {
                                        const Eigen::Vector3f& sHatBdyCmd,
                                        float sunAxisSpinRate,
                                        const Eigen::Vector3f& omega_RN_B,
-                                       int observationThreshold,
+                                       uint32_t observationThreshold,
                                        float controlPeriod) {
         for (auto [rotationDuration, rotationRate, rotationAxis] : rotations) {
             if (!isValidRotationDuration(rotationDuration)) {
@@ -95,7 +95,7 @@ class SunSearchPointConfig final {
     const Eigen::Vector3f& getSHatBdyCmd() const { return sHatBdyCmd; }
     float getSunAxisSpinRate() const { return sunAxisSpinRate; }
     const Eigen::Vector3f& getOmega_RN_B() const { return omega_RN_B; }
-    int getObservationThreshold() const { return observationThreshold; }
+    uint32_t getObservationThreshold() const { return observationThreshold; }
     float getControlPeriod() const { return controlPeriod; }
 
    private:
@@ -104,7 +104,7 @@ class SunSearchPointConfig final {
                          const Eigen::Vector3f& sHatBdyCmdIn,
                          float sunAxisSpinRateIn,
                          const Eigen::Vector3f& omega_RN_BIn,
-                         int observationThresholdIn,
+                         uint32_t observationThresholdIn,
                          float controlPeriodIn)
         : rotations(rotationsIn),
           sHatBdyCmd(sHatBdyCmdIn),
@@ -117,7 +117,7 @@ class SunSearchPointConfig final {
     Eigen::Vector3f sHatBdyCmd;
     float sunAxisSpinRate;
     Eigen::Vector3f omega_RN_B;
-    int observationThreshold;
+    uint32_t observationThreshold;
     float controlPeriod;
 };
 
@@ -137,7 +137,7 @@ class SunSearchPointAlgorithm final {
 
     SunSearchPointOutput update(const Eigen::Vector3f& rHat_SB_B,
                                 const Eigen::Vector3f& omega_BN_B,
-                                int numCssViewingSun);
+                                uint32_t numCssViewingSun);
 
     void setConfig(const SunSearchPointConfig& config);
     void reInitialize();

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm.h
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm.h
@@ -34,8 +34,9 @@ struct SunSearchPointOutput {
  * @brief Validated configuration for the sun search point algorithm.
  *
  * Holds the sun-search rotation sequence and the pointing parameters. An instance can only exist if
- * every rotation has a finite, positive duration, a finite commanded rate, and a valid axis, and if
- * sHatBdyCmd has unit norm (within 1e-3). Construct via SunSearchPointConfig::create(...).
+ * every rotation has a finite, positive duration, a finite commanded rate, and a valid axis, if
+ * sHatBdyCmd has unit norm (within 1e-3), if sunAxisSpinRate and omega_RN_B are finite, and if
+ * controlPeriod is finite and positive. Construct via SunSearchPointConfig::create(...).
  */
 class SunSearchPointConfig final {
    public:
@@ -60,6 +61,12 @@ class SunSearchPointConfig final {
         if (!isValidSHatBdyCmd(sHatBdyCmd)) {
             FSW_THROW_INVALID_ARGUMENT("sunSearchPoint: sHatBdyCmd norm must be within 1e-3 of 1.0");
         }
+        if (!isValidSunAxisSpinRate(sunAxisSpinRate)) {
+            FSW_THROW_INVALID_ARGUMENT("sunSearchPoint: sunAxisSpinRate must be finite");
+        }
+        if (!isValidOmega_RN_B(omega_RN_B)) {
+            FSW_THROW_INVALID_ARGUMENT("sunSearchPoint: omega_RN_B must be finite");
+        }
         if (!isValidControlPeriod(controlPeriod)) {
             FSW_THROW_INVALID_ARGUMENT("sunSearchPoint: controlPeriod must be finite and > 0");
         }
@@ -76,9 +83,13 @@ class SunSearchPointConfig final {
         constexpr float kUnitNormTol = 1e-3F;
         return fabsf(sHatBdyCmd.norm() - 1.0F) <= kUnitNormTol;
     }
+    static bool isValidSunAxisSpinRate(float sunAxisSpinRate) { return fsw::is_finite(sunAxisSpinRate); }
+    static bool isValidOmega_RN_B(const Eigen::Vector3f& omega_RN_B) { return omega_RN_B.allFinite(); }
     static bool isValidControlPeriod(float controlPeriod) {
         return fsw::is_finite(controlPeriod) && controlPeriod > 0.0F;
     }
+    // No isValidObservationThreshold - every count is meaningful. Zero transitions to pointing as
+    // soon as the first rotation completes; a count the sensors cannot reach runs the full sequence.
 
     const std::array<RotationProperties, kNumRotations>& getRotations() const { return rotations; }
     const Eigen::Vector3f& getSHatBdyCmd() const { return sHatBdyCmd; }

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.cpp
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.cpp
@@ -2,6 +2,7 @@
 #include "sunSearchPointAlgorithm.h"
 #include "sunSearchPointTypes.h"
 #include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/freestandingInvalidArgument.h"
 #include "utilities/fsw/opaqueHandle.h"
 
 #include <Eigen/Core>
@@ -35,14 +36,30 @@ SunSearchPointConfig configFromC(const RotationPropertiesArray4_c& rotationsIn,
 
 uint32_t SunSearchPointAlgorithm_getNumRotations(void) { return SUN_SEARCH_POINT_NUM_ROTATIONS; }
 
+bool SunSearchPointAlgorithm_validateConfig(const RotationPropertiesArray4_c* rotations,
+                                            const Vector3f_c sHatBdyCmd,
+                                            const float sunAxisSpinRate,
+                                            const Vector3f_c omega_RN_B,
+                                            const uint32_t observationThreshold,
+                                            const float controlPeriod) {
+    // Build the config through the real create path; success means valid, a throw means invalid.
+    // Reusing configFromC keeps the validity rules from drifting away from create/setConfig.
+    try {
+        (void)configFromC(*rotations, sHatBdyCmd, sunAxisSpinRate, omega_RN_B, observationThreshold, controlPeriod);
+        return true;
+    } catch (const fsw::invalid_argument&) {
+        return false;
+    }
+}
+
 SunSearchPointAlgorithmHandle* SunSearchPointAlgorithm_create(const RotationPropertiesArray4_c* rotations,
                                                               const Vector3f_c sHatBdyCmd,
                                                               const float sunAxisSpinRate,
                                                               const Vector3f_c omega_RN_B,
                                                               const uint32_t observationThreshold,
                                                               const float controlPeriod) {
-    return fsw::createHandle<::SunSearchPointAlgorithm, SunSearchPointAlgorithmHandle>(configFromC(
-        *rotations, sHatBdyCmd, sunAxisSpinRate, omega_RN_B, observationThreshold, controlPeriod));
+    return fsw::createHandle<::SunSearchPointAlgorithm, SunSearchPointAlgorithmHandle>(
+        configFromC(*rotations, sHatBdyCmd, sunAxisSpinRate, omega_RN_B, observationThreshold, controlPeriod));
 }
 
 void SunSearchPointAlgorithm_destroy(SunSearchPointAlgorithmHandle* self) {
@@ -56,8 +73,8 @@ void SunSearchPointAlgorithm_setConfig(SunSearchPointAlgorithmHandle* self,
                                        const Vector3f_c omega_RN_B,
                                        const uint32_t observationThreshold,
                                        const float controlPeriod) {
-    fsw::fromHandle<::SunSearchPointAlgorithm>(self)->setConfig(configFromC(
-        *rotations, sHatBdyCmd, sunAxisSpinRate, omega_RN_B, observationThreshold, controlPeriod));
+    fsw::fromHandle<::SunSearchPointAlgorithm>(self)->setConfig(
+        configFromC(*rotations, sHatBdyCmd, sunAxisSpinRate, omega_RN_B, observationThreshold, controlPeriod));
 }
 
 void SunSearchPointAlgorithm_reInitialize(SunSearchPointAlgorithmHandle* self) {

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.cpp
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.cpp
@@ -7,35 +7,57 @@
 #include <Eigen/Core>
 #include <array>
 
+static_assert(SUN_SEARCH_POINT_NUM_ROTATIONS == kNumRotations,
+              "C-shim rotation count must match the algorithm's kNumRotations");
+
 namespace {
-SunSearchPointConfig configFromC(const SunSearchPointConfig_c& c) {
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+SunSearchPointConfig configFromC(const RotationPropertiesArray4_c& rotationsIn,
+                                 const Vector3f_c sHatBdyCmd,
+                                 const float sunAxisSpinRate,
+                                 const Vector3f_c omega_RN_B,
+                                 const uint32_t observationThreshold,
+                                 const float controlPeriod) {
     std::array<RotationProperties, kNumRotations> rotations{};
     for (uint32_t i = 0U; i < kNumRotations; ++i) {
-        rotations[i].rotationDuration = c.rotations[i].rotationDuration;
-        rotations[i].rotationRate = c.rotations[i].rotationRate;
-        rotations[i].rotationAxis = static_cast<RotationAxis>(c.rotations[i].rotationAxis);
+        rotations[i].rotationDuration = rotationsIn.rotations[i].rotationDuration;
+        rotations[i].rotationRate = rotationsIn.rotations[i].rotationRate;
+        rotations[i].rotationAxis = static_cast<RotationAxis>(rotationsIn.rotations[i].rotationAxis);
     }
     return SunSearchPointConfig::create(rotations,
-                                        cArrayToEigenVector3<float>(c.sHatBdyCmd.data),
-                                        c.sunAxisSpinRate,
-                                        cArrayToEigenVector3<float>(c.omega_RN_B.data),
-                                        c.observationThreshold,
-                                        c.controlPeriod);
+                                        cArrayToEigenVector3<float>(sHatBdyCmd.data),
+                                        sunAxisSpinRate,
+                                        cArrayToEigenVector3<float>(omega_RN_B.data),
+                                        observationThreshold,
+                                        controlPeriod);
 }
 }  // namespace
 
 uint32_t SunSearchPointAlgorithm_getNumRotations(void) { return SUN_SEARCH_POINT_NUM_ROTATIONS; }
 
-SunSearchPointAlgorithmHandle* SunSearchPointAlgorithm_create(const SunSearchPointConfig_c* config) {
-    return fsw::createHandle<::SunSearchPointAlgorithm, SunSearchPointAlgorithmHandle>(configFromC(*config));
+SunSearchPointAlgorithmHandle* SunSearchPointAlgorithm_create(const RotationPropertiesArray4_c* rotations,
+                                                              const Vector3f_c sHatBdyCmd,
+                                                              const float sunAxisSpinRate,
+                                                              const Vector3f_c omega_RN_B,
+                                                              const uint32_t observationThreshold,
+                                                              const float controlPeriod) {
+    return fsw::createHandle<::SunSearchPointAlgorithm, SunSearchPointAlgorithmHandle>(configFromC(
+        *rotations, sHatBdyCmd, sunAxisSpinRate, omega_RN_B, observationThreshold, controlPeriod));
 }
 
 void SunSearchPointAlgorithm_destroy(SunSearchPointAlgorithmHandle* self) {
     fsw::deleteHandle<::SunSearchPointAlgorithm>(self);
 }
 
-void SunSearchPointAlgorithm_setConfig(SunSearchPointAlgorithmHandle* self, const SunSearchPointConfig_c* config) {
-    fsw::fromHandle<::SunSearchPointAlgorithm>(self)->setConfig(configFromC(*config));
+void SunSearchPointAlgorithm_setConfig(SunSearchPointAlgorithmHandle* self,
+                                       const RotationPropertiesArray4_c* rotations,
+                                       const Vector3f_c sHatBdyCmd,
+                                       const float sunAxisSpinRate,
+                                       const Vector3f_c omega_RN_B,
+                                       const uint32_t observationThreshold,
+                                       const float controlPeriod) {
+    fsw::fromHandle<::SunSearchPointAlgorithm>(self)->setConfig(configFromC(
+        *rotations, sHatBdyCmd, sunAxisSpinRate, omega_RN_B, observationThreshold, controlPeriod));
 }
 
 void SunSearchPointAlgorithm_reInitialize(SunSearchPointAlgorithmHandle* self) {

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.cpp
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.cpp
@@ -45,7 +45,7 @@ void SunSearchPointAlgorithm_reInitialize(SunSearchPointAlgorithmHandle* self) {
 SunSearchPointOutput_c SunSearchPointAlgorithm_update(SunSearchPointAlgorithmHandle* self,
                                                       const Vector3f_c rHat_SB_B,
                                                       const Vector3f_c omega_BN_B,
-                                                      const int numCssViewingSun) {
+                                                      const uint32_t numCssViewingSun) {
     const SunSearchPointOutput out = fsw::fromHandle<::SunSearchPointAlgorithm>(self)->update(
         cArrayToEigenVector3<float>(rHat_SB_B.data), cArrayToEigenVector3<float>(omega_BN_B.data), numCssViewingSun);
 

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.h
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.h
@@ -69,7 +69,7 @@ void SunSearchPointAlgorithm_reInitialize(SunSearchPointAlgorithmHandle* self);
 SunSearchPointOutput_c SunSearchPointAlgorithm_update(SunSearchPointAlgorithmHandle* self,
                                                       Vector3f_c rHat_SB_B,
                                                       Vector3f_c omega_BN_B,
-                                                      int numCssViewingSun);
+                                                      uint32_t numCssViewingSun);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.h
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.h
@@ -40,6 +40,26 @@ typedef struct {
 uint32_t SunSearchPointAlgorithm_getNumRotations(void);
 
 /**
+ * @brief Report whether a configuration would be accepted by create/setConfig.
+ * @param rotations            [-] sun-search rotation sequence.
+ * @param sHatBdyCmd           [-] commanded body vector to point at the sun.
+ * @param sunAxisSpinRate      [rad/s] constant spin rate about the sun heading vector.
+ * @param omega_RN_B           [rad/s] fallback body rate when no sun direction is available.
+ * @param observationThreshold [-] CSS count at or above which to transition to pointing.
+ * @param controlPeriod        [s] per-update time step; advances the search timeline.
+ * @return true if the configuration is valid. Never throws, so it can guard the
+ *         throwing create/setConfig from an invalid configuration.
+ * @note The accepted value ranges are defined by SunSearchPointConfig::create; this predicate
+ *       reports whether a candidate set would be accepted, without throwing.
+ */
+bool SunSearchPointAlgorithm_validateConfig(const RotationPropertiesArray4_c* rotations,
+                                            Vector3f_c sHatBdyCmd,
+                                            float sunAxisSpinRate,
+                                            Vector3f_c omega_RN_B,
+                                            uint32_t observationThreshold,
+                                            float controlPeriod);
+
+/**
  * @brief Construct a new SunSearchPointAlgorithm instance from the supplied configuration.
  * Validate the values with validateConfig before calling; throws on invalid input.
  * @param rotations            [-] sun-search rotation sequence.

--- a/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.h
+++ b/algorithms/sunSearchPoint/sunSearchPointAlgorithm_c.h
@@ -2,6 +2,7 @@
 #define F32XMERA_SUNSEARCHPOINTALGORITHM_C_H
 
 #include "sunSearchPointTypes.h"
+#include "utilities/fsw/plainCAlgorithmDataTypes.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -14,6 +15,13 @@ extern "C" {
  * @brief Opaque handle to the C++ SunSearchPointAlgorithm instance.
  */
 typedef struct SunSearchPointAlgorithmHandle SunSearchPointAlgorithmHandle;
+
+/**
+ * @brief The sun-search rotation sequence, sized so the bound crosses the boundary in the type.
+ */
+typedef struct {
+    RotationProperties_c rotations[SUN_SEARCH_POINT_NUM_ROTATIONS];
+} RotationPropertiesArray4_c;
 
 /**
  * @brief C-compatible sun search point attitude guidance output.
@@ -33,10 +41,21 @@ uint32_t SunSearchPointAlgorithm_getNumRotations(void);
 
 /**
  * @brief Construct a new SunSearchPointAlgorithm instance from the supplied configuration.
- * @param config Pointer to the rotation-sequence configuration (validated; throws on invalid input).
+ * Validate the values with validateConfig before calling; throws on invalid input.
+ * @param rotations            [-] sun-search rotation sequence.
+ * @param sHatBdyCmd           [-] commanded body vector to point at the sun.
+ * @param sunAxisSpinRate      [rad/s] constant spin rate about the sun heading vector.
+ * @param omega_RN_B           [rad/s] fallback body rate when no sun direction is available.
+ * @param observationThreshold [-] CSS count at or above which to transition to pointing.
+ * @param controlPeriod        [s] per-update time step; advances the search timeline.
  * @return Pointer to a new SunSearchPointAlgorithm (must be destroyed).
  */
-SunSearchPointAlgorithmHandle* SunSearchPointAlgorithm_create(const SunSearchPointConfig_c* config);
+SunSearchPointAlgorithmHandle* SunSearchPointAlgorithm_create(const RotationPropertiesArray4_c* rotations,
+                                                              Vector3f_c sHatBdyCmd,
+                                                              float sunAxisSpinRate,
+                                                              Vector3f_c omega_RN_B,
+                                                              uint32_t observationThreshold,
+                                                              float controlPeriod);
 
 /**
  * @brief Destroy a previously created SunSearchPointAlgorithm.
@@ -45,12 +64,23 @@ SunSearchPointAlgorithmHandle* SunSearchPointAlgorithm_create(const SunSearchPoi
 void SunSearchPointAlgorithm_destroy(SunSearchPointAlgorithmHandle* self);
 
 /**
- * @brief Install the sun-search rotation sequence configuration (parameters only; call _reInitialize
- *        to re-arm the search phase).
- * @param self   Pointer to the instance.
- * @param config Pointer to the configuration to apply (validated; throws on invalid input).
+ * @brief Install a new configuration (parameters only; call _reInitialize to re-arm the search
+ *        phase). Validate the values with validateConfig before calling; throws on invalid input.
+ * @param self                 Pointer to the instance.
+ * @param rotations            [-] sun-search rotation sequence.
+ * @param sHatBdyCmd           [-] commanded body vector to point at the sun.
+ * @param sunAxisSpinRate      [rad/s] constant spin rate about the sun heading vector.
+ * @param omega_RN_B           [rad/s] fallback body rate when no sun direction is available.
+ * @param observationThreshold [-] CSS count at or above which to transition to pointing.
+ * @param controlPeriod        [s] per-update time step; advances the search timeline.
  */
-void SunSearchPointAlgorithm_setConfig(SunSearchPointAlgorithmHandle* self, const SunSearchPointConfig_c* config);
+void SunSearchPointAlgorithm_setConfig(SunSearchPointAlgorithmHandle* self,
+                                       const RotationPropertiesArray4_c* rotations,
+                                       Vector3f_c sHatBdyCmd,
+                                       float sunAxisSpinRate,
+                                       Vector3f_c omega_RN_B,
+                                       uint32_t observationThreshold,
+                                       float controlPeriod);
 
 /**
  * @brief Re-arm the runtime state machine so the next update begins a fresh search sequence.
@@ -60,9 +90,9 @@ void SunSearchPointAlgorithm_reInitialize(SunSearchPointAlgorithmHandle* self);
 
 /**
  * @brief Run the update step.
- * @param self              Pointer to the instance.
- * @param rHat_SB_B      Sun direction vector in body frame.
- * @param omega_BN_B        Inertial body angular velocity in body frame.
+ * @param self             Pointer to the instance.
+ * @param rHat_SB_B        Sun direction vector in body frame.
+ * @param omega_BN_B       Inertial body angular velocity in body frame.
  * @param numCssViewingSun Number of valid coarse-sun-sensor observations this cycle.
  * @return SunSearchPointOutput_c  The computed guidance output.
  */

--- a/algorithms/sunSearchPoint/sunSearchPointTypes.h
+++ b/algorithms/sunSearchPoint/sunSearchPointTypes.h
@@ -43,27 +43,6 @@ typedef struct {
     RotationAxis_c rotationAxis; /*!< [-]    axis about which to rotate */
 } RotationProperties_c;
 
-/**
- * @brief Plain-old-data mirror of the full C++ SunSearchPointConfig.
- *
- * Caller fills this struct and passes it to SunSearchPointAlgorithm_create / _setConfig. The C++ side
- * validates it via SunSearchPointConfig::create (rotations and sHatBdyCmd norm) and throws on invalid
- * input.
- *
- *  - sHatBdyCmd norm must be within 1e-3 of 1.0 (renormalized on storage)
- *  - sunAxisSpinRate and omega_RN_B are unconstrained
- *  - observationThreshold is the CSS count at or above which to transition to pointing
- *  - controlPeriod is the per-update time step [s] (must be finite and > 0)
- */
-typedef struct {
-    RotationProperties_c rotations[SUN_SEARCH_POINT_NUM_ROTATIONS]; /*!< [-] sun-search rotation sequence */
-    Vector3f_c sHatBdyCmd;    /*!< [-] commanded body vector to point at the sun */
-    float sunAxisSpinRate;    /*!< [rad/s] constant spin rate about the sun heading vector */
-    Vector3f_c omega_RN_B;    /*!< [rad/s] fallback body rate when no sun direction is available */
-    uint32_t observationThreshold; /*!< [-] CSS count at or above which to transition to pointing */
-    float controlPeriod;      /*!< [s] per-update time step; advances the search timeline (> 0) */
-} SunSearchPointConfig_c;
-
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/algorithms/sunSearchPoint/sunSearchPointTypes.h
+++ b/algorithms/sunSearchPoint/sunSearchPointTypes.h
@@ -15,8 +15,15 @@ extern "C" {
  * @brief C-compatible enumeration of body axes for the sun-search rotations.
  *
  * Numeric values must stay in lockstep with the C++ enum class in sunSearchPointAlgorithm.h.
+ *
+ * The underlying type is fixed at uint8_t to match the Ada side's 8-bit Rotation_Axis. A plain
+ * C enum is int-width, which would read four bytes where Ada wrote one.
  */
-typedef enum { ROTATION_AXIS_B1HAT_B_C = 0, ROTATION_AXIS_B2HAT_B_C = 1, ROTATION_AXIS_B3HAT_B_C = 2 } RotationAxis_c;
+typedef enum RotationAxis_c : uint8_t {
+    ROTATION_AXIS_B1HAT_B_C = 0,
+    ROTATION_AXIS_B2HAT_B_C = 1,
+    ROTATION_AXIS_B3HAT_B_C = 2
+} RotationAxis_c;
 
 /**
  * @brief Plain-old-data mirror of the C++ RotationProperties fields.
@@ -24,6 +31,11 @@ typedef enum { ROTATION_AXIS_B1HAT_B_C = 0, ROTATION_AXIS_B2HAT_B_C = 1, ROTATIO
  *  - rotationDuration must be finite and > 0
  *  - rotationRate must be finite (sign selects rotation direction)
  *  - rotationAxis must be one of the RotationAxis_c values
+ *
+ * The rotations array crosses by reference, so the C++ side reads it at fixed offsets:
+ * changing rotationAxis's width here silently misreads data rather than failing to compile.
+ * The binding's count asserts do not catch it, because the padding after rotationAxis absorbs
+ * any width up to 32 bits. The behavioural component tests are what guard the flag width.
  */
 typedef struct {
     float rotationDuration;      /*!< [s]    duration of this rotation */

--- a/algorithms/sunSearchPoint/sunSearchPointTypes.h
+++ b/algorithms/sunSearchPoint/sunSearchPointTypes.h
@@ -48,7 +48,7 @@ typedef struct {
     Vector3f_c sHatBdyCmd;    /*!< [-] commanded body vector to point at the sun */
     float sunAxisSpinRate;    /*!< [rad/s] constant spin rate about the sun heading vector */
     Vector3f_c omega_RN_B;    /*!< [rad/s] fallback body rate when no sun direction is available */
-    int observationThreshold; /*!< [-] CSS count at or above which to transition to pointing */
+    uint32_t observationThreshold; /*!< [-] CSS count at or above which to transition to pointing */
     float controlPeriod;      /*!< [s] per-update time step; advances the search timeline (> 0) */
 } SunSearchPointConfig_c;
 


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR add the Validate_Config function to the `sunSearchPoint` algorithm (in the final commit).

The first three commits contain some small tweaks to types and validation. Namely: 
- add missing config validators for `sunAxisSpinRate` and `omega_RN_B`
- change observation count from `int` to `uint32_t`
- specify the type on the rotation axis enum

The config interface was flattened as per other components to reduce type bloat in the Ada wrapper side. 

## Verification
Tests were updated to accommodate the observation count type change.

## Documentation
None invalidated, none new.

## Future work
None
