### PR TITLE
Add validation to thr firing schmitt

### DIFF
--- a/.github/workflows/downstream-build.yml
+++ b/.github/workflows/downstream-build.yml
@@ -26,6 +26,7 @@ jobs:
           set-safe-directory: true
           repository: lasp/adamant-xmera-components
           path: adamant-xmera-components
+          ref: 'feature/EMAGNCFSW-783-add-thr-firing-schmitt-component'
           persist-credentials: false
 
       - name: Check out fp32-fsw-xmera at PR head

--- a/.github/workflows/trigger_jenkins_renode.yml
+++ b/.github/workflows/trigger_jenkins_renode.yml
@@ -60,10 +60,10 @@ jobs:
       # branch's CI runs (e.g. one-off DROP / integration testing without
       # touching Jenkins UI). workflow_dispatch inputs still win over a
       # PIN; revert (or comment back) before merging.
-      # ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/your-branch-here'
+      ADAMANT_XMERA_COMPONENTS_REF_PIN: 'feature/EMAGNCFSW-783-add-thr-firing-schmitt-component'
       # ADAMANT_REF_PIN: 'feature/your-branch-here'
       # ADAMANT_EXAMPLE_REF_PIN: 'feature/your-branch-here'
-      # PROJECT_REF_PIN: 'feature/your-branch-here'
+      PROJECT_REF_PIN: 'feature/EMAGNCFSW-783-add-thr-firing-schmitt-trigger'
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
       - name: Resolve commit SHA

--- a/algorithms/thrFiringSchmitt/thrFiringSchmitt.cpp
+++ b/algorithms/thrFiringSchmitt/thrFiringSchmitt.cpp
@@ -23,23 +23,8 @@ void ThrFiringSchmitt::reset(uint64_t callTime) {
         throw std::invalid_argument("thrFiringSchmitt.thrForceInMsg wasn't connected.");
     }
 
-    /*! - read in the thruster configuration message and map to the validated thruster array */
-    const auto [numThrusters, thrusters] = this->thrConfInMsg();
-    ThrFiringSchmittThrusterArray thrusterArray{};
-    thrusterArray.numThrusters = numThrusters;
-    for (std::uint32_t i = 0U; i < numThrusters && i < kMaxThrusterCount; ++i) {
-        thrusterArray.maxThrust.at(i) = thrusters[i].maxThrust;
-    }
-
-    const ThrFiringSchmittControlParameters controlParameters{this->levelOn,
-                                                              this->levelOff,
-                                                              this->thrMinFireTime,
-                                                              this->controlPeriod,
-                                                              this->onTimeSaturationFactor,
-                                                              this->thrustPulsingRegime};
-
-    const auto config = ThrFiringSchmittConfig::create(thrusterArray, controlParameters);
-    this->algorithm = std::make_unique<ThrFiringSchmittAlgorithm>(config);
+    /*! - read in the thruster configuration message and build the validated configuration */
+    this->algorithm = std::make_unique<ThrFiringSchmittAlgorithm>(this->toConfig());
 }
 
 ThrFiringSchmittConfig ThrFiringSchmitt::toConfig() {

--- a/algorithms/thrFiringSchmitt/thrFiringSchmitt.rst
+++ b/algorithms/thrFiringSchmitt/thrFiringSchmitt.rst
@@ -36,7 +36,8 @@ provides information on what this message is used for.
       - Description
     * - thrConfInMsg
       - :ref:`THRArrayConfigMsgF32Payload`
-      - Read in ``reset()``. Contains ``numThrusters`` and per-thruster max thrust.
+      - Read in ``reset()`` and again in ``reconfigure()``. Contains ``numThrusters`` and per-thruster max
+        thrust.
     * - thrForceInMsg
       - :ref:`THRArrayCmdForceMsgF32Payload`
       - Read every ``updateState()``. Provides commanded forces :math:`F_i`. Values may be negative in
@@ -54,18 +55,24 @@ properties set before ``reset()``: ``levelOn``, ``levelOff``, ``thrMinFireTime``
 ``thrForceInMsg`` are connected (an unconnected input throws), reads the thruster configuration message into a
 ``ThrFiringSchmittThrusterArray`` (per-thruster ``maxThrust``), builds a validated ``ThrFiringSchmittConfig``, and
 constructs the owned algorithm instance — so the per-thruster ON/OFF history starts cleared on every reset. Calling
-``updateState()`` before ``reset()`` throws an ``XmeraLifecycleException``.
+``updateState()`` before ``reset()`` throws an ``XmeraLifecycleException``. ``reconfigure()`` re-reads the thruster
+configuration message and rebuilds the configuration without disturbing the ON/OFF history, so a changed thruster
+cluster takes effect there too.
 
 The validated ``ThrFiringSchmittConfig`` is immutable and is constructed via
 ``ThrFiringSchmittConfig::create(thrusterArray, controlParameters)``, which validates every field (see the bounds in
-the table below) and throws ``fsw::invalid_argument`` on any violation. The algorithm's
-``reInitialize()`` clears the per-thruster ON/OFF history without rebuilding the configuration (used by the C shim's
+the table below) and throws ``fsw::invalid_argument`` on any violation. The C shim takes the same values as a
+flattened argument list — Ada cannot see a C++ class — and reassembles the two structs before calling ``create``; it
+exposes the same rules without throwing, as ``ThrFiringSchmittAlgorithm_validateConfig``, so a caller that cannot
+handle an exception across the FFI boundary can test a candidate configuration before committing it. The algorithm's
+``reInitialize()`` clears the per-thruster ON/OFF history without touching the configuration (used by the C shim's
 reset entry point).
 
 Module Parameters
 -------------------------------
 The following table lists all the module parameters than can be set. The parameters are optional unless indicated
-(if not specified default is used). Bounds are enforced by ``ThrFiringSchmittConfig::create`` at ``reset()``.
+(if not specified default is used). Bounds are enforced by ``ThrFiringSchmittConfig::create`` at ``reset()`` and at
+``reconfigure()``.
 
 .. list-table:: Module Parameters
     :widths: 30 30 10 10 30 30

--- a/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.cpp
+++ b/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.cpp
@@ -1,5 +1,6 @@
 #include "thrFiringSchmittAlgorithm_c.h"
 #include "thrFiringSchmittAlgorithm.h"
+#include "utilities/fsw/freestandingInvalidArgument.h"
 #include "utilities/fsw/opaqueHandle.h"
 
 #include <algorithm>
@@ -38,6 +39,32 @@ ThrFiringSchmittConfig configFromC(const uint32_t numThrusters,
 }  // namespace
 
 uint32_t ThrFiringSchmittAlgorithm_getMaxThrusterCount(void) { return THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT; }
+
+bool ThrFiringSchmittAlgorithm_validateConfig(const uint32_t numThrusters,
+                                              float maxThrust[THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT],
+                                              const float levelOn,
+                                              const float levelOff,
+                                              const float thrMinFireTime,
+                                              const float controlPeriod,
+                                              const float onTimeSaturationFactor,
+                                              const ThrFiringSchmittPulsingRegime pulsingRegime) {
+    // Attempt to build the config through the real create path (configFromC ->
+    // ThrFiringSchmittConfig::create): success means valid, a throw means invalid.
+    // Reusing create means this validation can never drift from the rules it enforces.
+    try {
+        (void)configFromC(numThrusters,
+                          maxThrust,
+                          levelOn,
+                          levelOff,
+                          thrMinFireTime,
+                          controlPeriod,
+                          onTimeSaturationFactor,
+                          pulsingRegime);
+        return true;
+    } catch (const fsw::invalid_argument&) {
+        return false;
+    }
+}
 
 ThrFiringSchmittAlgorithmHandle* ThrFiringSchmittAlgorithm_create(
     const uint32_t numThrusters,

--- a/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.cpp
+++ b/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.cpp
@@ -8,30 +8,55 @@ static_assert(THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT == kMaxThrusterCount,
               "C-shim thruster count must match the algorithm's kMaxThrusterCount");
 
 namespace {
-ThrFiringSchmittConfig toConfig(const ThrFiringSchmittConfig_c* config) {
+// Reassemble the flattened C arguments into the C++ configuration structs. The flat argument
+// list is the shape of the extern "C" boundary only; everything behind this helper is struct
+// based, and ThrFiringSchmittConfig::create remains the single validation authority.
+ThrFiringSchmittConfig configFromC(const uint32_t numThrusters,
+                                   const float maxThrust[THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT],
+                                   const float levelOn,
+                                   const float levelOff,
+                                   const float thrMinFireTime,
+                                   const float controlPeriod,
+                                   const float onTimeSaturationFactor,
+                                   const ThrFiringSchmittPulsingRegime pulsingRegime) {
     ThrFiringSchmittThrusterArray thrusterArray{};
-    thrusterArray.numThrusters = config->thrusterArray.numThrusters;
-    const uint32_t copyCount = std::min(thrusterArray.numThrusters, kMaxThrusterCount);
+    thrusterArray.numThrusters = numThrusters;
+    const uint32_t copyCount = std::min(numThrusters, kMaxThrusterCount);
     for (uint32_t i = 0U; i < copyCount; ++i) {
-        thrusterArray.maxThrust.at(i) = config->thrusterArray.maxThrust[i];
+        thrusterArray.maxThrust.at(i) = maxThrust[i];
     }
 
-    const ThrFiringSchmittControlParameters params{
-        config->controlParameters.levelOn,
-        config->controlParameters.levelOff,
-        config->controlParameters.thrMinFireTime,
-        config->controlParameters.controlPeriod,
-        config->controlParameters.onTimeSaturationFactor,
-        static_cast<ThrustPulsingRegime>(config->controlParameters.pulsingRegime)};
+    const ThrFiringSchmittControlParameters controlParameters{levelOn,
+                                                              levelOff,
+                                                              thrMinFireTime,
+                                                              controlPeriod,
+                                                              onTimeSaturationFactor,
+                                                              static_cast<ThrustPulsingRegime>(pulsingRegime)};
 
-    return ThrFiringSchmittConfig::create(thrusterArray, params);
+    return ThrFiringSchmittConfig::create(thrusterArray, controlParameters);
 }
 }  // namespace
 
 uint32_t ThrFiringSchmittAlgorithm_getMaxThrusterCount(void) { return THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT; }
 
-ThrFiringSchmittAlgorithmHandle* ThrFiringSchmittAlgorithm_create(const ThrFiringSchmittConfig_c* config) {
-    return fsw::createHandle<::ThrFiringSchmittAlgorithm, ThrFiringSchmittAlgorithmHandle>(toConfig(config));
+ThrFiringSchmittAlgorithmHandle* ThrFiringSchmittAlgorithm_create(
+    const uint32_t numThrusters,
+    float maxThrust[THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT],
+    const float levelOn,
+    const float levelOff,
+    const float thrMinFireTime,
+    const float controlPeriod,
+    const float onTimeSaturationFactor,
+    const ThrFiringSchmittPulsingRegime pulsingRegime) {
+    return fsw::createHandle<::ThrFiringSchmittAlgorithm, ThrFiringSchmittAlgorithmHandle>(
+        configFromC(numThrusters,
+                    maxThrust,
+                    levelOn,
+                    levelOff,
+                    thrMinFireTime,
+                    controlPeriod,
+                    onTimeSaturationFactor,
+                    pulsingRegime));
 }
 
 void ThrFiringSchmittAlgorithm_destroy(ThrFiringSchmittAlgorithmHandle* self) {
@@ -39,8 +64,22 @@ void ThrFiringSchmittAlgorithm_destroy(ThrFiringSchmittAlgorithmHandle* self) {
 }
 
 void ThrFiringSchmittAlgorithm_setConfig(ThrFiringSchmittAlgorithmHandle* self,
-                                         const ThrFiringSchmittConfig_c* config) {
-    fsw::fromHandle<::ThrFiringSchmittAlgorithm>(self)->setConfig(toConfig(config));
+                                         const uint32_t numThrusters,
+                                         float maxThrust[THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT],
+                                         const float levelOn,
+                                         const float levelOff,
+                                         const float thrMinFireTime,
+                                         const float controlPeriod,
+                                         const float onTimeSaturationFactor,
+                                         const ThrFiringSchmittPulsingRegime pulsingRegime) {
+    fsw::fromHandle<::ThrFiringSchmittAlgorithm>(self)->setConfig(configFromC(numThrusters,
+                                                                              maxThrust,
+                                                                              levelOn,
+                                                                              levelOff,
+                                                                              thrMinFireTime,
+                                                                              controlPeriod,
+                                                                              onTimeSaturationFactor,
+                                                                              pulsingRegime));
 }
 
 void ThrFiringSchmittAlgorithm_reInitialize(ThrFiringSchmittAlgorithmHandle* self) {

--- a/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.h
+++ b/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.h
@@ -3,6 +3,7 @@
 
 #include "thrFiringSchmittTypes.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -17,6 +18,28 @@ typedef struct ThrFiringSchmittAlgorithmHandle ThrFiringSchmittAlgorithmHandle;
  * @return The maximum thruster count (THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT).
  */
 uint32_t ThrFiringSchmittAlgorithm_getMaxThrusterCount(void);
+
+/**
+ * @brief Report whether a configuration would be accepted by create/setConfig.
+ * @param numThrusters           [-] Number of thrusters on the vehicle.
+ * @param maxThrust              [N] Per-thruster maximum thrust; the first numThrusters entries are used.
+ * @param levelOn                [-] ON duty cycle fraction threshold, in (0, 1].
+ * @param levelOff               [-] OFF duty cycle fraction threshold, in [0, 1).
+ * @param thrMinFireTime         [s] Minimum commandable thruster fire time.
+ * @param controlPeriod          [s] Control period over which the force command applies.
+ * @param onTimeSaturationFactor [-] Control-period multiplier applied when on-time saturates.
+ * @param pulsingRegime          [-] On-pulsing or off-pulsing.
+ * @return true if the configuration is valid. Never throws, so it can guard the
+ *         throwing create/setConfig from an invalid configuration.
+ */
+bool ThrFiringSchmittAlgorithm_validateConfig(uint32_t numThrusters,
+                                              float maxThrust[THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT],
+                                              float levelOn,
+                                              float levelOff,
+                                              float thrMinFireTime,
+                                              float controlPeriod,
+                                              float onTimeSaturationFactor,
+                                              ThrFiringSchmittPulsingRegime pulsingRegime);
 
 /**
  * @brief Construct a new ThrFiringSchmittAlgorithm instance from the supplied configuration.

--- a/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.h
+++ b/algorithms/thrFiringSchmitt/thrFiringSchmittAlgorithm_c.h
@@ -20,10 +20,25 @@ uint32_t ThrFiringSchmittAlgorithm_getMaxThrusterCount(void);
 
 /**
  * @brief Construct a new ThrFiringSchmittAlgorithm instance from the supplied configuration.
- * @param config Pointer to the configuration to apply (validated; throws on invalid input).
- * @return Pointer to a new ThrFiringSchmittAlgorithm (must be destroyed).
+ * @param numThrusters           [-] Number of thrusters on the vehicle.
+ * @param maxThrust              [N] Per-thruster maximum thrust; the first numThrusters entries are used.
+ * @param levelOn                [-] ON duty cycle fraction threshold, in (0, 1].
+ * @param levelOff               [-] OFF duty cycle fraction threshold, in [0, 1).
+ * @param thrMinFireTime         [s] Minimum commandable thruster fire time.
+ * @param controlPeriod          [s] Control period over which the force command applies.
+ * @param onTimeSaturationFactor [-] Control-period multiplier applied when on-time saturates.
+ * @param pulsingRegime          [-] On-pulsing or off-pulsing.
+ * @return Pointer to a new ThrFiringSchmittAlgorithm (must be destroyed). Throws on invalid input.
  */
-ThrFiringSchmittAlgorithmHandle* ThrFiringSchmittAlgorithm_create(const ThrFiringSchmittConfig_c* config);
+ThrFiringSchmittAlgorithmHandle* ThrFiringSchmittAlgorithm_create(
+    uint32_t numThrusters,
+    float maxThrust[THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT],
+    float levelOn,
+    float levelOff,
+    float thrMinFireTime,
+    float controlPeriod,
+    float onTimeSaturationFactor,
+    ThrFiringSchmittPulsingRegime pulsingRegime);
 
 /**
  * @brief Destroy a previously created ThrFiringSchmittAlgorithm.
@@ -33,10 +48,26 @@ void ThrFiringSchmittAlgorithm_destroy(ThrFiringSchmittAlgorithmHandle* self);
 
 /**
  * @brief Replace the algorithm's configuration at runtime. The Schmitt-trigger state is preserved.
- * @param self   Pointer to the instance.
- * @param config Pointer to the configuration to apply (validated; throws on invalid input).
+ * @param self                   Pointer to the instance.
+ * @param numThrusters           [-] Number of thrusters on the vehicle.
+ * @param maxThrust              [N] Per-thruster maximum thrust; the first numThrusters entries are used.
+ * @param levelOn                [-] ON duty cycle fraction threshold, in (0, 1].
+ * @param levelOff               [-] OFF duty cycle fraction threshold, in [0, 1).
+ * @param thrMinFireTime         [s] Minimum commandable thruster fire time.
+ * @param controlPeriod          [s] Control period over which the force command applies.
+ * @param onTimeSaturationFactor [-] Control-period multiplier applied when on-time saturates.
+ * @param pulsingRegime          [-] On-pulsing or off-pulsing.
+ * @note Throws on invalid input.
  */
-void ThrFiringSchmittAlgorithm_setConfig(ThrFiringSchmittAlgorithmHandle* self, const ThrFiringSchmittConfig_c* config);
+void ThrFiringSchmittAlgorithm_setConfig(ThrFiringSchmittAlgorithmHandle* self,
+                                         uint32_t numThrusters,
+                                         float maxThrust[THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT],
+                                         float levelOn,
+                                         float levelOff,
+                                         float thrMinFireTime,
+                                         float controlPeriod,
+                                         float onTimeSaturationFactor,
+                                         ThrFiringSchmittPulsingRegime pulsingRegime);
 
 /**
  * @brief Clear the algorithm's per-thruster ON/OFF history (sets all to OFF).

--- a/algorithms/thrFiringSchmitt/thrFiringSchmittTypes.h
+++ b/algorithms/thrFiringSchmitt/thrFiringSchmittTypes.h
@@ -14,28 +14,6 @@ extern "C" {
 /** @brief Thrust pulsing regime selection. */
 typedef enum { THR_FIRING_SCHMITT_ON_PULSING = 0, THR_FIRING_SCHMITT_OFF_PULSING = 1 } ThrFiringSchmittPulsingRegime;
 
-/** @brief Plain-old-data mirror of the C++ ThrFiringSchmittThrusterArray. */
-typedef struct {
-    uint32_t numThrusters;                                  /*!< [-] number of thrusters on the vehicle */
-    float maxThrust[THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT]; /*!< [N] per-thruster maximum thrust */
-} ThrFiringSchmittThrusterArray_c;
-
-/** @brief Plain-old-data mirror of the C++ ThrFiringSchmittControlParameters. */
-typedef struct {
-    float levelOn;                               /*!< [-] ON duty cycle fraction threshold, in (0, 1] */
-    float levelOff;                              /*!< [-] OFF duty cycle fraction threshold, in [0, 1) */
-    float thrMinFireTime;                        /*!< [s] minimum commandable thruster fire time */
-    float controlPeriod;                         /*!< [s] control period over which the force command applies */
-    float onTimeSaturationFactor;                /*!< [-] control-period multiplier applied when on-time saturates */
-    ThrFiringSchmittPulsingRegime pulsingRegime; /*!< [-] on-pulsing or off-pulsing */
-} ThrFiringSchmittControlParameters_c;
-
-/** @brief Plain-old-data mirror of the C++ ThrFiringSchmittConfig. */
-typedef struct {
-    ThrFiringSchmittThrusterArray_c thrusterArray;         /*!< [-] per-thruster maximum thrust */
-    ThrFiringSchmittControlParameters_c controlParameters; /*!< [-] Schmitt-trigger firing control parameters */
-} ThrFiringSchmittConfig_c;
-
 /** @brief Thruster force command input (POD). */
 typedef struct {
     float thrForce[THR_FIRING_SCHMITT_MAX_THRUSTER_COUNT]; /*!< [N] Thruster force values */


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR adds a `ThrFiringSchmittAlgorithm_validateConfig` function to the C shim interface. The first three commits restructure the algorithm and its C shim to employ the flat parameters pattern we prefer.

## Verification
The tests were only modified to accommodate the flattened config.

## Documentation
The documentation was updated to reflect the removal of the `ThrFiringSchmittControlParameters` where flattening.

## Future work
None
