### PR TITLE
2386 add axisToGimbalAngles module

### DIFF
--- a/.github/clang-tidy-exclude.txt
+++ b/.github/clang-tidy-exclude.txt
@@ -5,6 +5,8 @@ algorithms/attTrackingError/attTrackingError.h
 algorithms/attTrackingError/attTrackingError.cpp
 algorithms/axisToGimbalAngles/axisToGimbalAngles.h
 algorithms/axisToGimbalAngles/axisToGimbalAngles.cpp
+algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm_c.h
+algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm_c.cpp
 algorithms/averageMimuData/averageMimuData.h
 algorithms/averageMimuData/averageMimuData.cpp
 algorithms/bodyRateMiscompare/bodyRateMiscompare.h

--- a/.github/clang-tidy-exclude.txt
+++ b/.github/clang-tidy-exclude.txt
@@ -3,6 +3,8 @@
 
 algorithms/attTrackingError/attTrackingError.h
 algorithms/attTrackingError/attTrackingError.cpp
+algorithms/axisToGimbalAngles/axisToGimbalAngles.h
+algorithms/axisToGimbalAngles/axisToGimbalAngles.cpp
 algorithms/averageMimuData/averageMimuData.h
 algorithms/averageMimuData/averageMimuData.cpp
 algorithms/bodyRateMiscompare/bodyRateMiscompare.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ add_subdirectory(algorithms/utilities/fsw)
 set(algorithms
     "cobConverter"
     "attTrackingError"
+    "axisToGimbalAngles"
     "averageMimuData"
     "bodyRateMiscompare"
     "celestialTwoBodyPoint"

--- a/algorithms/CMakeLists.txt
+++ b/algorithms/CMakeLists.txt
@@ -11,6 +11,7 @@ link_libraries(FswUtilities)
 
 add_subdirectory(cobConverter)
 add_subdirectory(attTrackingError)
+add_subdirectory(axisToGimbalAngles)
 add_subdirectory(averageMimuData)
 add_subdirectory(bodyRateMiscompare)
 add_subdirectory(celestialTwoBodyPoint)

--- a/algorithms/axisToGimbalAngles/CMakeLists.txt
+++ b/algorithms/axisToGimbalAngles/CMakeLists.txt
@@ -18,3 +18,5 @@ target_include_directories("${module}" PUBLIC
 target_link_libraries("${module}" PRIVATE
   Eigen3::Eigen
 )
+
+add_subdirectory(_tests)

--- a/algorithms/axisToGimbalAngles/CMakeLists.txt
+++ b/algorithms/axisToGimbalAngles/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(module "fp32.axisToGimbalAnglesF32")
+xmera_is_module_enabled("${module}" _is_enabled)
+if(NOT _is_enabled)
+  return()
+endif()
+
+xmera_add_swig_module("${module}")
+target_sources("${module}" PRIVATE
+  axisToGimbalAngles.cpp
+  axisToGimbalAnglesAlgorithm.cpp
+)
+
+target_include_directories("${module}" PUBLIC
+  ".."
+  "../.."
+)
+
+target_link_libraries("${module}" PRIVATE
+  Eigen3::Eigen
+)

--- a/algorithms/axisToGimbalAngles/CMakeLists.txt
+++ b/algorithms/axisToGimbalAngles/CMakeLists.txt
@@ -8,6 +8,7 @@ xmera_add_swig_module("${module}")
 target_sources("${module}" PRIVATE
   axisToGimbalAngles.cpp
   axisToGimbalAnglesAlgorithm.cpp
+  axisToGimbalAnglesAlgorithm_c.cpp
 )
 
 target_include_directories("${module}" PUBLIC

--- a/algorithms/axisToGimbalAngles/_tests/CMakeLists.txt
+++ b/algorithms/axisToGimbalAngles/_tests/CMakeLists.txt
@@ -1,0 +1,39 @@
+add_executable(test_axisToGimbalAngles
+  ../axisToGimbalAnglesAlgorithm.cpp
+  axisToGimbalAnglesTestHelpers.hpp
+  test_axisToGimbalAngles.cpp
+)
+
+target_include_directories(test_axisToGimbalAngles PRIVATE "..")
+target_include_directories(test_axisToGimbalAngles PRIVATE "${CMAKE_SOURCE_DIR}")
+
+target_link_libraries(test_axisToGimbalAngles PRIVATE
+    Eigen3::Eigen
+    GTest::gtest_main
+  )
+
+gtest_discover_tests(test_axisToGimbalAngles)
+
+if(XMERA_ENABLE_FUZZTESTS)
+  fuzztest_setup_fuzzing_flags()
+
+  add_executable(test_axisToGimbalAngles_fuzz
+    ../axisToGimbalAnglesAlgorithm.cpp
+    axisToGimbalAnglesTestHelpers.hpp
+    test_axisToGimbalAngles_fuzz.cpp
+  )
+
+  target_include_directories(test_axisToGimbalAngles_fuzz PRIVATE "..")
+  target_include_directories(test_axisToGimbalAngles_fuzz PRIVATE "${CMAKE_SOURCE_DIR}")
+
+  target_link_libraries(test_axisToGimbalAngles_fuzz PRIVATE
+    Eigen3::Eigen
+    fuzztest::fuzztest
+    fuzztest::fuzztest_gtest_main
+  )
+
+  gtest_discover_tests(test_axisToGimbalAngles_fuzz
+    PROPERTIES
+      LABELS "fuzz\;fuzz-smoke"
+  )
+endif()

--- a/algorithms/axisToGimbalAngles/_tests/axisToGimbalAnglesTestHelpers.hpp
+++ b/algorithms/axisToGimbalAngles/_tests/axisToGimbalAnglesTestHelpers.hpp
@@ -1,0 +1,229 @@
+#ifndef TEST_AXIS_TO_GIMBAL_ANGLES_H
+#define TEST_AXIS_TO_GIMBAL_ANGLES_H
+
+#include "axisToGimbalAnglesAlgorithm.h"
+#include "utilities/fsw/freestandingInvalidArgument.h"
+#include "utilities/fsw/rigidBodyKinematics.hpp"
+#include <gtest/gtest.h>
+#include <Eigen/Core>
+#include <cmath>
+#include <numbers>
+
+// Build a configuration from the mounting orientation that the tests use.
+inline AxisToGimbalAnglesConfig makeConfig(const Eigen::Vector3f& sigma_MB) {
+    return AxisToGimbalAnglesConfig::create(sigma_MB);
+}
+
+// The gimbal thrust axis for a pair of angles. This function does not use the algorithm, thus the tests can
+// examine the mapping and do not repeat it. T(angle1, angle2) is proportional to [-tan(angle2), tan(angle1), -1].
+// The cos(angle1)cos(angle2) factor keeps the components small at a deflection of 90 degrees.
+inline Eigen::Vector3f gimbalAxis_M(const float angle1, const float angle2) {
+    return Eigen::Vector3f{
+        -std::sin(angle2) * std::cos(angle1), std::cos(angle2) * std::sin(angle1), -std::cos(angle2) * std::cos(angle1)}
+        .normalized();
+}
+
+// The input direction in mount-frame coordinates. The two angles are ratios against the mount -z axis. Thus this
+// function does not change the length of the vector.
+inline Eigen::Vector3f thrustDir_M(const Eigen::Vector3f& sigma_MB, const Eigen::Vector3f& thrustDirection_B) {
+    return mrpToDcm(mrpSwitch(sigma_MB)) * thrustDirection_B;
+}
+
+// The input direction in mount-frame coordinates, with unit length. This function uses stableNormalized() and
+// not normalized(). normalized() calculates squaredNorm(), which is too small for a very short vector and too
+// large for a very long one. The module has neither problem, because it uses ratios.
+inline Eigen::Vector3f thrustHatUnit_M(const Eigen::Vector3f& sigma_MB, const Eigen::Vector3f& thrustDirection_B) {
+    return thrustDir_M(sigma_MB, thrustDirection_B).stableNormalized();
+}
+
+// Shows if the module can give two angles for the input direction. The direction must be in the open half-space
+// into which the neutral thrust fires, on the -z side of the mount frame. Each component must also be a number:
+// the safe arctangent gives zero for a component that is not a number, and a very large input can become
+// infinite in the rotation to mount-frame coordinates.
+inline bool isResolvable(const Eigen::Vector3f& sigma_MB, const Eigen::Vector3f& thrustDirection_B) {
+    const Eigen::Vector3f unitDirection = thrustHatUnit_M(sigma_MB, thrustDirection_B);
+    return unitDirection.allFinite() && -unitDirection.z() > 0.0F;
+}
+
+// Double-precision reference for the two gimbal angles. The regression tests compare the float algorithm with
+// this reference.
+struct GimbalAnglesDouble {
+    double angle1;
+    double angle2;
+};
+
+inline GimbalAnglesDouble referenceUpdate(const Eigen::Vector3d& sigma_MB, const Eigen::Vector3d& thrustDirection_B) {
+    const Eigen::Vector3d thrustDir = (mrpToDcm(mrpSwitch<double>(sigma_MB)) * thrustDirection_B).stableNormalized();
+    const double towardsThrust = -thrustDir.z();
+    // The float algorithm uses safe arctangents, which give zero for an argument that is not a number.
+    if (!thrustDir.allFinite() || !(towardsThrust > 0.0)) {
+        return {0.0, 0.0};
+    }
+    return {std::atan2(thrustDir.y(), towardsThrust), std::atan2(-thrustDir.x(), towardsThrust)};
+}
+
+// Shows if the input direction is on the boundary of the half-space, where the deflection is 90 degrees and the
+// mount-frame z component is zero. There the two angles are at the edge of their range and hold no more
+// information about the direction. The error of the float rotation is also larger than the z component, thus the
+// float algorithm and a double reference can put the direction on different sides of the boundary. The band is
+// much larger than that error, which is approximately 4e-7 for a direction of unit length.
+inline bool isOnTheHalfSpaceBoundary(const Eigen::Vector3f& unitDirection_M) {
+    constexpr float kBoundaryBand = 1e-5F;
+    return std::fabs(unitDirection_M.z()) < kBoundaryBand;
+}
+
+// The largest difference that is permitted between the float angles and the double reference angles.
+//
+// The two angles are the coordinates of the point where the thrust axis touches the plane z = -1. Thus they
+// become very large as the deflection increases to 90 degrees. Near that limit the last bits of a float value
+// hold all of the remaining z component, and the accuracy decreases in proportion to 1 / |z|. This is a property
+// of the two angles and not a defect. The constant below includes margin above the measured behaviour. For the
+// small deflections that a gimbal can move to, this bound is approximately 1e-5.
+inline float angleTolerance(const Eigen::Vector3f& unitDirection_M) {
+    constexpr float kScale = 2e-6F;
+    return 1e-5F + (kScale / std::fmax(-unitDirection_M.z(), kScale));
+}
+
+// In the half-space, both angles are arctangents of a ratio with a denominator of more than zero. Thus both
+// angles stay in the range -pi/2 to pi/2.
+inline void expectPrincipalBranches(const AxisToGimbalAnglesOutput& out, const float accuracy) {
+    constexpr float halfPi = std::numbers::pi_v<float> / 2.0F;
+    EXPECT_LE(std::fabs(out.gimbalAngle1), halfPi + accuracy);
+    EXPECT_LE(std::fabs(out.gimbalAngle2), halfPi + accuracy);
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests
+// ---------------------------------------------------------------------------
+
+// The float algorithm must agree with the double reference. For a direction in the half-space, the two angles
+// must also align the gimbal thrust axis with that direction.
+inline void regressionTestAxisToGimbalAngles(const Eigen::Vector3f& sigma_MB,
+                                             const Eigen::Vector3f& thrustDirection_B) {
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(sigma_MB)};
+    const AxisToGimbalAnglesOutput out = alg.update(thrustDirection_B);
+
+    const Eigen::Vector3f expected_M = thrustHatUnit_M(sigma_MB, thrustDirection_B);
+    const float accuracy = angleTolerance(expected_M);
+
+    // On the boundary of the half-space, neither the home position nor an angle at the edge of the range is more
+    // correct. Examine only that the two angles are usable.
+    if (isOnTheHalfSpaceBoundary(expected_M)) {
+        EXPECT_TRUE(std::isfinite(out.gimbalAngle1));
+        EXPECT_TRUE(std::isfinite(out.gimbalAngle2));
+        expectPrincipalBranches(out, 1e-5F);
+        return;
+    }
+
+    const GimbalAnglesDouble reference = referenceUpdate(sigma_MB.cast<double>(), thrustDirection_B.cast<double>());
+    EXPECT_NEAR(out.gimbalAngle1, static_cast<float>(reference.angle1), accuracy);
+    EXPECT_NEAR(out.gimbalAngle2, static_cast<float>(reference.angle2), accuracy);
+
+    if (!isResolvable(sigma_MB, thrustDirection_B)) {
+        // The direction is not in the half-space, thus the module gives the home position.
+        EXPECT_NEAR(out.gimbalAngle1, 0.0F, 1e-6F);
+        EXPECT_NEAR(out.gimbalAngle2, 0.0F, 1e-6F);
+        return;
+    }
+
+    expectPrincipalBranches(out, accuracy);
+    EXPECT_LT((gimbalAxis_M(out.gimbalAngle1, out.gimbalAngle2) - expected_M).norm(), accuracy);
+}
+
+// Regression test for a case that a known pair of angles defines. The helper builds the direction from the two
+// angles, changes it to body-frame coordinates, and makes sure that the module gives the same two angles again.
+// The body-frame input also makes the module apply the mounting orientation.
+inline void regressionTestAxisToGimbalAnglesFromAngles(const Eigen::Vector3f& sigma_MB,
+                                                       const float angle1,
+                                                       const float angle2) {
+    const Eigen::Vector3f thrustDirection_B = mrpToDcm(mrpSwitch(sigma_MB)).transpose() * gimbalAxis_M(angle1, angle2);
+
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(sigma_MB)};
+    const AxisToGimbalAnglesOutput out = alg.update(thrustDirection_B);
+
+    const float accuracy = angleTolerance(thrustHatUnit_M(sigma_MB, thrustDirection_B));
+    EXPECT_NEAR(out.gimbalAngle1, angle1, accuracy);
+    EXPECT_NEAR(out.gimbalAngle2, angle2, accuracy);
+
+    regressionTestAxisToGimbalAngles(sigma_MB, thrustDirection_B);
+}
+
+// ---------------------------------------------------------------------------
+// Property tests
+// ---------------------------------------------------------------------------
+
+// Each input gives two angles that a caller can use. The two angles are always numbers. For a direction in the
+// half-space they stay in the range -pi/2 to pi/2. For all other directions the module gives the home position.
+inline void propertyOutputIsUsable(const Eigen::Vector3f& sigma_MB, const Eigen::Vector3f& thrustDirection_B) {
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(sigma_MB)};
+    const AxisToGimbalAnglesOutput out = alg.update(thrustDirection_B);
+
+    // The home position is zero, thus these two conditions are true for every input.
+    EXPECT_TRUE(std::isfinite(out.gimbalAngle1));
+    EXPECT_TRUE(std::isfinite(out.gimbalAngle2));
+    expectPrincipalBranches(out, 1e-5F);
+
+    // The module gives the home position for a direction that is certainly outside the half-space. Two
+    // conditions are not certain. On the boundary the module can give the home position or an angle at the edge
+    // of the range, and both answers are correct. For a direction with a component that is not a number, the
+    // safe arctangent gives zero for one angle and can give a value for the other. This test makes no claim for
+    // those two conditions.
+    const Eigen::Vector3f unitDirection_M = thrustHatUnit_M(sigma_MB, thrustDirection_B);
+    const bool certainlyOutside =
+        unitDirection_M.allFinite() && -unitDirection_M.z() <= 0.0F && !isOnTheHalfSpaceBoundary(unitDirection_M);
+    if (certainlyOutside) {
+        EXPECT_NEAR(out.gimbalAngle1, 0.0F, 1e-6F);
+        EXPECT_NEAR(out.gimbalAngle2, 0.0F, 1e-6F);
+    }
+}
+
+// For a direction in the half-space, the two angles align the gimbal thrust axis with that direction. The helper
+// skips no input. It examines a direction that is not in the half-space with propertyOutputIsUsable.
+inline void propertyDirectionRecovered(const Eigen::Vector3f& sigma_MB, const Eigen::Vector3f& thrustDirection_B) {
+    const Eigen::Vector3f expected_M = thrustHatUnit_M(sigma_MB, thrustDirection_B);
+    if (!isResolvable(sigma_MB, thrustDirection_B) || isOnTheHalfSpaceBoundary(expected_M)) {
+        propertyOutputIsUsable(sigma_MB, thrustDirection_B);
+        return;
+    }
+
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(sigma_MB)};
+    const AxisToGimbalAnglesOutput out = alg.update(thrustDirection_B);
+
+    EXPECT_LT((gimbalAxis_M(out.gimbalAngle1, out.gimbalAngle2) - expected_M).norm(), angleTolerance(expected_M));
+}
+
+// Both angles are ratios against the mount -z axis. Thus a change of the length of the input direction does not
+// change the two angles.
+//
+// A very small or very large scale is the one exception, and it is a limit of the float type and not of the
+// module. Such a scale makes a component of the scaled vector too large for a float, or so small that it becomes
+// zero or loses almost all of its bits. The scaled vector then holds a different direction, or no direction, and
+// the module correctly gives different angles. The helper skips no input: it examines both vectors with
+// propertyOutputIsUsable in that condition.
+inline void propertyLengthHasNoEffect(const Eigen::Vector3f& sigma_MB,
+                                      const Eigen::Vector3f& thrustDirection_B,
+                                      const float scale) {
+    constexpr float kDirectionKept = 1e-6F;
+
+    const Eigen::Vector3f scaledDirection_B = scale * thrustDirection_B;
+    const bool scalingKeptTheDirection =
+        isResolvable(sigma_MB, thrustDirection_B) && isResolvable(sigma_MB, scaledDirection_B) &&
+        !isOnTheHalfSpaceBoundary(thrustHatUnit_M(sigma_MB, thrustDirection_B)) &&
+        (thrustHatUnit_M(sigma_MB, scaledDirection_B) - thrustHatUnit_M(sigma_MB, thrustDirection_B)).norm() <
+            kDirectionKept;
+    if (!scalingKeptTheDirection) {
+        propertyOutputIsUsable(sigma_MB, thrustDirection_B);
+        propertyOutputIsUsable(sigma_MB, scaledDirection_B);
+        return;
+    }
+
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(sigma_MB)};
+    const AxisToGimbalAnglesOutput out = alg.update(thrustDirection_B);
+    const AxisToGimbalAnglesOutput scaledOut = alg.update(scaledDirection_B);
+
+    const float accuracy = angleTolerance(thrustHatUnit_M(sigma_MB, thrustDirection_B));
+    EXPECT_NEAR(scaledOut.gimbalAngle1, out.gimbalAngle1, accuracy);
+    EXPECT_NEAR(scaledOut.gimbalAngle2, out.gimbalAngle2, accuracy);
+}
+
+#endif  // TEST_AXIS_TO_GIMBAL_ANGLES_H

--- a/algorithms/axisToGimbalAngles/_tests/test_axisToGimbalAngles.cpp
+++ b/algorithms/axisToGimbalAngles/_tests/test_axisToGimbalAngles.cpp
@@ -1,0 +1,184 @@
+#include "axisToGimbalAnglesTestHelpers.hpp"
+#include "utilities/fsw/freestandingInvalidArgument.h"
+
+#include <limits>
+
+namespace {
+constexpr float kAccuracy = 1e-5F;
+constexpr float kDegToRad = std::numbers::pi_v<float> / 180.0F;
+
+// A mount that is rotated about two axes, thus the tests examine the mounting orientation.
+Eigen::Vector3f rotatedMount() { return dcmToMrp(eulerAngles123ToDcm(Eigen::Vector3f(0.087F, 0.175F, 0.0F))); }
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Regression tests
+// ---------------------------------------------------------------------------
+
+// If the mount frame is aligned with the body frame, the neutral thrust axis needs no gimbal rotation.
+TEST(AxisToGimbalAnglesTest, RegressionNeutralDirection) {
+    regressionTestAxisToGimbalAnglesFromAngles(Eigen::Vector3f::Zero(), 0.0F, 0.0F);
+}
+
+// Each angle moves the thrust axis in one mount plane only. The module gives back the angle that made the
+// direction. The two conventions agree on each axis, thus these two cases set the signs and the zero positions.
+TEST(AxisToGimbalAnglesTest, RegressionPureFirstAndSecondAngle) {
+    regressionTestAxisToGimbalAnglesFromAngles(Eigen::Vector3f::Zero(), 12.0F * kDegToRad, 0.0F);
+    regressionTestAxisToGimbalAnglesFromAngles(Eigen::Vector3f::Zero(), 0.0F, -7.5F * kDegToRad);
+}
+
+// The module gives back the two angles that made the direction.
+TEST(AxisToGimbalAnglesTest, RegressionCombinedAngles) {
+    regressionTestAxisToGimbalAnglesFromAngles(Eigen::Vector3f::Zero(), -18.25F * kDegToRad, 9.75F * kDegToRad);
+}
+
+// The module applies the mounting orientation first. Thus a rotated mount changes the two angles that it gives
+// for the same body-frame direction.
+TEST(AxisToGimbalAnglesTest, RegressionRotatedMount) {
+    regressionTestAxisToGimbalAnglesFromAngles(rotatedMount(), 6.0F * kDegToRad, -11.0F * kDegToRad);
+    regressionTestAxisToGimbalAngles(rotatedMount(), {0.1F, -0.2F, -0.97F});
+    regressionTestAxisToGimbalAngles(rotatedMount(), -Eigen::Vector3f::UnitZ());
+}
+
+// A large deflection, which the mechanism cannot move to, still gives the correct two angles.
+TEST(AxisToGimbalAnglesTest, RegressionLargeDeflection) {
+    regressionTestAxisToGimbalAnglesFromAngles(Eigen::Vector3f::Zero(), 60.0F * kDegToRad, -55.0F * kDegToRad);
+}
+
+// ---------------------------------------------------------------------------
+// Property tests with selected values
+// ---------------------------------------------------------------------------
+
+TEST(AxisToGimbalAnglesTest, PropertyOutputIsUsable) {
+    propertyOutputIsUsable(rotatedMount(), {0.1F, -0.2F, -0.97F});
+    propertyOutputIsUsable(rotatedMount(), Eigen::Vector3f::UnitZ());
+    propertyOutputIsUsable(Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero());
+}
+
+TEST(AxisToGimbalAnglesTest, PropertyDirectionRecovered) {
+    propertyDirectionRecovered(rotatedMount(), {0.1F, -0.2F, -0.97F});
+    propertyDirectionRecovered(Eigen::Vector3f::Zero(), -Eigen::Vector3f::UnitZ());
+}
+
+TEST(AxisToGimbalAnglesTest, PropertyLengthHasNoEffect) {
+    propertyLengthHasNoEffect(rotatedMount(), {0.1F, -0.2F, -0.97F}, 137.0F);
+    propertyLengthHasNoEffect(rotatedMount(), {0.1F, -0.2F, -0.97F}, 1e-3F);
+}
+
+// ---------------------------------------------------------------------------
+// Edge case tests
+// ---------------------------------------------------------------------------
+
+// The module gives two plane angles, not a sequential Euler pair. The two conventions agree when one angle is
+// zero. For all other directions they are different, thus this direction separates them.
+TEST(AxisToGimbalAnglesTest, PlaneAnglesAreNotSequentialEulerAngles) {
+    // Build a direction with a known reading in each convention. The -x component is sin(eulerAngle), thus an
+    // arcsine gives eulerAngle. The remaining length is divided by planeAngle1 in the y-z plane.
+    constexpr float eulerAngle = 27.0F * kDegToRad;
+    constexpr float planeAngle1 = 18.5F * kDegToRad;
+    const Eigen::Vector3f request_M{-std::sin(eulerAngle),
+                                    std::cos(eulerAngle) * std::sin(planeAngle1),
+                                    -std::cos(eulerAngle) * std::cos(planeAngle1)};
+
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(Eigen::Vector3f::Zero())};
+    const AxisToGimbalAnglesOutput out = alg.update(request_M);
+
+    // The two conventions agree on the first angle.
+    EXPECT_NEAR(out.gimbalAngle1, planeAngle1, kAccuracy);
+
+    // They are different on the second angle, where tan(plane) = tan(euler) / cos(planeAngle1).
+    const float planeAngle2 = std::atan(std::tan(eulerAngle) / std::cos(planeAngle1));
+    EXPECT_NEAR(out.gimbalAngle2, planeAngle2, kAccuracy);
+
+    // Make sure that this direction separates the two conventions by more than the test accuracy.
+    EXPECT_GT(planeAngle2 - eulerAngle, 1.0F * kDegToRad);
+}
+
+// At a deflection of 90 degrees the two angles become very large. The module gives the home position and does
+// not give an angle at its limit.
+TEST(AxisToGimbalAnglesTest, NinetyDegreeDeflectionGivesHomePosition) {
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(Eigen::Vector3f::Zero())};
+
+    for (const float sign : {1.0F, -1.0F}) {
+        const AxisToGimbalAnglesOutput out = alg.update(sign * Eigen::Vector3f::UnitX());
+        EXPECT_NEAR(out.gimbalAngle1, 0.0F, kAccuracy);
+        EXPECT_NEAR(out.gimbalAngle2, 0.0F, kAccuracy);
+    }
+}
+
+// The gimbal cannot move to a direction behind the mount. The module gives the home position.
+TEST(AxisToGimbalAnglesTest, DirectionBehindTheMountGivesHomePosition) {
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(Eigen::Vector3f::Zero())};
+    const AxisToGimbalAnglesOutput out = alg.update(Eigen::Vector3f::UnitZ());
+
+    EXPECT_NEAR(out.gimbalAngle1, 0.0F, kAccuracy);
+    EXPECT_NEAR(out.gimbalAngle2, 0.0F, kAccuracy);
+}
+
+// A direction on the boundary of the half-space has a deflection of exactly 90 degrees. Its z component in
+// mount-frame coordinates is zero, and the error of the float rotation is larger than that component. Thus the
+// module can give the home position or two angles at the edge of the range, and both answers are correct. A
+// fuzz test found this input.
+TEST(AxisToGimbalAnglesTest, DirectionOnTheHalfSpaceBoundaryGivesUsableAngles) {
+    const Eigen::Vector3f sigma_MB{-1.0F, 1.0F, 1.0F};
+    const Eigen::Vector3f direction_B{0.0F, -0.0482057929F, 1.0F};
+
+    // The direction is on the boundary: its mount-frame z component is smaller than the rotation error.
+    ASSERT_LT(std::fabs(thrustHatUnit_M(sigma_MB, direction_B).z()), 1e-6F);
+
+    propertyOutputIsUsable(sigma_MB, direction_B);
+    regressionTestAxisToGimbalAngles(sigma_MB, direction_B);
+}
+
+// A direction vector of zero length has a zero z component. Thus it fails the same test.
+TEST(AxisToGimbalAnglesTest, ZeroDirectionGivesHomePosition) {
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(Eigen::Vector3f::Zero())};
+    const AxisToGimbalAnglesOutput out = alg.update(Eigen::Vector3f::Zero());
+
+    EXPECT_NEAR(out.gimbalAngle1, 0.0F, kAccuracy);
+    EXPECT_NEAR(out.gimbalAngle2, 0.0F, kAccuracy);
+}
+
+// The module cannot use a direction vector that contains a value that is not a number.
+TEST(AxisToGimbalAnglesTest, NonFiniteDirectionGivesHomePosition) {
+    constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+    const AxisToGimbalAnglesAlgorithm alg{makeConfig(Eigen::Vector3f::Zero())};
+
+    EXPECT_NEAR(alg.update({nan, 0.0F, -1.0F}).gimbalAngle1, 0.0F, kAccuracy);
+    EXPECT_NEAR(alg.update({0.0F, 0.0F, nan}).gimbalAngle2, 0.0F, kAccuracy);
+}
+
+// ---------------------------------------------------------------------------
+// Setup tests
+// ---------------------------------------------------------------------------
+
+TEST(AxisToGimbalAnglesTest, SetupTest) {
+    constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+    constexpr float inf = std::numeric_limits<float>::infinity();
+
+    // The configuration accepts a finite mounting orientation.
+    EXPECT_NO_THROW((void)makeConfig(Eigen::Vector3f::Zero()));
+    EXPECT_NO_THROW((void)makeConfig({0.1F, -0.2F, 0.05F}));
+
+    // The configuration rejects a mounting orientation that is not finite.
+    EXPECT_THROW((void)makeConfig({nan, 0.0F, 0.0F}), fsw::invalid_argument);
+    EXPECT_THROW((void)makeConfig({0.0F, inf, 0.0F}), fsw::invalid_argument);
+
+    // An MRP with a norm of more than one gives the same rotation. The module stores the shadow set.
+    const Eigen::Vector3f shadow{0.0F, 0.0F, 2.0F};
+    EXPECT_LE(makeConfig(shadow).getSigma_MB().norm(), 1.0F);
+    EXPECT_TRUE(mrpToDcm(makeConfig(shadow).getSigma_MB()).isApprox(mrpToDcm(shadow), 1e-4F));
+}
+
+// setConfig() calculates the mounting orientation again. Thus the module uses the new mount for the same input.
+TEST(AxisToGimbalAnglesTest, SetConfigAppliesNewMounting) {
+    AxisToGimbalAnglesAlgorithm alg{makeConfig(Eigen::Vector3f::Zero())};
+
+    constexpr float angle2 = 20.0F * kDegToRad;
+    const Eigen::Vector3f sigma_MB = dcmToMrp(eulerAngles123ToDcm(Eigen::Vector3f(0.0F, -angle2, 0.0F)));
+    alg.setConfig(makeConfig(sigma_MB));
+
+    const AxisToGimbalAnglesOutput out = alg.update(-Eigen::Vector3f::UnitZ());
+    EXPECT_NEAR(out.gimbalAngle1, 0.0F, kAccuracy);
+    EXPECT_NEAR(out.gimbalAngle2, angle2, kAccuracy);
+}

--- a/algorithms/axisToGimbalAngles/_tests/test_axisToGimbalAngles.py
+++ b/algorithms/axisToGimbalAngles/_tests/test_axisToGimbalAngles.py
@@ -1,0 +1,113 @@
+import numpy as np
+import pytest
+
+from xmera.architecture import messaging
+from xmera.fp32 import axisToGimbalAnglesF32
+from xmera.utilities import RigidBodyKinematics as rbk
+from xmera.utilities import SimulationBaseClass
+from xmera.utilities import macros
+
+
+def gimbal_axis_M(angle1, angle2):
+    """The gimbal thrust axis in mount frame coordinates: T(alpha, beta), proportional to
+    [-tan(beta), tan(alpha), -1], scaled so it stays finite up to the 90 degree boundary. The mount frame's -z axis
+    is the un-deflected thrust, so a neutral gimbal gives [0, 0, -1]."""
+    axis = np.array([-np.sin(angle2) * np.cos(angle1),
+                     np.cos(angle2) * np.sin(angle1),
+                     -np.cos(angle2) * np.cos(angle1)])
+    return axis / np.linalg.norm(axis)
+
+
+@pytest.mark.parametrize("angle1", [0.0, 12.0 * macros.D2R, -18.25 * macros.D2R])
+@pytest.mark.parametrize("angle2", [0.0, -7.5 * macros.D2R, 9.75 * macros.D2R])
+@pytest.mark.parametrize("mount_euler_angles", [np.zeros(3), np.array([5.0, 10.0, 0.0]) * macros.D2R])
+@pytest.mark.parametrize("request_scale", [1.0, 137.0])
+@pytest.mark.parametrize("accuracy", [1e-5])
+def test_axis_to_gimbal_angles(angle1, angle2, mount_euler_angles, request_scale, accuracy):
+    """Module Unit Test: the module maps a commanded body-frame thrust direction onto the two gimbal angles that
+    place the gimbal thrust axis on it. Each angle is the inclination of that axis projected into one of the mount planes
+    containing the un-deflected axis. The request is built from a known pair of angles and rotated into the body
+    frame, so the module must return that same pair whatever the mounting orientation and whatever the length of
+    the request."""
+    # The mount frame is defined with its -z axis along the un-deflected gimbal thrust axis, so sigma_MB carries
+    # the gimbal's mounting orientation on the hub.
+    sigma_MB = np.array(rbk.euler1232MRP(mount_euler_angles))
+    dcm_MB = rbk.MRP2C(sigma_MB)
+
+    # Build the request from the angles under test, then express it in the body frame the module reads it in.
+    thrust_hat_M = gimbal_axis_M(angle1, angle2)
+    thrust_hat_B = request_scale * np.matmul(dcm_MB.transpose(), thrust_hat_M)
+
+    task_name = "unitTask"
+    process_name = "TestProcess"
+
+    sim = SimulationBaseClass.SimBaseClass()
+
+    test_process_rate = macros.sec2nano(1)
+    test_proc = sim.CreateNewProcess(process_name)
+    test_proc.addTask(sim.CreateNewTask(task_name, test_process_rate))
+
+    module = axisToGimbalAnglesF32.AxisToGimbalAngles()
+    module.modelTag = "axisToGimbalAngles"
+    sim.AddModelToTask(task_name, module)
+
+    module.sigma_MB = sigma_MB
+
+    thrust_direction_message = messaging.BodyHeadingMsgF32Payload()
+    thrust_direction_message.rHat_XB_B = thrust_hat_B
+    thrust_direction_in_msg = messaging.BodyHeadingMsgF32().write(thrust_direction_message)
+    module.thrustDirectionInMsg.subscribeTo(thrust_direction_in_msg)
+
+    gimbal_log = module.twoAxisGimbalOutMsg.recorder()
+    sim.AddModelToTask(task_name, gimbal_log)
+
+    sim.InitializeSimulation()
+    sim.ConfigureStopTime(macros.sec2nano(1))
+    sim.ExecuteSimulation()
+
+    theta1 = gimbal_log.theta1[-1]
+    theta2 = gimbal_log.theta2[-1]
+
+    # The module recovers the angles the request was built from.
+    np.testing.assert_allclose(theta1, angle1, rtol=accuracy, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(theta2, angle2, rtol=accuracy, atol=accuracy, verbose=True)
+
+    # And those angles put the gimbal thrust axis back on the request.
+    np.testing.assert_allclose(gimbal_axis_M(theta1, theta2), thrust_hat_M, rtol=accuracy, atol=accuracy,
+                               verbose=True)
+
+
+@pytest.mark.parametrize("request_B", [np.zeros(3),                   # carries no direction
+                                       np.array([0.0, 0.0, 1.0]),    # points back through the mount
+                                       np.array([1.0, 0.0, 0.0])])   # exactly 90 deg of deflection
+@pytest.mark.parametrize("accuracy", [1e-5])
+def test_axis_to_gimbal_angles_unreachable_request(request_B, accuracy):
+    """The projected angles only describe the open half-space ahead of the mount. A request outside it leaves the
+    gimbal at its home position rather than producing a meaningless or railed pair of angles."""
+    task_name = "unitTask"
+    process_name = "TestProcess"
+
+    sim = SimulationBaseClass.SimBaseClass()
+
+    test_process_rate = macros.sec2nano(1)
+    test_proc = sim.CreateNewProcess(process_name)
+    test_proc.addTask(sim.CreateNewTask(task_name, test_process_rate))
+
+    module = axisToGimbalAnglesF32.AxisToGimbalAngles()
+    module.modelTag = "axisToGimbalAngles"
+    sim.AddModelToTask(task_name, module)
+
+    thrust_direction_message = messaging.BodyHeadingMsgF32Payload()
+    thrust_direction_message.rHat_XB_B = request_B
+    thrust_direction_in_msg = messaging.BodyHeadingMsgF32().write(thrust_direction_message)
+    module.thrustDirectionInMsg.subscribeTo(thrust_direction_in_msg)
+
+    gimbal_log = module.twoAxisGimbalOutMsg.recorder()
+    sim.AddModelToTask(task_name, gimbal_log)
+
+    sim.InitializeSimulation()
+    sim.ConfigureStopTime(macros.sec2nano(1))
+    sim.ExecuteSimulation()
+
+    np.testing.assert_allclose(gimbal_log.theta1[-1], 0.0, rtol=accuracy, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(gimbal_log.theta2[-1], 0.0, rtol=accuracy, atol=accuracy, verbose=True)

--- a/algorithms/axisToGimbalAngles/_tests/test_axisToGimbalAngles_fuzz.cpp
+++ b/algorithms/axisToGimbalAngles/_tests/test_axisToGimbalAngles_fuzz.cpp
@@ -1,0 +1,52 @@
+#include "axisToGimbalAnglesTestHelpers.hpp"
+#include "utilities/testUtilities/eigenFuzzDomains.hpp"
+#include <fuzztest/fuzztest.h>
+
+namespace {
+// The two angles are arctangents, thus the module can only give a value in the open range -pi/2 to pi/2. An
+// angle outside that range is not a value that the module can give, and the direction that it builds is not in
+// the half-space. Thus it is not a regression input. This limit is a property of the two angles.
+constexpr float kMaxAngle = 1.5707F;  // less than pi/2 by 5e-5 rad
+
+// Direction components stay near unit length. This keeps the directions in all parts of the sphere and includes
+// the zero vector. The length of the direction has no effect on the two angles, and propertyLengthHasNoEffect
+// examines that property across the full float range.
+constexpr float kDirectionLimit = 1.0F;
+
+// The mounting range covers the principal MRP set and more, which create() changes to the shadow set.
+constexpr float kMrpLimit = 2.0F;
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Regression fuzz tests
+// ---------------------------------------------------------------------------
+
+// The direction range includes the origin and both half-spaces, thus the fuzz test also examines the directions
+// that the module cannot use.
+FUZZ_TEST(AxisToGimbalAnglesFuzz, regressionTestAxisToGimbalAngles)
+    .WithDomains(xmera::fuzz::Vector3fInRange(-kMrpLimit, kMrpLimit),               // sigma_MB (MRP)
+                 xmera::fuzz::Vector3fInRange(-kDirectionLimit, kDirectionLimit));  // direction, body frame
+
+FUZZ_TEST(AxisToGimbalAnglesFuzz, regressionTestAxisToGimbalAnglesFromAngles)
+    .WithDomains(xmera::fuzz::Vector3fInRange(-kMrpLimit, kMrpLimit),  // sigma_MB (MRP)
+                 fuzztest::InRange(-kMaxAngle, kMaxAngle),             // angle1 [rad]
+                 fuzztest::InRange(-kMaxAngle, kMaxAngle));            // angle2 [rad]
+
+// ---------------------------------------------------------------------------
+// Property fuzz tests
+// ---------------------------------------------------------------------------
+
+FUZZ_TEST(AxisToGimbalAnglesPropertyFuzz, propertyOutputIsUsable)
+    .WithDomains(xmera::fuzz::Vector3fInRange(-kMrpLimit, kMrpLimit),
+                 xmera::fuzz::Vector3fInRange(-kDirectionLimit, kDirectionLimit));
+
+FUZZ_TEST(AxisToGimbalAnglesPropertyFuzz, propertyDirectionRecovered)
+    .WithDomains(xmera::fuzz::Vector3fInRange(-kMrpLimit, kMrpLimit),
+                 xmera::fuzz::Vector3fInRange(-kDirectionLimit, kDirectionLimit));
+
+// The module makes the input direction a unit vector, thus the length has no effect. The range below keeps each
+// scaled component in the normal float range, where the scaling keeps the direction.
+FUZZ_TEST(AxisToGimbalAnglesPropertyFuzz, propertyLengthHasNoEffect)
+    .WithDomains(xmera::fuzz::Vector3fInRange(-kMrpLimit, kMrpLimit),
+                 xmera::fuzz::Vector3fInRange(-kDirectionLimit, kDirectionLimit),
+                 fuzztest::InRange(1e-3F, 1e3F));

--- a/algorithms/axisToGimbalAngles/axisToGimbalAngles.cpp
+++ b/algorithms/axisToGimbalAngles/axisToGimbalAngles.cpp
@@ -1,0 +1,55 @@
+#include "axisToGimbalAngles.h"
+#include "utilities/fsw/eigenSupport.h"
+#include "utilities/xmera/xmeraLifecycleException.h"
+
+#include <stdexcept>
+
+/*! @brief Build the validated configuration from the public properties.
+ @return AxisToGimbalAnglesConfig validated configuration
+*/
+AxisToGimbalAnglesConfig AxisToGimbalAngles::toConfig() const {
+    return AxisToGimbalAnglesConfig::create(this->sigma_MB);
+}
+
+/*! This method validates the required input message and builds the algorithm from the current configuration.
+ @return void
+ @param callTime [ns] time the method is called
+*/
+void AxisToGimbalAngles::reset(const uint64_t callTime) {
+    if (!this->thrustDirectionInMsg.isLinked()) {
+        throw std::invalid_argument("axisToGimbalAngles.thrustDirectionInMsg wasn't connected.");
+    }
+
+    this->algorithm = std::make_unique<AxisToGimbalAnglesAlgorithm>(this->toConfig());
+}
+
+/*! @brief Re-push the current properties into the running algorithm.
+ @return void
+*/
+void AxisToGimbalAngles::reconfigure() const {
+    if (!this->algorithm) {
+        throw XmeraLifecycleException("AxisToGimbalAngles reset() has not been called.");
+    }
+
+    this->algorithm->setConfig(this->toConfig());
+}
+
+/*! This method reads the commanded thrust direction, delegates the gimbal angle solve to the algorithm, and
+writes the resulting gimbal angles to the output message.
+ @return void
+ @param callTime [ns] the current time of simulation
+*/
+void AxisToGimbalAngles::updateState(const uint64_t callTime) {
+    if (!this->algorithm) {
+        throw XmeraLifecycleException("AxisToGimbalAngles reset() has not been called.");
+    }
+
+    const Eigen::Vector3f thrustHat_B = cArrayToEigenVector3<float>(this->thrustDirectionInMsg().rHat_XB_B);
+
+    const AxisToGimbalAnglesOutput out = this->algorithm->update(thrustHat_B);
+
+    TwoAxisGimbalMsgF32Payload twoAxisGimbalOut{};
+    twoAxisGimbalOut.theta1 = out.gimbalAngle1;
+    twoAxisGimbalOut.theta2 = out.gimbalAngle2;
+    this->twoAxisGimbalOutMsg.write(twoAxisGimbalOut, this->moduleID, callTime);
+}

--- a/algorithms/axisToGimbalAngles/axisToGimbalAngles.h
+++ b/algorithms/axisToGimbalAngles/axisToGimbalAngles.h
@@ -1,0 +1,37 @@
+#ifndef F32XMERA_AXIS_TO_GIMBAL_ANGLES_H
+#define F32XMERA_AXIS_TO_GIMBAL_ANGLES_H
+
+#include "axisToGimbalAnglesAlgorithm.h"
+#include "msgPayloadDef/BodyHeadingMsgF32Payload.h"
+#include "msgPayloadDef/TwoAxisGimbalMsgF32Payload.h"
+#include <architecture/_GeneralModuleFiles/sys_model.h>
+#include <architecture/messaging/messaging.h>
+#include <stdint.h>
+
+#include <memory>
+
+/*! @brief Adapter for the axis to gimbal angles algorithm. Reads the commanded body-frame thrust direction,
+delegates the angle solve to AxisToGimbalAnglesAlgorithm, and writes the resulting gimbal angles. */
+class AxisToGimbalAngles final : public SysModel {
+   public:
+    void reset(uint64_t callTime) override;
+    void updateState(uint64_t callTime) override;
+
+    /*! Re-push the current properties into the running algorithm. */
+    void reconfigure() const;
+
+    /*! Phase 1: user-defined configuration properties, set before reset() */
+    Eigen::Vector3f sigma_MB{Eigen::Vector3f::Zero()};  //!< orientation of the M frame w.r.t. the B frame; M's -z axis
+                                                        //!< is the un-deflected gimbal thrust axis
+
+    /*! module IO interfaces */
+    ReadFunctor<BodyHeadingMsgF32Payload>
+        thrustDirectionInMsg;  //!< input msg containing the commanded thrust direction, body frame
+    Message<TwoAxisGimbalMsgF32Payload> twoAxisGimbalOutMsg;  //!< output msg containing the gimbal angles
+
+   private:
+    AxisToGimbalAnglesConfig toConfig() const;
+    std::unique_ptr<AxisToGimbalAnglesAlgorithm> algorithm = nullptr;  //!< algorithm instance
+};
+
+#endif  // F32XMERA_AXIS_TO_GIMBAL_ANGLES_H

--- a/algorithms/axisToGimbalAngles/axisToGimbalAngles.rst
+++ b/algorithms/axisToGimbalAngles/axisToGimbalAngles.rst
@@ -1,0 +1,216 @@
+Executive Summary
+-----------------
+This module calculates the two gimbal angles :math:`(\alpha, \beta)` that align the gimbal thrust axis with the
+thrust direction from the input message. :ref:`thrustVectoring` gives that thrust direction.
+:ref:`gimbalAnglesToMotorAngles` receives the two gimbal angles and calculates the stepper motor angles.
+
+The module calculates the two angles directly. It does no iteration, keeps no state, and does not use data from
+the previous cycle. The module needs only one configuration parameter, which is the orientation of the gimbal
+mount frame on the hub.
+
+All calculations use single-precision floating point (``float`` / fp32). The module has one algorithm class
+(``AxisToGimbalAnglesAlgorithm``) and two adapters. The ``SysModel`` adapter connects the algorithm to the Xmera
+system with messages. The C shim connects the algorithm to the Adamant system with the C/Ada FFI.
+
+Module Architecture
+-------------------
+The algorithm (``AxisToGimbalAnglesAlgorithm``) has no framework dependencies and uses Eigen types. It contains
+the mathematics that follows and keeps no runtime state. The algorithm does not use message payloads.
+``update()`` receives the thrust direction, which is the only quantity that changes each cycle. ``update()``
+returns an ``AxisToGimbalAnglesOutput`` structure. The ``AxisToGimbalAnglesConfig`` object holds the mounting
+orientation, and the algorithm calculates the DCM from it one time, when the caller sets the configuration.
+
+The Xmera adapter (``AxisToGimbalAngles``) uses ``SysModel`` as its base class and does all message operations.
+The configuration parameters are public member variables (two-phase initialization). The caller sets the
+parameters and then calls ``reset()``. ``reset()`` makes sure that the input message is connected, and builds
+the configuration from the current parameter values. ``updateState()`` reads the thrust direction,
+calls the algorithm, and writes the result to the output message. ``reconfigure()`` sends the current parameter
+values to the algorithm again.
+
+The module has no ``reInitialize()`` function. The algorithm keeps no runtime state.
+
+The Adamant adapter is a C shim (``axisToGimbalAnglesAlgorithm_c.h`` / ``.cpp``). It makes the algorithm
+available through an ``extern "C"`` interface for the C/Ada FFI bindings.
+
+Message Connection Descriptions
+-------------------------------
+The table that follows gives the module input and output messages. The user sets the message variable name from
+Python. The message type contains a link to the message structure definition.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - thrustDirectionInMsg
+      - :ref:`BodyHeadingMsgPayload`
+      - Input message with the thrust direction in body-frame coordinates
+        (:math:`{}^\mathcal{B}\hat{\boldsymbol{t}}`, the field ``rHat_XB_B``). :ref:`thrustVectoring` usually
+        gives this message. This is the only argument to ``update()``.
+    * - twoAxisGimbalOutMsg
+      - :ref:`TwoAxisGimbalMsgPayload`
+      - Output message with the two gimbal angles. ``theta1`` is the angle :math:`\alpha`. ``theta2`` is the
+        angle :math:`\beta`. :ref:`gimbalAnglesToMotorAngles` receives this message. The module does not write
+        the step fields of the payload.
+
+Module Parameters
+-----------------
+``reset()`` makes sure that the configuration parameters are correct when it builds the algorithm configuration.
+An incorrect value causes an ``fsw::invalid_argument`` exception.
+
+.. list-table:: Module Parameters
+    :widths: 20 15 20 45
+    :header-rows: 1
+
+    * - Parameter
+      - Default
+      - Valid Range
+      - Description
+    * - ``sigma_MB``
+      - [0, 0, 0]
+      - finite
+      - MRP rotation between the body-fixed frames :math:`\mathcal{M}` and :math:`\mathcal{B}`. The :math:`-z`
+        axis of the :math:`\mathcal{M}` frame is the neutral gimbal thrust axis, thus this parameter gives the
+        mounting orientation of the gimbal
+
+An MRP with a norm of more than one gives the same rotation as its shadow set. The module changes such an MRP to
+the shadow set before it stores the value.
+
+Mathematical Formulation
+------------------------
+
+Frames and mounting
+^^^^^^^^^^^^^^^^^^^
+The gimbal is on the hub-fixed mount frame :math:`\mathcal{M}`. The :math:`-z` axis of this frame is the neutral
+thrust direction. A gimbal at its home position thus fires along :math:`-z_\mathcal{M}`. The parameter
+``sigma_MB`` gives the mounting orientation of the gimbal on the hub.
+
+The module first changes the input direction to mount-frame coordinates:
+
+.. math::
+    {}^\mathcal{M}\boldsymbol{t} = [\mathcal{MB}]\,{}^\mathcal{B}\hat{\boldsymbol{t}}, \qquad
+    [\mathcal{MB}] = [\mathcal{MB}](\boldsymbol{\sigma}_{\mathcal{M}/\mathcal{B}}).
+
+The module calculates :math:`[\mathcal{MB}]` one time, when the caller sets the configuration.
+
+.. note::
+
+    The :math:`-z` direction is a convention. The module sets it, and the caller cannot change it, because the
+    sign of each angle depends on it.
+
+    Two rotations give a frame whose :math:`+z` axis is along the thrust:
+
+    - a rotation of :math:`180^\circ` about the mount :math:`x` axis, which changes the sign of :math:`\beta`,
+    - a rotation of :math:`180^\circ` about the mount :math:`y` axis, which changes the sign of :math:`\alpha`.
+
+    Both rotations are correct. Thus one thrust direction gives two different pairs of angles, and the equations
+    below cannot show which pair the mechanism uses. One frame for all modules removes this problem.
+
+    :ref:`thrustVectoring` uses the same :math:`\mathcal{M}` frame, thus one ``sigma_MB`` value is sufficient for
+    both modules.
+
+Gimbal kinematics
+^^^^^^^^^^^^^^^^^
+The gimbal has **two plane angles**. Each angle is the inclination of the thrust axis in one of the
+two mount planes that contain the neutral axis:
+
+- the angle :math:`\alpha` (``theta1``) is the inclination in the :math:`y`-:math:`z` plane,
+- the angle :math:`\beta` (``theta2``) is the inclination in the :math:`x`-:math:`z` plane.
+
+Neither angle moves the axis of the other angle. Both angles are referenced to fixed mount axes. The thrust axis
+in terms of the two angles is:
+
+.. math::
+    {}^\mathcal{M}\boldsymbol{T}(\alpha, \beta) \;\propto\; \begin{bmatrix}
+        -\tan\beta \\ \tan\alpha \\ -1
+    \end{bmatrix}.
+
+The two angles are thus the coordinates of the point where the thrust axis touches the plane
+:math:`z_\mathcal{M} = -1`. Lines of constant :math:`\alpha` and constant :math:`\beta` make a square grid on
+that plane.
+
+.. note::
+
+    This is **not** a sequential Euler parameterization. In a nested-ring gimbal, the second rotation moves a
+    frame that the first rotation turned. Such a gimbal gives
+    :math:`{}^\mathcal{M}\hat{\boldsymbol{t}} = [\sin\phi,\; -\cos\phi\sin\psi,\; \cos\phi\cos\psi]^T`, in which
+    the second angle is an out-of-plane (latitude) angle.
+
+    The two forms agree when one of the angles is zero. For all other angles they are different, because
+    :math:`\tan\beta = \tan\phi / \cos\alpha`. The difference increases with each angle. At
+    :math:`\alpha = 18.5^\circ` and :math:`\phi = 27^\circ`, for example, :math:`\beta` is
+    :math:`28.25^\circ`, which is :math:`1.25^\circ` more than :math:`\phi`. A given mechanism has one of these
+    two forms, and this module uses the plane-angle form.
+
+Solving for the gimbal angles
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The module calculates the two angles directly from this relation, with two four-quadrant arctangents:
+
+.. math::
+    \alpha = \tan^{-1}\left( \frac{{}^{\mathcal{M}}t_2}{-\,{}^{\mathcal{M}}t_3} \right), \qquad
+    \beta  = \tan^{-1}\left( \frac{-\,{}^{\mathcal{M}}t_1}{-\,{}^{\mathcal{M}}t_3} \right).
+
+Both angles are ratios against the mount :math:`-z` axis. This has two results. First, the length of the input
+direction has no effect, because it cancels in each ratio. The module also makes the direction a unit vector
+before it calculates the two ratios. This keeps the direction for a very short or a very long input. Second, the
+two angles are correct only where the denominator is more than zero. This is the open half-space into which the thrust
+fires, :math:`{}^{\mathcal{M}}t_3 < 0`. The two angles become very large as the deflection increases to
+:math:`90^\circ`. In this half-space both angles stay in the range :math:`(-\pi/2, \pi/2)`, and the mapping is
+correct in the two directions.
+
+Directions outside the half-space
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The module examines :math:`{}^{\mathcal{M}}t_3` each cycle. If :math:`{}^{\mathcal{M}}t_3 < 0` is not true, the
+module gives the gimbal home position :math:`(\alpha, \beta) = (0, 0)`. Three conditions fail this test:
+
+- a deflection of :math:`90^\circ` or more,
+- a zero direction vector,
+- a direction vector with a component that is not a number.
+
+The home position is the neutral thrust axis.
+
+.. note::
+
+    This test prevents an incorrect result, not a numerical error. :math:`\operatorname{atan2}` does no
+    division, thus it always gives a value. Outside the half-space the two angles leave the range
+    :math:`(-\pi/2, \pi/2)`, and the direction that they give is opposite to the input direction. If the module
+    does not do this test, it gives the angles for a direction :math:`180^\circ` from the input direction.
+
+User Guide
+----------
+The module uses two-phase initialization. Do the steps that follow:
+
+1. Set the public configuration parameters.
+2. Connect the input message.
+3. Add the module to the simulation task. ``reset()`` then builds the configuration.
+
+::
+
+    gimbalAngles = axisToGimbalAnglesF32.AxisToGimbalAngles()
+    gimbalAngles.modelTag = "gimbalAngles"
+    gimbalAngles.sigma_MB = sigma_MB
+
+    gimbalAngles.thrustDirectionInMsg.subscribeTo(thrustVectoring.bodyHeadingOutMsg)
+
+    scSim.AddModelToTask(simTaskName, gimbalAngles)
+
+If the mounting orientation changes during the mission, call ``reconfigure()`` to build the configuration again.
+
+To calculate the stepper motor angles, connect the output message to :ref:`gimbalAnglesToMotorAngles`:
+
+::
+
+    motorAngles.twoAxisGimbalInMsg.subscribeTo(gimbalAngles.twoAxisGimbalOutMsg)
+
+Module Assumptions and Limitations
+----------------------------------
+**Assumption.** The gimbal has two plane angles, as *Gimbal kinematics* shows. The module cannot
+examine the mechanism, thus it cannot identify a mechanism that does not agree with this description. If the
+mechanism is a nested-ring gimbal, the angles from this module are incorrect. The note in *Gimbal kinematics*
+gives the size of the error.
+
+**Limitation.** The module applies no travel limits. It calculates the angles for all directions in the
+half-space, and includes directions to which the gimbal cannot move. :ref:`gimbalAnglesToMotorAngles` applies
+the travel limits.

--- a/algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm.cpp
+++ b/algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm.cpp
@@ -1,0 +1,40 @@
+#include "axisToGimbalAnglesAlgorithm.h"
+
+#include "utilities/fsw/safeMath.h"
+
+/*! @brief Construct the algorithm with a validated configuration.
+ @param config Validated configuration (gimbal mount orientation).
+*/
+AxisToGimbalAnglesAlgorithm::AxisToGimbalAnglesAlgorithm(const AxisToGimbalAnglesConfig& config) : cfg(config) {
+    this->setConfig(config);
+}
+
+/*! @brief Replace the stored configuration at runtime.
+ @param config New validated configuration to apply.
+*/
+void AxisToGimbalAnglesAlgorithm::setConfig(const AxisToGimbalAnglesConfig& config) {
+    this->cfg = config;
+    this->dcm_MB = mrpToDcm(this->cfg.getSigma_MB());
+}
+
+/*! This method determines the two gimbal angles that align the gimbal thrust axis with the requested thrust
+direction. Each angle is the inclination of the thrust axis projected into one of the two mount planes containing
+the un-deflected axis, so the pair are independent of one another.
+ @return AxisToGimbalAnglesOutput gimbal angles
+ @param thrustHat_B [-] commanded thrust direction, body frame coordinates
+*/
+AxisToGimbalAnglesOutput AxisToGimbalAnglesAlgorithm::update(const Eigen::Vector3f& thrustHat_B) const {
+    const Eigen::Vector3f thrustDir_M = (this->dcm_MB * thrustHat_B).stableNormalized();
+
+    // Resolvable only in the half-space the thrust fires into; anything else leaves the gimbal angles zeroed.
+    const float towardsThrust = -thrustDir_M.z();
+    if (!(towardsThrust > 0.0F)) {
+        return AxisToGimbalAnglesOutput{};
+    }
+
+    AxisToGimbalAnglesOutput output{};
+    output.gimbalAngle1 = safeAtan2f(thrustDir_M.y(), towardsThrust);
+    output.gimbalAngle2 = safeAtan2f(-thrustDir_M.x(), towardsThrust);
+
+    return output;
+}

--- a/algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm.h
+++ b/algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm.h
@@ -1,0 +1,66 @@
+#ifndef F32XMERA_AXIS_TO_GIMBAL_ANGLES_ALGORITHM_H
+#define F32XMERA_AXIS_TO_GIMBAL_ANGLES_ALGORITHM_H
+
+#include "utilities/fsw/freestandingInvalidArgument.h"
+#include "utilities/fsw/rigidBodyKinematics.hpp"
+
+#include <Eigen/Core>
+
+/*! @brief Gimbal angles that place the gimbal thrust axis on the requested direction. */
+struct AxisToGimbalAnglesOutput {
+    float gimbalAngle1{};  //!< [rad] alpha: inclination of the thrust axis projected into the mount y-z plane
+    float gimbalAngle2{};  //!< [rad] beta: inclination of the thrust axis projected into the mount x-z plane
+};
+
+/*!
+ * @brief Validated configuration for the axis to gimbal angles algorithm.
+ *
+ * Carries the only quantity the mapping needs: the orientation of the gimbal mount frame M on the hub. The M
+ * frame is defined with its -z axis along the un-deflected thrust axis, so a neutral gimbal fires along -z_M.
+ * Construct via AxisToGimbalAnglesConfig::create(...).
+ */
+class AxisToGimbalAnglesConfig final {
+   public:
+    static AxisToGimbalAnglesConfig create(const Eigen::Vector3f& sigma_MB) {
+        if (!isValidSigma_MB(sigma_MB)) {
+            FSW_THROW_INVALID_ARGUMENT("axisToGimbalAngles: sigma_MB must be finite.");
+        }
+
+        // The shadow set describes the same rotation, so store the principal one (norm <= 1).
+        return AxisToGimbalAnglesConfig{mrpSwitch(sigma_MB)};
+    }
+
+    static bool isValidSigma_MB(const Eigen::Vector3f& sigma_MB) { return sigma_MB.allFinite(); }
+
+    const Eigen::Vector3f& getSigma_MB() const { return this->sigma_MB; }
+
+   private:
+    // NOLINTBEGIN(modernize-pass-by-value)
+    // modernize-pass-by-value: this is a private constructor invoked only from create() with an already-validated
+    //   argument; the small fixed-size vector is stored by copy without a move for clarity.
+    explicit AxisToGimbalAnglesConfig(const Eigen::Vector3f& sigma_MB) : sigma_MB(sigma_MB) {}
+    // NOLINTEND(modernize-pass-by-value)
+
+    Eigen::Vector3f sigma_MB;  //!< [-] MRP of the mount frame M w.r.t. the body frame B
+};
+
+/*! @brief Pure algorithm mapping a commanded body-frame thrust direction onto the two gimbal angles.
+ *
+ * The gimbal is described by two independent plane angles, each measured on the thrust axis projected into one of
+ * mount planes that contain the un-deflected axis, so the map inverts in closed form as a pair of arctangents.
+ * The algorithm holds no runtime state.
+ */
+class AxisToGimbalAnglesAlgorithm final {
+   public:
+    explicit AxisToGimbalAnglesAlgorithm(const AxisToGimbalAnglesConfig& config);
+    void setConfig(const AxisToGimbalAnglesConfig& config);
+    AxisToGimbalAnglesOutput update(const Eigen::Vector3f& thrustHat_B) const;
+
+   private:
+    AxisToGimbalAnglesConfig cfg;  //!< [-] validated configuration
+    //! [-] DCM from the body frame to the mount frame, resolved from sigma_MB whenever the configuration is set
+    //! so the per-cycle map never has to rebuild it
+    Eigen::Matrix3f dcm_MB{Eigen::Matrix3f::Identity()};
+};
+
+#endif  // F32XMERA_AXIS_TO_GIMBAL_ANGLES_ALGORITHM_H

--- a/algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm_c.cpp
+++ b/algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm_c.cpp
@@ -1,0 +1,46 @@
+#include "axisToGimbalAnglesAlgorithm_c.h"
+#include "axisToGimbalAnglesAlgorithm.h"
+#include "axisToGimbalAnglesTypes.h"
+#include "utilities/fsw/eigenSupport.h"
+#include "utilities/fsw/opaqueHandle.h"
+
+#include <Eigen/Core>
+
+namespace {
+/*! Build the validated C++ configuration from the flattened C parameters. */
+AxisToGimbalAnglesConfig makeConfig(const Vector3f_c& sigma_MB) {
+    return AxisToGimbalAnglesConfig::create(cArrayToEigenVector3<float>(sigma_MB.data));
+}
+}  // namespace
+
+bool AxisToGimbalAnglesAlgorithm_validateConfig(const Vector3f_c* sigma_MB) {
+    try {
+        (void)makeConfig(*sigma_MB);
+        return true;
+    } catch (const fsw::invalid_argument&) {
+        return false;
+    }
+}
+
+AxisToGimbalAnglesAlgorithmHandle* AxisToGimbalAnglesAlgorithm_create(const Vector3f_c* sigma_MB) {
+    return fsw::createHandle<::AxisToGimbalAnglesAlgorithm, AxisToGimbalAnglesAlgorithmHandle>(makeConfig(*sigma_MB));
+}
+
+void AxisToGimbalAnglesAlgorithm_destroy(AxisToGimbalAnglesAlgorithmHandle* self) {
+    fsw::deleteHandle<::AxisToGimbalAnglesAlgorithm>(self);
+}
+
+void AxisToGimbalAnglesAlgorithm_setConfig(AxisToGimbalAnglesAlgorithmHandle* self, const Vector3f_c* sigma_MB) {
+    fsw::fromHandle<::AxisToGimbalAnglesAlgorithm>(self)->setConfig(makeConfig(*sigma_MB));
+}
+
+AxisToGimbalAnglesOutput_c AxisToGimbalAnglesAlgorithm_update(const AxisToGimbalAnglesAlgorithmHandle* self,
+                                                              const Vector3f_c* thrustHat_B) {
+    const AxisToGimbalAnglesOutput out = fsw::fromHandle<const ::AxisToGimbalAnglesAlgorithm>(self)->update(
+        cArrayToEigenVector3<float>(thrustHat_B->data));
+
+    AxisToGimbalAnglesOutput_c result{};
+    result.gimbalAngle1 = out.gimbalAngle1;
+    result.gimbalAngle2 = out.gimbalAngle2;
+    return result;
+}

--- a/algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm_c.h
+++ b/algorithms/axisToGimbalAngles/axisToGimbalAnglesAlgorithm_c.h
@@ -1,0 +1,61 @@
+#ifndef F32XMERA_AXIS_TO_GIMBAL_ANGLES_ALGORITHM_C_H
+#define F32XMERA_AXIS_TO_GIMBAL_ANGLES_ALGORITHM_C_H
+
+#include "axisToGimbalAnglesTypes.h"
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Opaque handle to the C++ AxisToGimbalAnglesAlgorithm instance.
+ */
+typedef struct AxisToGimbalAnglesAlgorithmHandle AxisToGimbalAnglesAlgorithmHandle;
+
+/**
+ * @brief Report whether a configuration would be accepted by create/setConfig.
+ * @param sigma_MB MRP of the mount frame M w.r.t. the body frame B; must be finite. The M frame's -z axis is
+ *                 the un-deflected gimbal thrust axis.
+ * @return true when the configuration is valid. Never throws, so it can guard the throwing
+ *         create/setConfig from an invalid configuration.
+ */
+bool AxisToGimbalAnglesAlgorithm_validateConfig(const Vector3f_c* sigma_MB);
+
+/**
+ * @brief Construct a new AxisToGimbalAnglesAlgorithm instance from the supplied configuration.
+ * Validate the values with validateConfig first; invalid input throws.
+ * @param sigma_MB MRP of the mount frame M w.r.t. the body frame B.
+ * @return Pointer to a new AxisToGimbalAnglesAlgorithm (must be destroyed).
+ */
+AxisToGimbalAnglesAlgorithmHandle* AxisToGimbalAnglesAlgorithm_create(const Vector3f_c* sigma_MB);
+
+/**
+ * @brief Destroy a previously created AxisToGimbalAnglesAlgorithm.
+ * @param self Pointer to the instance to destroy.
+ */
+void AxisToGimbalAnglesAlgorithm_destroy(AxisToGimbalAnglesAlgorithmHandle* self);
+
+/**
+ * @brief Replace the algorithm's configuration at runtime.
+ * Validate the values with validateConfig first; invalid input throws.
+ * @param self     Pointer to the instance.
+ * @param sigma_MB MRP of the mount frame M w.r.t. the body frame B.
+ */
+void AxisToGimbalAnglesAlgorithm_setConfig(AxisToGimbalAnglesAlgorithmHandle* self, const Vector3f_c* sigma_MB);
+
+/**
+ * @brief Determine the gimbal angles that align the gimbal thrust axis with the commanded direction.
+ * @param self        Pointer to the instance.
+ * @param thrustHat_B [-] commanded thrust direction, body-frame coordinates.
+ * @return AxisToGimbalAnglesOutput_c gimbal angles.
+ */
+AxisToGimbalAnglesOutput_c AxisToGimbalAnglesAlgorithm_update(const AxisToGimbalAnglesAlgorithmHandle* self,
+                                                              const Vector3f_c* thrustHat_B);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // F32XMERA_AXIS_TO_GIMBAL_ANGLES_ALGORITHM_C_H

--- a/algorithms/axisToGimbalAngles/axisToGimbalAnglesF32.i
+++ b/algorithms/axisToGimbalAngles/axisToGimbalAnglesF32.i
@@ -1,0 +1,13 @@
+%module axisToGimbalAnglesF32
+%{
+   #include "axisToGimbalAngles.h"
+%}
+
+%include <architecture/_GeneralModuleFiles/sys_model.i>
+%include <architecture/_GeneralModuleFiles/swig_conly_data.i>
+%include <architecture/_GeneralModuleFiles/swig_eigen.i>
+
+%include "axisToGimbalAngles.h"
+
+%include "msgPayloadDef/BodyHeadingMsgF32Payload.h"
+%include "msgPayloadDef/TwoAxisGimbalMsgF32Payload.h"

--- a/algorithms/axisToGimbalAngles/axisToGimbalAnglesTypes.h
+++ b/algorithms/axisToGimbalAngles/axisToGimbalAnglesTypes.h
@@ -1,0 +1,22 @@
+#ifndef F32XMERA_AXIS_TO_GIMBAL_ANGLES_TYPES_H
+#define F32XMERA_AXIS_TO_GIMBAL_ANGLES_TYPES_H
+
+#include "utilities/fsw/plainCAlgorithmDataTypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Plain-old-data mirror of the C++ AxisToGimbalAnglesOutput.
+ */
+typedef struct {
+    float gimbalAngle1; /*!< [rad] inclination of the thrust axis projected into the mount y-z plane */
+    float gimbalAngle2; /*!< [rad] inclination of the thrust axis projected into the mount x-z plane */
+} AxisToGimbalAnglesOutput_c;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // F32XMERA_AXIS_TO_GIMBAL_ANGLES_TYPES_H


### PR DESCRIPTION
* **Tickets addressed:** ema-gnc-2386
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
The axisToGimbalAngles module is added. This module converts a heading in body frame components (e.g. from `thrustVectoring`) to gimbal angles. The gimbal angles can then be converted to motor angles using `gimbalAnglesToMotorAngles`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't
add or update any tests justify this choice. -->
Pytest and Cpp tests added.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and
completeness? -->
RST added.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None.